### PR TITLE
[DIET-215] Fix is_dirty() false-positive: align snapshot fixtures with production builder

### DIFF
--- a/netbox_hedgehog/tests/test_topology_planning/test_models_generation_state.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_models_generation_state.py
@@ -24,6 +24,7 @@ from netbox_hedgehog.models.topology_planning import (
     GenerationState,
     DeviceTypeExtension,
 )
+from netbox_hedgehog.utils.snapshot_builder import build_plan_snapshot
 from dcim.models import DeviceType, Manufacturer
 
 
@@ -196,30 +197,21 @@ class GenerationStateModelTestCase(TestCase):
             slug="gpu-server"
         )
 
-        server = PlanServerClass.objects.create(
+        PlanServerClass.objects.create(
             plan=plan,
             server_class_id="gpu-b200",
             quantity=96,
             server_device_type=server_dt
         )
 
-        # Create snapshot matching current state
-        snapshot = {
-            'server_classes': [
-                {
-                    'server_class_id': 'gpu-b200',
-                    'quantity': 96
-                }
-            ],
-            'switch_classes': []
-        }
-
+        # Snapshot taken at "generation time" using the same builder production uses.
+        # Structurally identical to what is_dirty() will compare against.
         state = GenerationState.objects.create(
             plan=plan,
             device_count=96,
             interface_count=192,
             cable_count=192,
-            snapshot=snapshot,
+            snapshot=build_plan_snapshot(plan),
             status='generated'
         )
 
@@ -242,27 +234,17 @@ class GenerationStateModelTestCase(TestCase):
             server_device_type=server_dt
         )
 
-        # Create snapshot with old quantity
-        snapshot = {
-            'server_classes': [
-                {
-                    'server_class_id': 'gpu-b200',
-                    'quantity': 96
-                }
-            ],
-            'switch_classes': []
-        }
-
+        # Snapshot captures plan at quantity=96 (simulates generation time).
         state = GenerationState.objects.create(
             plan=plan,
             device_count=96,
             interface_count=192,
             cable_count=192,
-            snapshot=snapshot,
+            snapshot=build_plan_snapshot(plan),
             status='generated'
         )
 
-        # Change server quantity
+        # Change server quantity — plan now differs from stored snapshot.
         server.quantity = 128
         server.save()
 
@@ -278,7 +260,7 @@ class GenerationStateModelTestCase(TestCase):
             slug="gpu-server"
         )
 
-        # Create initial server
+        # Create initial server.
         PlanServerClass.objects.create(
             plan=plan,
             server_class_id="gpu-b200",
@@ -286,27 +268,17 @@ class GenerationStateModelTestCase(TestCase):
             server_device_type=server_dt
         )
 
-        # Create snapshot with one server class
-        snapshot = {
-            'server_classes': [
-                {
-                    'server_class_id': 'gpu-b200',
-                    'quantity': 96
-                }
-            ],
-            'switch_classes': []
-        }
-
+        # Snapshot captures plan with one server class (simulates generation time).
         state = GenerationState.objects.create(
             plan=plan,
             device_count=96,
             interface_count=192,
             cable_count=192,
-            snapshot=snapshot,
+            snapshot=build_plan_snapshot(plan),
             status='generated'
         )
 
-        # Add new server class
+        # Add a second server class — plan now has 2, snapshot has 1.
         PlanServerClass.objects.create(
             plan=plan,
             server_class_id="storage-a",
@@ -326,8 +298,8 @@ class GenerationStateModelTestCase(TestCase):
             slug="gpu-server"
         )
 
-        # Create two server classes
-        server1 = PlanServerClass.objects.create(
+        # Create two server classes.
+        PlanServerClass.objects.create(
             plan=plan,
             server_class_id="gpu-b200",
             quantity=96,
@@ -341,25 +313,17 @@ class GenerationStateModelTestCase(TestCase):
             server_device_type=server_dt
         )
 
-        # Create snapshot with both
-        snapshot = {
-            'server_classes': [
-                {'server_class_id': 'gpu-b200', 'quantity': 96},
-                {'server_class_id': 'storage-a', 'quantity': 32}
-            ],
-            'switch_classes': []
-        }
-
+        # Snapshot captures plan with both server classes (simulates generation time).
         state = GenerationState.objects.create(
             plan=plan,
             device_count=128,
             interface_count=256,
             cable_count=256,
-            snapshot=snapshot,
+            snapshot=build_plan_snapshot(plan),
             status='generated'
         )
 
-        # Remove one server class
+        # Remove one server class — plan now has 1, snapshot has 2.
         server2.delete()
 
         self.assertTrue(state.is_dirty())
@@ -368,7 +332,7 @@ class GenerationStateModelTestCase(TestCase):
         """Test is_dirty() detects switch quantity changes"""
         plan = TopologyPlan.objects.create(name="Plan")
 
-        # Create switch class
+        # Create switch class with override_quantity=12.
         switch = PlanSwitchClass.objects.create(
             plan=plan,
             switch_class_id="fe-leaf",
@@ -377,27 +341,17 @@ class GenerationStateModelTestCase(TestCase):
             override_quantity=12
         )
 
-        # Create snapshot
-        snapshot = {
-            'server_classes': [],
-            'switch_classes': [
-                {
-                    'switch_class_id': 'fe-leaf',
-                    'effective_quantity': 12
-                }
-            ]
-        }
-
+        # Snapshot captures effective_quantity=12 (simulates generation time).
         state = GenerationState.objects.create(
             plan=plan,
             device_count=12,
             interface_count=768,
             cable_count=0,
-            snapshot=snapshot,
+            snapshot=build_plan_snapshot(plan),
             status='generated'
         )
 
-        # Change switch quantity
+        # Change switch quantity — plan now has effective_quantity=16, snapshot has 12.
         switch.override_quantity = 16
         switch.save()
 
@@ -595,12 +549,13 @@ class TopologyPlanPropertiesTestCase(TestCase):
         """Test needs_regeneration returns False when not dirty"""
         plan = TopologyPlan.objects.create(name="Plan")
 
+        # Snapshot of empty plan using production builder — matches what is_dirty() compares against.
         GenerationState.objects.create(
             plan=plan,
             device_count=0,
             interface_count=0,
             cable_count=0,
-            snapshot={'server_classes': [], 'switch_classes': []},
+            snapshot=build_plan_snapshot(plan),
             status='generated'
         )
 
@@ -619,18 +574,17 @@ class TopologyPlanPropertiesTestCase(TestCase):
             slug="gpu-server"
         )
 
