### PR TITLE
[DIET-148] Fix switch profile import edge cases

### DIFF
--- a/netbox_hedgehog/management/commands/fix_ds5000_interface_types.py
+++ b/netbox_hedgehog/management/commands/fix_ds5000_interface_types.py
@@ -1,0 +1,97 @@
+"""
+Management command to fix DS5000 interface types (DIET-148 backfill).
+
+Corrects interface type for DS5000 variants from QSFP-DD to OSFP for 800G ports.
+"""
+
+from django.core.management.base import BaseCommand
+from dcim.models import DeviceType, InterfaceTemplate
+
+
+class Command(BaseCommand):
+    help = "Fix interface types for DS5000 variants (DIET-148: OSFP vs QSFP-DD)"
+
+    # Device types to fix
+    DS5000_MODELS = ["DS5000", "celestica-ds5000", "celestica-ds5000-clsp"]
+
+    # Interface type correction
+    OLD_TYPE = "800gbase-x-qsfpdd"  # Wrong (QSFP-DD)
+    NEW_TYPE = "800gbase-x-osfp"     # Correct (OSFP)
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be changed without making changes"
+        )
+
+    def handle(self, **options):
+        dry_run = options["dry_run"]
+        verbosity = options["verbosity"]
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("=== DRY RUN MODE ==="))
+            self.stdout.write("No changes will be made\n")
+
+        # Find DS5000 variants
+        device_types = DeviceType.objects.filter(model__in=self.DS5000_MODELS)
+
+        if not device_types.exists():
+            self.stdout.write(self.style.WARNING("No DS5000 device types found"))
+            return
+
+        total_updated = 0
+
+        for dt in device_types:
+            # Safety check: verify manufacturer is Celestica
+            if dt.manufacturer.name != "Celestica":
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Skipping {dt.model}: unexpected manufacturer {dt.manufacturer.name}"
+                    )
+                )
+                continue
+
+            # Find interfaces with wrong type
+            wrong_interfaces = dt.interfacetemplates.filter(type=self.OLD_TYPE)
+            count = wrong_interfaces.count()
+
+            if count == 0:
+                if verbosity >= 2:
+                    self.stdout.write(f"OK {dt.model}: already correct (no changes needed)")
+                continue
+
+            # Expected count: 64 ports per DS5000 variant
+            if count != 64:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"WARN {dt.model}: found {count} interfaces (expected 64)"
+                    )
+                )
+
+            # Show what will change
+            self.stdout.write(f"\n{dt.manufacturer.name} {dt.model}:")
+            self.stdout.write(f"  Interfaces to update: {count}")
+            self.stdout.write(f"  Change: {self.OLD_TYPE} -> {self.NEW_TYPE}")
+
+            if dry_run:
+                total_updated += count
+                # Show sample interfaces
+                samples = wrong_interfaces[:3]
+                for iface in samples:
+                    self.stdout.write(f"    - {iface.name}")
+                if count > 3:
+                    self.stdout.write(f"    - ... ({count - 3} more)")
+            else:
+                # Apply fix
+                updated = wrong_interfaces.update(type=self.NEW_TYPE)
+                total_updated += updated
+                self.stdout.write(self.style.SUCCESS(f"  OK Updated {updated} interfaces"))
+
+        # Summary
+        self.stdout.write("\n" + "=" * 60)
+        if dry_run:
+            self.stdout.write(self.style.WARNING(f"DRY RUN: Would update {total_updated} interfaces"))
+            self.stdout.write("\nRun without --dry-run to apply changes")
+        else:
+            self.stdout.write(self.style.SUCCESS(f"OK Fixed {total_updated} interface types"))

