### PR TITLE
[DIET-224] Wiring artifact integrity and reproducible capture

### DIFF
--- a/netbox_hedgehog/management/commands/export_wiring_yaml.py
+++ b/netbox_hedgehog/management/commands/export_wiring_yaml.py
@@ -1,0 +1,145 @@
+"""
+Export wiring YAML for a topology plan to a deterministic file path (DIET-224).
+
+Writes the complete Hedgehog wiring artifact, validates it parses as a complete
+YAML document stream, and emits integrity metadata (sha256, byte size, line count).
+
+Usage:
+    docker compose exec netbox python manage.py export_wiring_yaml <plan_id> --output /path/to/wiring.yaml
+    docker compose exec netbox python manage.py export_wiring_yaml 1 --output /tmp/plan-1.yaml
+
+Exit codes:
+    0 - Success
+    1 - Plan not found, precondition failure, write error, or parse validation failure
+"""
+
+import hashlib
+import os
+import tempfile
+from datetime import datetime, timezone
+
+import yaml
+from django.core.management.base import BaseCommand, CommandError
+
+from netbox_hedgehog.choices import GenerationStatusChoices
+from netbox_hedgehog.models.topology_planning import TopologyPlan
+from netbox_hedgehog.services.yaml_generator import generate_yaml_for_plan
+
+
+class Command(BaseCommand):
+    help = "Export wiring YAML for a topology plan to a file with integrity metadata"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'plan_id',
+            type=int,
+            help='ID of the TopologyPlan to export',
+        )
+        parser.add_argument(
+            '--output',
+            required=True,
+            metavar='PATH',
+            help='Destination file path for the exported YAML',
+        )
+
+    def handle(self, *args, **options):
+        plan_id = options['plan_id']
+        output_path = os.path.abspath(options['output'])
+
+        # --- Fetch plan ---
+        try:
+            plan = TopologyPlan.objects.get(pk=plan_id)
+        except TopologyPlan.DoesNotExist:
+            raise CommandError(f"TopologyPlan with ID {plan_id} does not exist")
+
+        self.stdout.write(f"Exporting wiring YAML for plan: {plan.name} (ID: {plan.pk})")
+
+        # --- Precondition: generation must be complete ---
+        try:
+            generation_state = plan.generation_state
+        except Exception:
+            raise CommandError(
+                "No generation state found for this plan. "
+                "Run device generation before exporting."
+            )
+
+        if generation_state.status != GenerationStatusChoices.GENERATED:
+            raise CommandError(
+                f"Plan generation status is '{generation_state.status}'. "
+                f"Device generation must complete (status=generated) before export."
+            )
+
+        # --- Generate YAML content ---
+        try:
+            yaml_content = generate_yaml_for_plan(plan)
+        except Exception as e:
+            raise CommandError(f"YAML generation failed: {e}")
+
+        # --- Validate completeness: must parse as a full document stream ---
+        try:
+            documents = list(yaml.safe_load_all(yaml_content))
+            doc_count = len([d for d in documents if d is not None])
+        except yaml.YAMLError as e:
+            raise CommandError(
+                f"Generated YAML is not parseable as a complete document stream: {e}"
+            )
+
+        if doc_count == 0:
+            raise CommandError(
+                "Generated YAML contains no documents. "
+                "Export aborted to prevent empty artifact."
+            )
+
+        # --- Compute integrity metadata ---
+        content_bytes = yaml_content.encode('utf-8')
+        sha256 = hashlib.sha256(content_bytes).hexdigest()
+        byte_size = len(content_bytes)
+        line_count = yaml_content.count('\n') + (1 if yaml_content else 0)
+        timestamp = datetime.now(tz=timezone.utc).isoformat()
+
+        # --- Write atomically: temp file in same dir + rename (prevents partial writes) ---
+        output_dir = os.path.dirname(output_path)
+        if not os.path.isdir(output_dir):
+            raise CommandError(f"Output directory does not exist: {output_dir}")
+
+        try:
+            fd, tmp_path = tempfile.mkstemp(dir=output_dir, suffix='.tmp')
+            try:
+                with os.fdopen(fd, 'w', encoding='utf-8') as f:
+                    f.write(yaml_content)
+                    f.flush()
+                    os.fsync(f.fileno())
+                os.replace(tmp_path, output_path)
+            except Exception:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+        except OSError as e:
+            raise CommandError(f"Failed to write export file to {output_path}: {e}")
+
+        # --- Verify written file re-reads and re-parses correctly ---
+        try:
+            with open(output_path, 'r', encoding='utf-8') as f:
+                written_content = f.read()
+            written_docs = list(yaml.safe_load_all(written_content))
+            written_doc_count = len([d for d in written_docs if d is not None])
+        except Exception as e:
+            raise CommandError(f"Written file failed re-parse validation: {e}")
+
+        if written_doc_count != doc_count:
+            raise CommandError(
+                f"Written file integrity failure: expected {doc_count} documents, "
+                f"re-read yielded {written_doc_count}"
+            )
+
+        # --- Emit integrity metadata ---
+        self.stdout.write("")
+        self.stdout.write(f"[OK] Export complete: {output_path}")
+        self.stdout.write(f"  plan_id:    {plan.pk}")
+        self.stdout.write(f"  timestamp:  {timestamp}")
+        self.stdout.write(f"  sha256:     {sha256}")
+        self.stdout.write(f"  bytes:      {byte_size}")
+        self.stdout.write(f"  lines:      {line_count}")
+        self.stdout.write(f"  documents:  {doc_count}")

