### PR TITLE
[DIET-192] Phase 5: GREEN - managed-fabric export scoping

### DIFF
--- a/netbox_hedgehog/choices.py
+++ b/netbox_hedgehog/choices.py
@@ -162,13 +162,27 @@ class FabricTypeChoices(ChoiceSet):
 
     FRONTEND = 'frontend'
     BACKEND = 'backend'
-    OOB = 'oob'
+    OOB = 'oob'  # Legacy - not Hedgehog-managed
+    OOB_MGMT = 'oob-mgmt'
+    IN_BAND_MGMT = 'in-band-mgmt'
+    NETWORK_MGMT = 'network-mgmt'
+
+    # Fabrics that appear in Hedgehog wiring YAML export
+    HEDGEHOG_MANAGED_SET = frozenset([FRONTEND, BACKEND])
 
     CHOICES = [
         (FRONTEND, 'Frontend'),
         (BACKEND, 'Backend'),
-        (OOB, 'Out-of-Band'),
+        (OOB, 'Out-of-Band (DEPRECATED)'),
+        (OOB_MGMT, 'OOB Management'),
+        (IN_BAND_MGMT, 'In-Band Management'),
+        (NETWORK_MGMT, 'Network Management'),
     ]
+
+    @classmethod
+    def is_hedgehog_managed(cls, fabric: str) -> bool:
+        """Return True if fabric is exported in Hedgehog wiring YAML."""
+        return fabric in cls.HEDGEHOG_MANAGED_SET
 
 
 class HedgehogRoleChoices(ChoiceSet):

--- a/netbox_hedgehog/forms/topology_planning.py
+++ b/netbox_hedgehog/forms/topology_planning.py
@@ -226,7 +226,12 @@ class PlanSwitchClassForm(NetBoxModelForm):
         }
         help_texts = {
             'switch_class_id': "Unique identifier (e.g., 'fe-gpu-leaf', 'be-spine')",
-            'fabric': 'Fabric type (Frontend, Backend, OOB)',
+            'fabric': (
+                'Fabric type. Frontend and Backend are Hedgehog-managed and appear in wiring YAML export. '
+                'Management types (OOB Management, In-Band Management, Network Management) are tracked '
+                'for inventory but excluded from wiring export. Out-of-Band (oob) is deprecated; use '
+                'OOB Management instead.'
+            ),
             'hedgehog_role': 'Hedgehog role (Spine, Server Leaf, Border Leaf)',
             'device_type_extension': 'Switch model with Hedgehog-specific metadata',
             'redundancy_type': 'Redundancy mode (MCLAG=even pairs with peer link, ESLAG=2-4 switches without peer link)',

--- a/netbox_hedgehog/migrations/0034_fabrictype_expand_management_types.py
+++ b/netbox_hedgehog/migrations/0034_fabrictype_expand_management_types.py
@@ -1,0 +1,37 @@
+"""Migration 0034: Expand FabricTypeChoices with management fabric types.
+
+This is a state-only migration (AlterField). No schema change because the
+fabric column is a VARCHAR and the new values are simply additional valid
+choices. Existing 'oob' data is unaffected.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('netbox_hedgehog', '0033_finalize_zone_targeted'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='planswitchclass',
+            name='fabric',
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ('frontend', 'Frontend'),
+                    ('backend', 'Backend'),
+                    ('oob', 'Out-of-Band (DEPRECATED)'),
+                    ('oob-mgmt', 'OOB Management'),
+                    ('in-band-mgmt', 'In-Band Management'),
+                    ('network-mgmt', 'Network Management'),
+                ],
+                help_text='Fabric type. Frontend and Backend are Hedgehog-managed (appear in wiring YAML). '
+                          'Management types are tracked for inventory but excluded from wiring export. '
+                          'Out-of-Band (oob) is deprecated; use oob-mgmt instead.',
+                max_length=50,
+            ),
+        ),
+    ]

--- a/netbox_hedgehog/models/topology_planning/topology_plans.py
+++ b/netbox_hedgehog/models/topology_planning/topology_plans.py
@@ -208,7 +208,11 @@ class PlanSwitchClass(NetBoxModel):
         max_length=50,
         choices=FabricTypeChoices,
         blank=True,
-        help_text="Fabric type (Frontend, Backend, OOB)"
+        help_text=(
+            'Fabric type. Frontend and Backend are Hedgehog-managed (appear in wiring YAML). '
+            'Management types are tracked for inventory but excluded from wiring export. '
+            'Out-of-Band (oob) is deprecated; use oob-mgmt instead.'
+        ),
     )
 
     hedgehog_role = models.CharField(
@@ -295,6 +299,11 @@ class PlanSwitchClass(NetBoxModel):
 
     def get_absolute_url(self):
         return reverse('plugins:netbox_hedgehog:planswitchclass_detail', args=[self.pk])
+
+    @property
+    def is_hedgehog_managed(self) -> bool:
+        """Return True if this switch class is exported in Hedgehog wiring YAML."""
+        return FabricTypeChoices.is_hedgehog_managed(self.fabric)
 
     def save(self, *args, **kwargs):
         """

--- a/netbox_hedgehog/services/device_generator.py
+++ b/netbox_hedgehog/services/device_generator.py
@@ -357,11 +357,7 @@ class DeviceGenerator:
             for switch_class in self.plan.switch_classes.all()
         }
 
