### PR TITLE
[DIET-008] Integration Testing Suite – End-to-End Scenarios

### DIFF
--- a/netbox_hedgehog/tests/test_topology_planning/test_integration.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_integration.py
@@ -2318,9 +2318,15 @@ class BreakoutSelectionCorrectnessTestCase(TestCase):
             speed=200  # 200G connection speed
         )
 
-        # Trigger recalculation
-        from netbox_hedgehog.utils.topology_calculations import calculate_switch_quantity
-        calculated = calculate_switch_quantity(switch_class)
+        # Trigger recalculation via HTTP endpoint (UX-accurate path)
+        recalc_url = reverse('plugins:netbox_hedgehog:topologyplan_recalculate', args=[plan.pk])
+        recalc_response = self.client.post(recalc_url, follow=True)
+        self.assertEqual(recalc_response.status_code, 200,
+                        "Recalculation endpoint should succeed")
+
+        # Refresh to get calculated value
+        switch_class.refresh_from_db()
+        calculated = switch_class.calculated_quantity
 
         # Expected calculation:
         # NOTE: Current MVP implementation uses hardcoded 64 physical ports
@@ -2393,9 +2399,15 @@ class BreakoutSelectionCorrectnessTestCase(TestCase):
             speed=400  # 400G connection speed
         )
 
-        # Trigger recalculation
-        from netbox_hedgehog.utils.topology_calculations import calculate_switch_quantity
-        calculated = calculate_switch_quantity(switch_class)
+        # Trigger recalculation via HTTP endpoint (UX-accurate path)
+        recalc_url = reverse('plugins:netbox_hedgehog:topologyplan_recalculate', args=[plan.pk])
+        recalc_response = self.client.post(recalc_url, follow=True)
+        self.assertEqual(recalc_response.status_code, 200,
+                        "Recalculation endpoint should succeed")
+
+        # Refresh to get calculated value
+        switch_class.refresh_from_db()
+        calculated = switch_class.calculated_quantity
 
         # Expected calculation:
         # NOTE: Current MVP implementation uses hardcoded 64 physical ports
@@ -2467,9 +2479,15 @@ class BreakoutSelectionCorrectnessTestCase(TestCase):
             speed=100  # 100G connection speed
         )
 
-        # Trigger recalculation
-        from netbox_hedgehog.utils.topology_calculations import calculate_switch_quantity
-        calculated = calculate_switch_quantity(switch_class)
+        # Trigger recalculation via HTTP endpoint (UX-accurate path)
+        recalc_url = reverse('plugins:netbox_hedgehog:topologyplan_recalculate', args=[plan.pk])
+        recalc_response = self.client.post(recalc_url, follow=True)
+        self.assertEqual(recalc_response.status_code, 200,
+                        "Recalculation endpoint should succeed")
+
+        # Refresh to get calculated value
+        switch_class.refresh_from_db()
+        calculated = switch_class.calculated_quantity
 
         # Expected calculation:
         # NOTE: Current MVP implementation uses hardcoded 64 physical ports


### PR DESCRIPTION
## Summary

Implements Issue #92: E2E integration testing suite for DIET topology planning workflows.

## Changes

**Added 3 E2E Integration Test Classes** (6 test methods, 688 lines):

1. **SimplePlanE2ETestCase**
   - Validates complete UX flow: create plan → add entities → recalculate → export YAML
   - Verifies YAML contains correct CRD count (20 Connection CRDs for 10 servers × 2 ports)
   - Ensures no duplicate switch port assignments
   - Validates YAML structure, MIME type, and content

2. **MCLAGEvenCountEnforcementTestCase**
   - Validates MCLAG pairing enforces even switch counts
   - Test 1: Odd count rounds up (1 → 2 switches)
   - Test 2: Even count stays even (6 switches remains 6)

3. **BreakoutSelectionCorrectnessTestCase**
   - Validates breakout selection based on connection speed
   - 200G → 4x200G breakout (4 logical ports)
   - 400G → 2x400G breakout (2 logical ports)
   - 100G → 8x100G breakout (8 logical ports)

## Test Results

```
Ran 6 tests in 8.449s
OK ✅
```

All tests passing. Tests use NetBox integration patterns (TestCase + Client + reverse()) to validate actual UX behavior via HTTP requests.

## UX Flows Validated

✅ Plan creation → server/switch configuration → calculation → YAML export  
✅ YAML reflects current plan state with correct CRD count  
✅ MCLAG enforcement ensures even switch counts (critical for HA)  
✅ Breakout selection chooses correct option based on connection speed  
✅ Port allocator prevents duplicate switch port assignments  

## Known Gaps/Risks Documented

**MEDIUM Risk:** Hardcoded physical port count (64) in `topology_calculations.py:182`
- Works for DS5000 switches but won't adapt to other models
- TODO comment exists for future enhancement using InterfaceTemplate

**MEDIUM Risk:** Breakout application in calculation
- `determine_optimal_breakout()` works correctly (validated by tests)
- But switch quantity calculation uses fallback (1:1) in practice
- Results in over-provisioning (safer than under-provisioning)
- Tests document expected vs actual behavior with TODO notes

## Test Commands

```bash
cd /home/ubuntu/afewell-hh/netbox-docker

docker compose exec netbox python manage.py test \
  netbox_hedgehog.tests.test_topology_planning.test_integration.SimplePlanE2ETestCase \
  netbox_hedgehog.tests.test_topology_planning.test_integration.MCLAGEvenCountEnforcementTestCase \
  netbox_hedgehog.tests.test_topology_planning.test_integration.BreakoutSelectionCorrectnessTestCase \
  --keepdb
```

## Files Changed

- `netbox_hedgehog/tests/test_topology_planning/test_integration.py` (+688 lines)

## Related

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>