### PR TITLE
[DIET-202] Remove dead helper methods and unused imports from setup command

### DIFF
--- a/netbox_hedgehog/tests/test_topology_planning/test_case_128gpu_command.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_case_128gpu_command.py
@@ -128,6 +128,28 @@ class Case128GpuCommandTestCase(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
 
+    def test_create_case_data_delegates_to_apply_case_id(self):
+        """_create_case_data() must delegate to apply_case_id, not inline construction."""
+        from unittest.mock import patch, MagicMock
+        from netbox_hedgehog.management.commands.setup_case_128gpu_odd_ports import Command
+
+        cmd = Command()
+        mock_plan = MagicMock()
+
+        with patch(
+            "netbox_hedgehog.test_cases.runner.apply_case_id",
+            return_value=mock_plan,
+        ) as mock_apply:
+            result = cmd._create_case_data()
+
+        mock_apply.assert_called_once_with(
+            "ux_case_128gpu_odd_ports",
+            clean=False,
+            prune=True,
+            reference_mode="ensure",
+        )
+        self.assertEqual(result, mock_plan)
+
     def test_rail_requires_value_for_rail_optimized(self):
         connection = PlanServerConnection.objects.filter(server_class__plan=self.plan).first()
         form = PlanServerConnectionForm(


### PR DESCRIPTION
## Summary

Post-merge cleanup following DIET-202 (zone-targeted connections).

- Removes three unreachable helper methods from `setup_case_128gpu_odd_ports.py`: `_ensure_breakout`, `_ensure_ds5000_extension`, `_ensure_server_device_type` — all dead after `_create_case_data()` was delegated to `apply_case_id()` in Phase 5
- Trims all imports that only served those helpers: `Manufacturer`, `DeviceType`, `InterfaceTemplate`, `ModuleType`, `DeviceTypeExtension`, `BreakoutOption`, and the full `choices` import block
- Adds regression test `test_create_case_data_delegates_to_apply_case_id` that mocks `apply_case_id` and asserts it is called with the correct case ID and kwargs — prevents silent regression back to inline construction

## Test plan

- [x] `test_case_128gpu_command`: 10 tests — OK
- [x] `test_apply_diet_test_case_command`: 6 tests — OK
- [x] Total: 16 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)