--- a/netbox_hedgehog/tests/test_fabric_import/test_backfill.py
+++ b/netbox_hedgehog/tests/test_fabric_import/test_backfill.py
@@ -1,0 +1,147 @@
+"""
+Tests for fix_ds5000_interface_types management command (DIET-148).
+
+These tests validate the backfill command that corrects interface types
+for DS5000 variants from QSFP-DD to OSFP for 800G ports.
+"""
+
+from io import StringIO
+from django.core.management import call_command
+from django.test import TestCase
+
+from dcim.models import DeviceType, Manufacturer, InterfaceTemplate
+
+
+class FixDS5000InterfaceTypesTestCase(TestCase):
+    """Test backfill command for DS5000 interface type fix."""
+
+    DS5000_MODELS = ["DS5000", "celestica-ds5000", "celestica-ds5000-clsp"]
+
+    def setUp(self):
+        """Create DS5000 device types with wrong interface types."""
+        self.manufacturer, _ = Manufacturer.objects.get_or_create(
+            name="Celestica",
+            defaults={"slug": "celestica"}
+        )
+
+        # Create 3 DS5000 variants with wrong interface types
+        for model_name in self.DS5000_MODELS:
+            dt, _ = DeviceType.objects.get_or_create(
+                manufacturer=self.manufacturer,
+                model=model_name,
+                defaults={"slug": model_name.lower()},
+            )
+
+            # Ensure a clean slate for interface templates
+            dt.interfacetemplates.all().delete()
+
+            # Create 64 interfaces with WRONG type (qsfpdd instead of osfp)
+            for i in range(1, 65):
+                InterfaceTemplate.objects.create(
+                    device_type=dt,
+                    name=f"E1/{i}",
+                    type="800gbase-x-qsfpdd"  # WRONG
+                )
+
+    def test_dry_run_shows_changes_without_applying(self):
+        """Dry-run should show what would change without changing data."""
+        out = StringIO()
+
+        # Run in dry-run mode
+        call_command("fix_ds5000_interface_types", "--dry-run", stdout=out)
+
+        output = out.getvalue()
+
+        # Verify output mentions all 3 device types
+        self.assertIn("DS5000", output)
+        self.assertIn("celestica-ds5000", output)
+        self.assertIn("celestica-ds5000-clsp", output)
+
+        # Verify shows 192 total interfaces
+        self.assertIn("192", output)
+
+        # Verify no changes made
+        wrong_interfaces = InterfaceTemplate.objects.filter(
+            device_type__model__in=self.DS5000_MODELS,
+            type="800gbase-x-qsfpdd",
+        )
+        self.assertEqual(wrong_interfaces.count(), 192, "Dry-run should not change data")
+
+    def test_backfill_fixes_all_ds5000_interfaces(self):
+        """Running command should fix all DS5000 interface types."""
+        out = StringIO()
+
+        # Verify broken state
+        wrong_before = InterfaceTemplate.objects.filter(
+            device_type__model__in=self.DS5000_MODELS,
+            type="800gbase-x-qsfpdd",
+        ).count()
+        correct_before = InterfaceTemplate.objects.filter(
+            device_type__model__in=self.DS5000_MODELS,
+            type="800gbase-x-osfp",
+        ).count()
+        self.assertEqual(wrong_before, 192)
+        self.assertEqual(correct_before, 0)
+
+        # Run fix
+        call_command("fix_ds5000_interface_types", stdout=out)
+
+        # Verify fixed state
+        wrong_after = InterfaceTemplate.objects.filter(
+            device_type__model__in=self.DS5000_MODELS,
+            type="800gbase-x-qsfpdd",
+        ).count()
+        correct_after = InterfaceTemplate.objects.filter(
+            device_type__model__in=self.DS5000_MODELS,
+            type="800gbase-x-osfp",
+        ).count()
+        self.assertEqual(wrong_after, 0, "Should have no QSFP-DD 800G interfaces")
+        self.assertEqual(correct_after, 192, "Should have 192 OSFP 800G interfaces")
+
+        # Verify output mentions success
+        output = out.getvalue()
+        self.assertIn("OK", output)
+        self.assertIn("192", output)
+
+    def test_backfill_is_idempotent(self):
+        """Running command multiple times should be safe."""
+        # Run fix twice
+        call_command("fix_ds5000_interface_types")
+        call_command("fix_ds5000_interface_types")
+
+        # Should still have correct state
+        correct = InterfaceTemplate.objects.filter(
+            device_type__model__in=self.DS5000_MODELS,
+            type="800gbase-x-osfp",
+        ).count()
+        self.assertEqual(correct, 192)
+
+    def test_backfill_skips_non_celestica_manufacturers(self):
+        """Safety check: skip device types with wrong manufacturer."""
+        # Create fake DS5000 under wrong manufacturer
+        wrong_mfg = Manufacturer.objects.create(
+            name="FakeVendor",
+            slug="fakevendor"
+        )
+        fake_dt = DeviceType.objects.create(
+            manufacturer=wrong_mfg,
+            model="DS5000",
+            slug="fake-ds5000"
+        )
+        InterfaceTemplate.objects.create(
+            device_type=fake_dt,
+            name="E1/1",
+            type="800gbase-x-qsfpdd"
+        )
+
+        out = StringIO()
+        call_command("fix_ds5000_interface_types", stdout=out)
+
+        # Should skip fake device type
+        output = out.getvalue()
+        self.assertIn("Skipping", output)
+        self.assertIn("FakeVendor", output)
+
+        # Fake device type should remain unchanged
+        fake_iface = fake_dt.interfacetemplates.first()
+        self.assertEqual(fake_iface.type, "800gbase-x-qsfpdd", "Should not modify non-Celestica device")

--- a/netbox_hedgehog/tests/test_fabric_import/test_import_command.py
+++ b/netbox_hedgehog/tests/test_fabric_import/test_import_command.py
@@ -64,7 +64,7 @@ class ImportFabricProfilesCommandTestCase(TestCase):
 
         # Should show success
         self.assertIn("Import Complete", output)
-        self.assertIn("Profiles processed: 3", output)
+        self.assertIn("Profiles processed: 5", output)
 
         # Should create device types (check specific models, not total count)
         self.assertTrue(DeviceType.objects.filter(model="celestica-ds5000").exists())


### PR DESCRIPTION
## Summary
Fixes OSFP vs QSFP-DD mapping bug and adds support for nonstandard switch profiles:
- **Critical fix:** DS5000 variants now use OSFP (800gbase-x-osfp) instead of QSFP-DD
- **Alias profiles:** Supermicro SSE-C4632 imports using DS3000 specs
- **Virtual switches:** vs and vs-clsp profiles now import (essential for hhfab QA)
- **Backfill command:** Fix existing DS5000 devices (192 interfaces)

## Implementation
- Profile-name-first mapping with speed-based fallback (backward compatible)
- Alias profile import wired into management command
- Virtual switch import wired into management command
- Backfill management command with dry-run mode and safety checks

## Test Results
✅ 44/44 tests passing (33 existing + 11 new)
- See issue #148 for complete test report

## Post-Merge Steps
Run backfill command to fix existing DS5000 devices:


Closes #148
