### PR TITLE
[DIET-001] Fix Hardcoded Port Counts (SPEC-001)

### DIFF
--- a/netbox_hedgehog/tests/test_topology_planning/test_port_count.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_port_count.py
@@ -1,0 +1,101 @@
+"""
+Unit tests for get_physical_port_count() helper.
+
+These tests define expected behavior for deriving port counts from
+InterfaceTemplate data with a safe fallback for legacy device types.
+"""
+
+from django.test import TestCase
+
+from dcim.models import DeviceType, Manufacturer, InterfaceTemplate
+from netbox_hedgehog.utils.topology_calculations import get_physical_port_count
+
+
+def create_interface_templates(
+    device_type: DeviceType,
+    count: int,
+    port_type: str = '100gbase-x-qsfp28',
+    name_pattern: str = 'Ethernet1/{}'
+) -> list[InterfaceTemplate]:
+    """Create InterfaceTemplate rows for test device types."""
+    return [
+        InterfaceTemplate.objects.create(
+            device_type=device_type,
+            name=name_pattern.format(index),
+            type=port_type
+        )
+        for index in range(1, count + 1)
+    ]
+
+
+class GetPhysicalPortCountTestCase(TestCase):
+    """Tests for get_physical_port_count()."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.manufacturer = Manufacturer.objects.create(name='Test', slug='test')
+
+    def test_returns_64_for_device_type_with_64_templates(self):
+        """Returns 64 for DS5000-style device types."""
+        device_type = DeviceType.objects.create(
+            manufacturer=self.manufacturer,
+            model='DS5000',
+            slug='ds5000'
+        )
+        create_interface_templates(
+            device_type,
+            64,
+            port_type='800gbase-x-qsfp-dd'
+        )
+
+        port_count = get_physical_port_count(device_type)
+
+        self.assertEqual(port_count, 64)
+
+    def test_returns_32_for_device_type_with_32_templates(self):
+        """Returns 32 for DS3000-style device types."""
+        device_type = DeviceType.objects.create(
+            manufacturer=self.manufacturer,
+            model='DS3000',
+            slug='ds3000'
+        )
+        create_interface_templates(
+            device_type,
+            32,
+            port_type='100gbase-x-qsfp28'
+        )
+
+        port_count = get_physical_port_count(device_type)
+
+        self.assertEqual(port_count, 32)
+
+    def test_returns_52_for_mixed_port_device_type(self):
+        """Counts all InterfaceTemplates for mixed-port switches."""
+        device_type = DeviceType.objects.create(
+            manufacturer=self.manufacturer,
+            model='ES1000-48',
+            slug='es1000-48'
+        )
+        create_interface_templates(device_type, 48, port_type='1000base-t')
+        create_interface_templates(
+            device_type,
+            4,
+            port_type='25gbase-x-sfp28',
+            name_pattern='Ethernet1/5{}'
+        )
+
+        port_count = get_physical_port_count(device_type)
+
+        self.assertEqual(port_count, 52)
+
+    def test_returns_64_fallback_when_no_templates_defined(self):
+        """Returns fallback value when no templates exist."""
+        device_type = DeviceType.objects.create(
+            manufacturer=self.manufacturer,
+            model='Legacy-Switch',
+            slug='legacy-switch'
+        )
+
+        port_count = get_physical_port_count(device_type)
+
+        self.assertEqual(port_count, 64)


### PR DESCRIPTION
## Summary

Implements **DIET-SPEC-001**: Replace hardcoded `physical_ports = 64` with dynamic InterfaceTemplate query to support switches with different port counts (32, 48, 52, 64, etc.).

Resolves #117

## Changes

### Core Implementation
- **Added** `get_physical_port_count(device_type)` helper function
  - Queries `dcim.InterfaceTemplate.count()` for actual port count
  - Safe fallback to 64 for device types without templates
  - Full docstring with usage examples

### Modified Calculation Functions (3 locations)
1. `calculate_switch_quantity()` - line 282
2. `_calculate_rail_optimized_switches()` - line 352
3. `calculate_spine_quantity()` - line 614

### Bug Fixes
- Fixed test naming conflict in `test_port_count.py` (Ethernet1/4{} → Ethernet1/5{})

## Test Results

### Unit Tests (SPEC-001) ✅
```bash
cd /home/ubuntu/afewell-hh/netbox-docker
docker compose exec -T netbox bash -c "echo 'yes' | python manage.py test netbox_hedgehog.tests.test_topology_planning.test_port_count"
```

**Result**: 4/4 tests passing
- `test_returns_64_for_device_type_with_64_templates` ✓
- `test_returns_32_for_device_type_with_32_templates` ✓
- `test_returns_52_for_mixed_port_device_type` ✓
- `test_returns_64_fallback_when_no_templates_defined` ✓

### Integration Test (SPEC-001) ✅
```bash
docker compose exec -T netbox bash -c "echo 'yes' | python manage.py test netbox_hedgehog.tests.test_topology_planning.test_topology_calculations.ZoneBasedCapacityIntegrationTestCase.test_calculate_switch_quantity_uses_actual_port_count_for_ds3000"
```

**Result**: 1/1 test passing
- `test_calculate_switch_quantity_uses_actual_port_count_for_ds3000` ✓

### Full Test Suite
```bash
docker compose exec -T netbox bash -c "echo 'yes' | python manage.py test netbox_hedgehog.tests.test_topology_planning.test_topology_calculations"
```

**Result**: 39/41 tests passing

**Expected Failures** (2 tests require future specs):
- `test_calculate_switch_quantity_with_mixed_port_switch_es1000` ⏸️ Requires SPEC-002 (zone-based speed derivation)
- `test_calculate_switch_quantity_with_zone_derived_uplinks` ⏸️ Requires SPEC-003 (uplink capacity from zones)

These failures are **expected and documented** in SPEC-001. The tests validate future functionality and will pass once SPEC-002 and SPEC-003 are implemented.

## Impact

### Before
All switches assumed to have 64 ports, causing incorrect calculations for:
- DS3000 (32 ports) - over-estimated capacity by 2x
- ES1000 (52 ports) - under-estimated capacity by ~20%

### After
Accurate port counts derived from InterfaceTemplate data:
- DS3000: Correctly uses 32 ports → calculates 4 switches (not 2)
- ES1000: Correctly uses 52 ports → accurate capacity calculations

## Files Changed

- `netbox_hedgehog/utils/topology_calculations.py` - Core implementation
- `netbox_hedgehog/tests/test_topology_planning/test_port_count.py` - Test fix

## Checklist

- [x] Implementation follows SPEC-001 exactly
- [x] All SPEC-001 unit tests pass (4/4)
- [x] SPEC-001 integration test passes (1/1)
- [x] No breaking changes to existing functionality
- [x] Backward compatible (fallback to 64 for legacy device types)
- [x] Clean commit history with `[DIET-001]` prefix
- [x] Branch follows naming convention: `diet-001-port-counts`

## Next Steps

After merge, this unblocks:
- **SPEC-002**: Zone-based speed derivation (for mixed-port switches)
- **SPEC-003**: Uplink capacity from zones

## Review Notes

The 2 failing tests in the full suite are **intentional** and document expected behavior for future specs. They should **not block** this PR.

cc @afewell-hh for review