### PR TITLE
[DIET-216] Align test_uplink_capacity with DIET-165 zones-win priority rule

### DIFF
--- a/netbox_hedgehog/tests/test_topology_planning/test_uplink_capacity.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_uplink_capacity.py
@@ -51,7 +51,7 @@ class GetUplinkPortCountTestCase(TestCase):
         )
 
     def test_override_takes_precedence(self):
-        """Explicit override wins (Priority 1)."""
+        """Deprecated field used as fallback when no uplink zones exist (DIET-165 Priority 2)."""
         switch_class = PlanSwitchClass.objects.create(
             plan=self.plan,
             device_type_extension=self.extension,
@@ -85,8 +85,18 @@ class GetUplinkPortCountTestCase(TestCase):
 
         self.assertEqual(uplink_count, 4)
 
-    def test_override_takes_precedence_over_zones(self):
-        """Override wins even when uplink zones exist."""
+    def test_override_ignored_when_uplink_zones_exist(self):
+        """Zones take precedence over uplink_ports_per_switch when both are set (DIET-165).
+
+        Approved priority order:
+          Priority 1: SwitchPortZone with zone_type='uplink' (zones win)
+          Priority 2: uplink_ports_per_switch (deprecated fallback, only used when no zones)
+
+        Proof sources:
+          - DIET-164 technical spec: "PRIORITY 1: Zones (SINGLE SOURCE OF TRUTH)"
+          - test_calculation_priority.py::test_get_uplink_port_count_zones_take_precedence
+          - topology_calculations.get_uplink_port_count() checks uplink_zones.exists() first
+        """
         switch_class = PlanSwitchClass.objects.create(
             plan=self.plan,
             device_type_extension=self.extension,
@@ -105,7 +115,7 @@ class GetUplinkPortCountTestCase(TestCase):
 
         uplink_count = get_uplink_port_count(switch_class)
 
-        self.assertEqual(uplink_count, 6)
+        self.assertEqual(uplink_count, 4)  # zones win: 4 ports in spec '61-64', not override=6
 
     def test_multiple_uplink_zones_are_summed(self):
         """Multiple uplink zones are aggregated."""


### PR DESCRIPTION
## Summary

Aligns the stale `test_override_takes_precedence_over_zones` test with the DIET-165 approved priority rule. No production code changes.

## Invariants

**Unchanged:** Production behavior was already correct per DIET-165. The stale test was encoding pre-DIET-165 (override-wins) behavior that was superseded when DIET-165 flipped the priority.

**Not changed:** `topology_calculations.get_uplink_port_count()`, all models, migrations, views, forms.

## Changes (test-only, 1 file)

**`test_uplink_capacity.py`:**

1. **Rename** `test_override_takes_precedence_over_zones` → `test_override_ignored_when_uplink_zones_exist`
2. **Update docstring** to state the DIET-165 priority order explicitly and cite all three proof sources
3. **Flip assertion** `assertEqual(uplink_count, 6)` → `assertEqual(uplink_count, 4)` (zones win: 4 ports from spec `'61-64'`, not override=6)
4. **Update `test_override_takes_precedence` docstring**: "Explicit override wins (Priority 1)" was directly misleading about the same rule — now reads "Deprecated field used as fallback when no uplink zones exist (DIET-165 Priority 2)"

## DIET-165 Proof Sources

The zones-win direction is confirmed by three independent sources:

| Source | Location | States |
|--------|----------|--------|
| DIET-164 technical spec | GitHub issue #164 | "PRIORITY 1: Zones (SINGLE SOURCE OF TRUTH - matches generation)" |
| `test_calculation_priority.py` | `test_get_uplink_port_count_zones_take_precedence` (line 106) | `assertEqual(uplink_count, 4)` (zones win) — PASSES |
| `topology_calculations.py` | `get_uplink_port_count()` (lines 205–291) | Checks `uplink_zones.exists()` first, returns zone-derived count |

## Test Methods Updated

- **Renamed:** `GetUplinkPortCountTestCase.test_override_takes_precedence_over_zones` → `test_override_ignored_when_uplink_zones_exist`
- **Docstring only:** `GetUplinkPortCountTestCase.test_override_takes_precedence`

## Test Commands Run

```
docker compose exec netbox python manage.py test \
  netbox_hedgehog.tests.test_topology_planning.test_uplink_capacity \
  --keepdb --verbosity=2
```

**Result:** Ran 7 tests in 0.403s — **OK** (all pass)

Closes #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)