-        # Create initial state
-        snapshot = {'server_classes': [], 'switch_classes': []}
+        # Snapshot of empty plan at "generation time".
         GenerationState.objects.create(
             plan=plan,
             device_count=0,
             interface_count=0,
             cable_count=0,
-            snapshot=snapshot,
+            snapshot=build_plan_snapshot(plan),
             status='generated'
         )
 
-        # Add server class (modifies plan)
+        # Add server class — plan now differs from empty snapshot.
         PlanServerClass.objects.create(
             plan=plan,
             server_class_id="gpu-b200",


### PR DESCRIPTION
## Summary

Fixes a false-positive in `GenerationState.is_dirty()` caused by stale test fixtures. No production code changes.

## Invariants

**Unchanged:** `build_plan_snapshot()`, `compare_snapshots()`, and `is_dirty()` are not modified. Only malformed test snapshot fixtures are corrected.

## Root Cause

`is_dirty()` calls `build_plan_snapshot(plan)` (5-key dict) and compares it against the stored snapshot via `compare_snapshots()`. Test fixtures manually constructed 2-key dicts, missing `connections`, `port_zones`, and `mclag_domains`. Since `compare_snapshots()` performs strict equality after normalization, the structural mismatch caused `is_dirty()` to always return `True` — even when the plan had not changed.

Production code was already correct: `_upsert_generation_state()` in `device_generator.py` has always called `build_plan_snapshot(plan)` to store the snapshot.

## Previously Failing (false-positive — now correctly pass)

| Test method | Expected | Was | Now |
|-------------|----------|-----|-----|
| `test_is_dirty_returns_false_when_unchanged` | `assertFalse` | True (FAIL) | False (PASS) |
| `test_needs_regeneration_returns_false_when_clean` | `assertFalse` | True (FAIL) | False (PASS) |

## Previously Passing for Wrong Reason (now pass for correct reason)

These tests asserted `assertTrue(state.is_dirty())`. They passed before only because the structural mismatch guaranteed `True` regardless of whether the plan was actually dirty. They now pass because `build_plan_snapshot()` correctly captures the state at generation time, and the subsequent plan mutations produce a genuine snapshot diff.

| Test method | Change detected |
|-------------|----------------|
| `test_is_dirty_returns_true_when_server_quantity_changed` | qty 96 → 128 |
| `test_is_dirty_returns_true_when_server_class_added` | 1 class → 2 classes |
| `test_is_dirty_returns_true_when_server_class_removed` | 2 classes → 1 class |
| `test_is_dirty_returns_true_when_switch_quantity_changed` | override_qty 12 → 16 |
| `test_needs_regeneration_returns_true_when_plan_changed` | empty plan → server class added |

## Fix

Replace all 7 malformed manual snapshot dicts in `is_dirty()` / `needs_regeneration()` tests with `build_plan_snapshot(plan)` calls, exactly mirroring what production `_upsert_generation_state()` does.

```python
# Before (stale — 2 keys, missing connections/port_zones/mclag_domains):
snapshot = {'server_classes': [...], 'switch_classes': []}

# After (production-shaped — 5 keys, structurally identical to what is_dirty() compares against):
snapshot = build_plan_snapshot(plan)
```

Tests using `{}` or `{'test': 'data'}` for CRUD/constraint/validation (not `is_dirty()`) are untouched.

## Test Commands Run

```
docker compose exec netbox python manage.py test \
  netbox_hedgehog.tests.test_topology_planning.test_models_generation_state \
  --keepdb --verbosity=2
```

**Result:** Ran 21 tests in 1.477s — **OK** (all pass)

Closes #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)