-        for fabric in (
-            FabricTypeChoices.FRONTEND,
-            FabricTypeChoices.BACKEND,
-            FabricTypeChoices.OOB,
-        ):
+        for fabric in sorted(FabricTypeChoices.HEDGEHOG_MANAGED_SET):
             leaves = [
                 device
                 for device in switch_devices.values()

--- a/netbox_hedgehog/templates/netbox_hedgehog/planswitchclass.html
+++ b/netbox_hedgehog/templates/netbox_hedgehog/planswitchclass.html
@@ -27,6 +27,16 @@
             <td>{% badge object.get_fabric_display %}</td>
           </tr>
           <tr>
+            <th scope="row">Wiring Diagram</th>
+            <td>
+              {% if object.is_hedgehog_managed %}
+                <span class="badge bg-success">Included</span>
+              {% else %}
+                <span class="badge bg-secondary">Excluded</span>
+              {% endif %}
+            </td>
+          </tr>
+          <tr>
             <th scope="row">Hedgehog Role</th>
             <td>{% badge object.get_hedgehog_role_display bg_color="blue" %}</td>
           </tr>

--- a/netbox_hedgehog/tests/test_topology_planning/test_yaml_export_inventory_based.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_yaml_export_inventory_based.py
@@ -1040,7 +1040,8 @@ class YAMLExportRedundancyCRDsTestCase(YAMLExportTestBase):
             snapshot={}
         )
 
-    def _create_switch_device(self, plan, name, hedgehog_class, hedgehog_role='server-leaf'):
+    def _create_switch_device(self, plan, name, hedgehog_class, hedgehog_role='server-leaf',
+                              hedgehog_fabric='frontend'):
         digits = ''.join([ch for ch in name if ch.isdigit()])
         mac_suffix = int(digits) if digits else 0
         return Device.objects.create(
@@ -1052,6 +1053,7 @@ class YAMLExportRedundancyCRDsTestCase(YAMLExportTestBase):
                 'hedgehog_plan_id': str(plan.pk),
                 'hedgehog_class': hedgehog_class,
                 'hedgehog_role': hedgehog_role,
+                'hedgehog_fabric': hedgehog_fabric,
                 'boot_mac': f"0c:20:12:ff:00:{mac_suffix:02x}",
             }
         )


### PR DESCRIPTION
## Summary

GREEN implementation for DIET-192 — Hedgehog-managed fabric flag. All 22 RED tests from PR #207 now pass.

## Changes

### Core implementation (7 files)

| File | Change |
|---|---|
| `choices.py` | `HEDGEHOG_MANAGED_SET = frozenset([FRONTEND, BACKEND])`; `is_hedgehog_managed()` classmethod; 3 new fabric choices (OOB_MGMT, IN_BAND_MGMT, NETWORK_MGMT); OOB label → 'Out-of-Band (DEPRECATED)' |
| `migrations/0034_fabrictype_expand_management_types.py` | AlterField state migration — no schema change; VARCHAR column accepts any string |
| `topology_plans.py` | `PlanSwitchClass.is_hedgehog_managed` property; `fabric` help_text updated to match migration |
| `yaml_generator.py` | `_generate_switches()` adds `hedgehog_fabric__in=HEDGEHOG_MANAGED_SET` filter; `_generate_connection_crds()` builds `_managed_switch_ids` set and guards each cable with `_endpoint_is_allowed()` |
| `device_generator.py` | fabric loop uses `sorted(HEDGEHOG_MANAGED_SET)` instead of hardcoded `(FRONTEND, BACKEND, OOB)` |
| `forms/topology_planning.py` | `fabric` field `help_text` updated |
| `planswitchclass.html` | Wiring Diagram row with Included/Excluded badge based on `is_hedgehog_managed` |

### Test adjustments (2 files, minimal changes)

| File | Change |
|---|---|
| `test_managed_fabric_export.py` | `server_role` uses `slug='server'` (matches `_generate_servers()` filter); T3 uses 4 separate servers (1 cable each) for correct 2-CRD count |
| `test_yaml_export_inventory_based.py` | `_create_switch_device()` adds `hedgehog_fabric='frontend'` so new fabric filter doesn't exclude existing test switches |

## Key design decisions

- **Server endpoint rule**: `_endpoint_is_allowed()` uses `hedgehog_fabric` presence as discriminant (switches always have it set; servers never do). Does not rely on role slug.
- **Legacy 'oob'**: Not in HEDGEHOG_MANAGED_SET → excluded from YAML export. No data migration needed.
- **Migration 0034**: renumbers correctly after DIET-202 consumed 0031-0033.

## Test results

```
docker compose exec netbox python manage.py test \
  netbox_hedgehog.tests.test_topology_planning.test_managed_fabric_export \
  --keepdb --verbosity=1
Ran 22 tests ... OK
```

Pre-existing failures in full suite (NOT introduced by this PR, verified by stash/baseline check):
- 9 FAIL: test_uc_case_128_gpu_backward_compatibility (996 != 548 — pre-existing state issue), ServerConnectionFiltering, GenerationState, UplinkCapacity, etc.
- ~150 ERROR: nic_module_type NOT NULL (from DIET-179, migration 0030)

🤖 Generated with [Claude Code](https://claude.com/claude-code)