--- a/netbox_hedgehog/tests/test_topology_planning/test_export_artifact.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_export_artifact.py
@@ -1,0 +1,255 @@
+"""
+Integration tests for export_wiring_yaml management command (DIET-224).
+
+These tests validate artifact capture reliability and observability:
+- Complete YAML written to a deterministic path
+- Integrity metadata emitted (sha256, bytes, lines, documents)
+- Atomic write prevents partial-file artifacts
+- Written file re-parses as a complete YAML document stream
+- Invalid path/permission failure surfaces a clear error
+- Rerun on unchanged inventory yields identical sha256
+
+Tests do NOT use mocks for the YAML generator; they rely on the real
+generate_yaml_for_plan() path, which always emits at least 2 CRD documents
+(VLANNamespace + IPv4Namespace) even for plans with no generated devices.
+
+## Invariants
+- Unchanged: generation semantics, yaml_generator output, existing export view
+- Changed: artifact capture reliability and observability only
+"""
+
+import hashlib
+import os
+import tempfile
+
+import yaml
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from netbox_hedgehog.choices import GenerationStatusChoices
+from netbox_hedgehog.models.topology_planning import (
+    TopologyPlan,
+    GenerationState,
+)
+
+
+class ExportArtifactHappyPathTestCase(TestCase):
+    """
+    Integration tests for the export_wiring_yaml happy path.
+
+    Uses a plan with GENERATED status and no device inventory.
+    The real YAML generator always emits VLANNamespace + IPv4Namespace (2 docs minimum).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.plan = TopologyPlan.objects.create(
+            name="Test Export Plan",
+            customer_name="Test Customer",
+        )
+        GenerationState.objects.create(
+            plan=cls.plan,
+            device_count=0,
+            interface_count=0,
+            cable_count=0,
+            snapshot={},
+            status=GenerationStatusChoices.GENERATED,
+        )
+
+    def test_export_writes_complete_yaml_file(self):
+        """Export command writes a non-empty file that parses as complete YAML."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "wiring.yaml")
+
+            call_command(
+                "export_wiring_yaml",
+                str(self.plan.pk),
+                "--output", output_path,
+            )
+
+            self.assertTrue(os.path.exists(output_path), "Output file must exist")
+            self.assertGreater(os.path.getsize(output_path), 0, "Output file must be non-empty")
+
+            with open(output_path, "r", encoding="utf-8") as f:
+                content = f.read()
+
+            docs = list(yaml.safe_load_all(content))
+            non_null_docs = [d for d in docs if d is not None]
+            self.assertGreater(len(non_null_docs), 0, "Written file must contain at least one document")
+
+    def test_export_emits_required_metadata(self):
+        """Export command stdout includes sha256, bytes, lines, documents, plan_id."""
+        from io import StringIO
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "wiring.yaml")
+            out = StringIO()
+
+            call_command(
+                "export_wiring_yaml",
+                str(self.plan.pk),
+                "--output", output_path,
+                stdout=out,
+            )
+
+        output = out.getvalue()
+        self.assertIn("sha256:", output)
+        self.assertIn("bytes:", output)
+        self.assertIn("lines:", output)
+        self.assertIn("documents:", output)
+        self.assertIn(f"plan_id:", output)
+        self.assertIn("[OK] Export complete:", output)
+
+    def test_export_sha256_matches_file_content(self):
+        """sha256 in output matches actual sha256 of written file bytes."""
+        from io import StringIO
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "wiring.yaml")
+            out = StringIO()
+
+            call_command(
+                "export_wiring_yaml",
+                str(self.plan.pk),
+                "--output", output_path,
+                stdout=out,
+            )
+
+            with open(output_path, "rb") as f:
+                actual_sha256 = hashlib.sha256(f.read()).hexdigest()
+
+        output = out.getvalue()
+        sha256_line = [ln for ln in output.splitlines() if "sha256:" in ln][0]
+        reported_sha256 = sha256_line.split("sha256:")[-1].strip()
+
+        self.assertEqual(reported_sha256, actual_sha256, "Reported sha256 must match file content")
+
+    def test_export_includes_minimum_crd_kinds(self):
+        """Written file contains VLANNamespace and IPv4Namespace (minimum guaranteed documents)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "wiring.yaml")
+
+            call_command(
+                "export_wiring_yaml",
+                str(self.plan.pk),
+                "--output", output_path,
+            )
+
+            with open(output_path, "r", encoding="utf-8") as f:
+                docs = list(yaml.safe_load_all(f.read()))
+
+        kinds = {d.get("kind") for d in docs if isinstance(d, dict)}
+        self.assertIn("VLANNamespace", kinds, "Export must include VLANNamespace CRD")
+        self.assertIn("IPv4Namespace", kinds, "Export must include IPv4Namespace CRD")
+
+    def test_export_reproducible_identical_checksum(self):
+        """Rerun on unchanged inventory yields identical sha256."""
+        from io import StringIO
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path1 = os.path.join(tmpdir, "run1.yaml")
+            path2 = os.path.join(tmpdir, "run2.yaml")
+
+            out1 = StringIO()
+            call_command(
+                "export_wiring_yaml",
+                str(self.plan.pk),
+                "--output", path1,
+                stdout=out1,
+            )
+
+            out2 = StringIO()
+            call_command(
+                "export_wiring_yaml",
+                str(self.plan.pk),
+                "--output", path2,
+                stdout=out2,
+            )
+
+        def extract_sha256(output):
+            for ln in output.splitlines():
+                if "sha256:" in ln:
+                    return ln.split("sha256:")[-1].strip()
+            return None
+
+        sha1 = extract_sha256(out1.getvalue())
+        sha2 = extract_sha256(out2.getvalue())
+
+        self.assertIsNotNone(sha1)
+        self.assertEqual(sha1, sha2, "Rerun on unchanged inventory must yield identical sha256")
+
+
+class ExportArtifactPreconditionTestCase(TestCase):
+    """Tests for precondition failures that must surface clear errors."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.plan_no_state = TopologyPlan.objects.create(
+            name="Plan Without Generation State",
+        )
+        cls.plan_failed = TopologyPlan.objects.create(
+            name="Plan With Failed Generation",
+        )
+        GenerationState.objects.create(
+            plan=cls.plan_failed,
+            device_count=0,
+            interface_count=0,
+            cable_count=0,
+            snapshot={},
+            status=GenerationStatusChoices.FAILED,
+        )
+
+    def test_nonexistent_plan_raises_error(self):
+        """Command raises CommandError for non-existent plan ID."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(CommandError) as ctx:
+                call_command(
+                    "export_wiring_yaml",
+                    "999999",
+                    "--output", os.path.join(tmpdir, "out.yaml"),
+                )
+        self.assertIn("does not exist", str(ctx.exception))
+
+    def test_plan_without_generation_state_raises_error(self):
+        """Command raises CommandError when plan has no generation state."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(CommandError) as ctx:
+                call_command(
+                    "export_wiring_yaml",
+                    str(self.plan_no_state.pk),
+                    "--output", os.path.join(tmpdir, "out.yaml"),
+                )
+        self.assertIn("No generation state", str(ctx.exception))
+
+    def test_failed_generation_state_raises_error(self):
+        """Command raises CommandError when generation status is not GENERATED."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(CommandError) as ctx:
+                call_command(
+                    "export_wiring_yaml",
+                    str(self.plan_failed.pk),
+                    "--output", os.path.join(tmpdir, "out.yaml"),
+                )
+        self.assertIn("status", str(ctx.exception).lower())
+
+    def test_nonexistent_output_directory_raises_error(self):
+        """Command raises CommandError when output directory does not exist."""
+        plan = TopologyPlan.objects.create(name="Plan For Bad Path Test")
+        GenerationState.objects.create(
+            plan=plan,
+            device_count=0,
+            interface_count=0,
+            cable_count=0,
+            snapshot={},
+            status=GenerationStatusChoices.GENERATED,
+        )
+
+        with self.assertRaises(CommandError) as ctx:
+            call_command(
+                "export_wiring_yaml",
+                str(plan.pk),
+                "--output", "/nonexistent/directory/wiring.yaml",
+            )
+        self.assertIn("does not exist", str(ctx.exception))


### PR DESCRIPTION
## Summary

Implements #224 - artifact capture reliability baseline for the Wiring Export Recovery Program (#223).

- New management command `export_wiring_yaml <plan_id> --output PATH`
- Atomic write via temp-file + `os.replace()` prevents partial/truncated artifacts
- Post-write re-parse validation catches any integrity failure immediately
- Integrity metadata emitted: `sha256`, `bytes`, `lines`, `documents`, `plan_id`, `timestamp`
- Reproducible: rerun on unchanged inventory yields identical sha256

## Invariants

- **Unchanged:** generation semantics, `yaml_generator` output, existing `TopologyPlanExportView`
- **Changed:** artifact capture reliability and observability only

## Test commands run

```bash
docker compose exec netbox python manage.py test \
  netbox_hedgehog.tests.test_topology_planning.test_export_artifact \
  --keepdb --verbosity=2
```

Result: **9/9 tests passed** (0.386s)

## Usage example

```bash
docker compose exec netbox python manage.py export_wiring_yaml 1 --output /tmp/plan-1.yaml
```

Output:
```
Exporting wiring YAML for plan: UX Case 128GPU Odd Ports (ID: 1)

[OK] Export complete: /tmp/plan-1.yaml
  plan_id:    1
  timestamp:  2026-03-05T17:33:43.353467+00:00
  sha256:     90fcbffd6ea6301198b53c2e7698e7fcb08e8159e953beae1a01c2e511580014
  bytes:      302
  lines:      20
  documents:  2
```

## Residual risk

- Export content completeness (Switch/Server/Connection CRD counts) is not enforced here - that is #225's scope.
- The existing `TopologyPlanExportView` (HTTP export) is unchanged and not hardened with atomic write; #224 adds a new CLI path only.

Closes #224