### PR TITLE
[DIET-226] Fix breakout lane mapping: E1/<port> keys + uppercase G for hhfab

### DIFF
--- a/netbox_hedgehog/services/yaml_generator.py
+++ b/netbox_hedgehog/services/yaml_generator.py
@@ -659,31 +659,31 @@ class YAMLGenerator:
 
     def _generate_port_configuration(self, switch_class: 'PlanSwitchClass') -> Dict[str, Dict[str, Any]]:
         """
-        Generate portBreakouts, portSpeeds, and portAutoNegs for a switch class.
+        Generate portBreakouts for a switch class using hhfab-compatible key format.
 
-        Reads SwitchPortZone data to determine which ports have breakouts and their speeds.
+        All ports (breakout and native) are represented in portBreakouts with
+        'E1/<port>' keys, matching the hhfab wiring schema. portSpeeds and
+        portAutoNegs are not emitted; hhfab derives speeds from portBreakouts.
 
         Args:
             switch_class: PlanSwitchClass instance
 
         Returns:
             Dict with keys: portBreakouts, portSpeeds, portAutoNegs
+            (portSpeeds and portAutoNegs are always empty; retained for
+            compatibility with the existing emit check in _generate_switches)
 
-        Example output for fe-gpu-leaf (odd ports = 4x200g, even ports = 1x800g):
+        Example output for fe-gpu-leaf (odd ports = 4x200G, even ports = 1x800G):
             {
-                'portBreakouts': {'1': '4x200g', '3': '4x200g', ...},
-                'portSpeeds': {'E1/2': '800g', 'E1/4': '800g', ...},
-                'portAutoNegs': {'E1/2': False, 'E1/4': False, ...}
+                'portBreakouts': {'E1/1': '4x200g', 'E1/3': '4x200g', ...,
+                                  'E1/2': '1x800G', 'E1/4': '1x800G', ...},
+                'portSpeeds': {},
+                'portAutoNegs': {}
             }
-
-        Note: Breakout subports are NOT included in portSpeeds/portAutoNegs.
-              The breakout config itself defines speeds for subports.
         """
         from ..models.topology_planning import SwitchPortZone
 
         port_breakouts = {}
-        port_speeds = {}
-        port_auto_negs = {}
 
         # Query all port zones for this switch class
         zones = SwitchPortZone.objects.filter(switch_class=switch_class).order_by('priority')
@@ -694,42 +694,25 @@ class YAMLGenerator:
             ports = self._parse_port_spec(zone.port_spec)
 
             if zone.breakout_option:
-                # Ports have breakout configured
-                # Fix breakout_id format: lowercase 'x', uppercase 'G' (e.g., 1x800G not 1x800g or 1X800G)
+                # Normalise breakout_id to hhfab-canonical form: lowercase 'x', uppercase 'G'
+                # e.g. "2x400g" → "2x400G", "4x200g" → "4x200G", "1x800g" → "1x800G"
+                # hhfab profile matching is case-sensitive on the trailing 'G'.
                 breakout_id = zone.breakout_option.breakout_id.replace('g', 'G')
-                logical_ports = zone.breakout_option.logical_ports
-                logical_speed = zone.breakout_option.logical_speed
 
-                # Check if this is a "real" breakout or just native speed (1x)
-                if logical_ports == 1:
-                    # 1x<speed> means native speed - treat as regular port, NOT a breakout
-                    # Add to portSpeeds as native port
-                    for port in ports:
-                        port_speeds[str(port)] = f"{logical_speed}g"
-                        port_auto_negs[str(port)] = False
-                else:
-                    # Real breakout (2x, 4x, 8x, etc.)
-                    for port in ports:
-                        # Add breakout config with port number as key (e.g., "1": "4x200g")
-                        port_breakouts[str(port)] = breakout_id.lower()
-
-                        # Add breakout subports to portSpeeds/portAutoNegs
-                        # Format: "1/1", "1/2", etc. for subports
-                        for subport in range(1, logical_ports + 1):
-                            port_speeds[f"{port}/{subport}"] = f"{logical_speed}g"
-                            port_auto_negs[f"{port}/{subport}"] = False
+                # All ports go into portBreakouts with 'E1/<port>' key.
+                # 1x entries (native speed) use the same format as multi-lane breakouts.
+                for port in ports:
+                    port_breakouts[f"E1/{port}"] = breakout_id
             else:
-                # No breakout - ports use native speed
+                # No breakout_option configured: emit native speed as 1x<N>G.
                 native_speed = switch_class.device_type_extension.native_speed
                 for port in ports:
-                    # Use E1/{port} naming to match NetBox Interface names
-                    port_speeds[f"E1/{port}"] = f"{native_speed}g"
-                    port_auto_negs[f"E1/{port}"] = False
+                    port_breakouts[f"E1/{port}"] = f"1x{native_speed}G"
 
         return {
             'portBreakouts': port_breakouts,
-            'portSpeeds': port_speeds,
-            'portAutoNegs': port_auto_negs
+            'portSpeeds': {},
+            'portAutoNegs': {}
         }
 
     def _parse_port_spec(self, port_spec: str) -> List[int]:

--- a/netbox_hedgehog/tests/test_topology_planning/test_breakout_lane_mapping.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_breakout_lane_mapping.py
@@ -1,0 +1,163 @@
+"""
+Unit tests for breakout lane mapping in yaml_generator (DIET-226).
+
+These tests verify that _generate_port_configuration() emits hhfab-compatible
+Switch CRD portBreakouts entries:
+  - Key format: 'E1/<port>' (not bare port number)
+  - Breakout mode: uppercase 'G' (e.g. '2x400G', '4x200G', '1x800G')
+  - portSpeeds and portAutoNegs: not emitted (empty)
+
+Root cause of the bug: bare port numbers ('1': '2x400g') were rejected by hhfab
+with 'port 34 not found in switch profile'. The fix uses 'E1/<port>' keys and
+uppercase G to match the hhfab switch profile schema.
+
+## Invariants
+- Unchanged: connection CRD port names (come from Interface.name, already E1/<port>/<lane>)
+- Unchanged: port allocator naming (PortAllocatorV2 already uses E1/<port>/<lane>)
+- Changed: Switch CRD portBreakouts key format and breakout mode capitalisation
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from netbox_hedgehog.services.yaml_generator import YAMLGenerator
+from netbox_hedgehog.models.topology_planning import SwitchPortZone
+
+
+def _make_gen():
+    """Return a bare YAMLGenerator instance without a plan (for unit-testing helpers)."""
+    return YAMLGenerator.__new__(YAMLGenerator)
+
+
+def _make_zone(breakout_id, logical_ports, logical_speed, port_spec):
+    """Return a mock SwitchPortZone with the given breakout_option."""
+    bo = MagicMock()
+    bo.breakout_id = breakout_id
+    bo.logical_ports = logical_ports
+    bo.logical_speed = logical_speed
+
+    zone = MagicMock()
+    zone.breakout_option = bo
+    zone.port_spec = port_spec
+    return zone
+
+
+def _run_port_config(zones, native_speed=800):
+    """Call _generate_port_configuration() with the given mock zones."""
+    ext = MagicMock()
+    ext.native_speed = native_speed
+    sc = MagicMock()
+    sc.device_type_extension = ext
+
+    gen = _make_gen()
+    with patch.object(SwitchPortZone, 'objects') as mock_qs:
+        mock_qs.filter.return_value.order_by.return_value = zones
+        return gen._generate_port_configuration(sc)
+
+
+class BreakoutKeyFormatTestCase(TestCase):
+    """portBreakouts keys must use 'E1/<port>' format, never bare port numbers."""
+
+    def test_2x400g_uses_e1_prefix(self):
+        result = _run_port_config([_make_zone('2x400g', 2, 400, '1-4')])
+        pb = result['portBreakouts']
+        self.assertIn('E1/1', pb)
+        self.assertIn('E1/2', pb)
+        self.assertIn('E1/3', pb)
+        self.assertIn('E1/4', pb)
+
+    def test_4x200g_uses_e1_prefix(self):
+        result = _run_port_config([_make_zone('4x200g', 4, 200, '1-3')])
+        pb = result['portBreakouts']
+        self.assertIn('E1/1', pb)
+        self.assertIn('E1/2', pb)
+        self.assertIn('E1/3', pb)
+
+    def test_1x800g_native_uses_e1_prefix(self):
+        result = _run_port_config([_make_zone('1x800g', 1, 800, '33-36')])
+        pb = result['portBreakouts']
+        self.assertIn('E1/33', pb)
+        self.assertIn('E1/34', pb)
+
+    def test_no_bare_number_keys(self):
+        result = _run_port_config([_make_zone('2x400g', 2, 400, '1-4')])
+        pb = result['portBreakouts']
+        for key in pb:
+            self.assertTrue(key.startswith('E1/'),
+                            f"portBreakouts key '{key}' must use E1/<port> format")
+
+
+class BreakoutModeCapitalisationTestCase(TestCase):
+    """Breakout mode values must use uppercase 'G' to match hhfab profile schema."""
+
+    def test_2x400g_is_uppercase_g(self):
+        result = _run_port_config([_make_zone('2x400g', 2, 400, '1-2')])
+        pb = result['portBreakouts']
+        self.assertEqual(pb.get('E1/1'), '2x400G')
+
+    def test_4x200g_is_uppercase_g(self):
+        result = _run_port_config([_make_zone('4x200g', 4, 200, '1-2')])
+        pb = result['portBreakouts']
+        self.assertEqual(pb.get('E1/1'), '4x200G')
+
+    def test_1x800g_native_is_uppercase_g(self):
+        result = _run_port_config([_make_zone('1x800g', 1, 800, '33-34')])
+        pb = result['portBreakouts']
+        self.assertEqual(pb.get('E1/33'), '1x800G')
+
+    def test_no_lowercase_g_in_breakout_values(self):
+        zones = [
+            _make_zone('2x400g', 2, 400, '1-4'),
+            _make_zone('1x800g', 1, 800, '33-36'),
+        ]
+        result = _run_port_config(zones)
+        for key, value in result['portBreakouts'].items():
+            self.assertFalse(value.endswith('g'),
+                             f"portBreakouts['{key}'] = '{value}' must use uppercase G")
+
+
+class PortSpeedsNotEmittedTestCase(TestCase):
+    """portSpeeds and portAutoNegs must be empty (hhfab does not use them)."""
+
+    def test_portSpeeds_empty_for_breakout_zone(self):
+        result = _run_port_config([_make_zone('2x400g', 2, 400, '1-8')])
+        self.assertEqual(result['portSpeeds'], {})
+
+    def test_portAutoNegs_empty_for_breakout_zone(self):
+        result = _run_port_config([_make_zone('4x200g', 4, 200, '1-8')])
+        self.assertEqual(result['portAutoNegs'], {})
+
+    def test_portSpeeds_empty_for_native_zone(self):
+        result = _run_port_config([_make_zone('1x800g', 1, 800, '33-64')])
+        self.assertEqual(result['portSpeeds'], {})
+
+    def test_portSpeeds_empty_for_mixed_zones(self):
+        zones = [
+            _make_zone('4x200g', 4, 200, '1-63:2'),
+            _make_zone('1x800g', 1, 800, '2-64:2'),
+        ]
+        result = _run_port_config(zones)
+        self.assertEqual(result['portSpeeds'], {})
+        self.assertEqual(result['portAutoNegs'], {})
+
+
+class OddEvenPortSpecTestCase(TestCase):
+    """Port spec parsing with stride (:2) produces correct E1/<port> keys."""
+
+    def test_odd_ports_1_to_63(self):
+        result = _run_port_config([_make_zone('4x200g', 4, 200, '1-63:2')])
+        pb = result['portBreakouts']
+        expected_ports = list(range(1, 64, 2))  # 1,3,5,...,63
+        for p in expected_ports:
+            self.assertIn(f'E1/{p}', pb, f"E1/{p} must be in portBreakouts")
+        # Even ports must NOT appear
+        for p in range(2, 64, 2):
+            self.assertNotIn(f'E1/{p}', pb, f"E1/{p} must not appear for odd-only spec")
+
+    def test_even_ports_2_to_64(self):
+        result = _run_port_config([_make_zone('1x800g', 1, 800, '2-64:2')])
+        pb = result['portBreakouts']
+        expected_ports = list(range(2, 65, 2))  # 2,4,6,...,64
+        for p in expected_ports:
+            self.assertIn(f'E1/{p}', pb, f"E1/{p} must be in portBreakouts")

--- a/netbox_hedgehog/tests/test_topology_planning/test_yaml_export_inventory_based.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_yaml_export_inventory_based.py
@@ -630,7 +630,12 @@ class YAMLExportBreakoutNamingTestCase(YAMLExportTestBase):
                          f"YAML should read from inventory, not regenerate names.")
 
     def test_switch_crd_includes_port_configuration(self):
-        """Switch CRD includes portBreakouts, portSpeeds, and portAutoNegs."""
+        """Switch CRD portBreakouts uses E1/<port> keys for all ports (DIET-226).
+
+        hhfab schema requires 'E1/<port>' keys in portBreakouts for all ports
+        (both multi-lane breakouts and native 1x). portSpeeds and portAutoNegs
+        are not emitted; hhfab derives speeds from portBreakouts.
+        """
         url = reverse('plugins:netbox_hedgehog:topologyplan_export', args=[self.plan.pk])
         response = self.client.get(url)
 
@@ -646,19 +651,26 @@ class YAMLExportBreakoutNamingTestCase(YAMLExportTestBase):
 
         spec = switch_docs[0].get('spec', {})
         port_breakouts = spec.get('portBreakouts', {})
-        port_speeds = spec.get('portSpeeds', {})
-        port_auto_negs = spec.get('portAutoNegs', {})
 
-        # Breakout ports should be represented in portBreakouts
-        self.assertEqual(port_breakouts.get('1'), '4x200g')
-        self.assertEqual(port_speeds.get('1/1'), '200g')
-        self.assertEqual(port_speeds.get('1/4'), '200g')
-        self.assertFalse(port_auto_negs.get('1/1'))
+        # Breakout ports use 'E1/<port>' key format with uppercase 'G' (DIET-226)
+        self.assertEqual(port_breakouts.get('E1/1'), '4x200G',
+                         "4x200G breakout port must use E1/<port> key with uppercase G")
 
-        # 1x breakouts are treated as native ports (no portBreakouts entry)
-        self.assertNotIn('49', port_breakouts)
-        self.assertEqual(port_speeds.get('49'), '800g')
-        self.assertFalse(port_auto_negs.get('49'))
+        # 1x native-speed ports also use 'E1/<port>' key in portBreakouts
+        self.assertEqual(port_breakouts.get('E1/49'), '1x800G',
+                         "1x native port must appear in portBreakouts with E1/<port> key and uppercase G")
+
+        # Bare-number keys must not be present
+        self.assertNotIn('1', port_breakouts,
+                         "portBreakouts must not use bare port numbers as keys")
+        self.assertNotIn('49', port_breakouts,
+                         "portBreakouts must not use bare port numbers as keys")
+
+        # portSpeeds and portAutoNegs are not emitted (hhfab does not use them)
+        self.assertNotIn('portSpeeds', spec,
+                         "portSpeeds must not be emitted; hhfab derives speeds from portBreakouts")
+        self.assertNotIn('portAutoNegs', spec,
+                         "portAutoNegs must not be emitted; hhfab derives auto-neg from portBreakouts")
 
     def test_yaml_export_does_not_mutate_plan(self):
         """


### PR DESCRIPTION
## Summary

Fixes #226 - Switch CRD `portBreakouts` entries were rejected by hhfab with
`port 34 not found in switch profile` because the generator emitted bare port
numbers as keys and lowercase `g` in breakout mode names.

**Two bugs fixed in `_generate_port_configuration()`:**
1. **Key format:** `'1': '2x400g'` → `'E1/1': '2x400G'` (hhfab requires `E1/<port>` prefix)
2. **Capitalisation:** `.lower()` removed so breakout mode preserves uppercase `G` (`2x400G`, `4x200G`, `1x800G`)
3. **`portSpeeds` / `portAutoNegs`:** no longer populated (hhfab derives all speeds from `portBreakouts`)
4. **1x native ports:** moved from `portSpeeds` into `portBreakouts` with `E1/<port>: 1x800G`

**Root cause traced to:** DS5000 switch profile defines breakouts as `"2x400G"` (uppercase G). hhfab profile matching is case-sensitive.

## Invariants

- **Unchanged:** Connection CRD port names come from `Interface.name` (already `E1/<port>/<lane>` — PortAllocatorV2 was already correct)
- **Unchanged:** PortAllocatorV2 lane numbering (sequential `/1`, `/2`,... — confirmed correct against DS5000 profile offsets `["0","4"]` mapping to subports 1, 2)
- **Unchanged:** generation semantics, device/cable counts
- **Changed:** Switch CRD `portBreakouts` key format and breakout mode capitalisation only

## hhfab error-to-green evidence (128GPU case, plan ID 81)

**BEFORE** (`sha256: da5e66...`, 254862 bytes, 724 documents):
```
18:43:38 ERR validating ... port 34 not found in switch profile
```

**AFTER** (`sha256: dd1d20...`, 224670 bytes, 724 documents):
```
18:47:19 INF Wiring hydrated successfully mode=if-not-present
18:47:23 INF Fabricator config and wiring are valid
```

Artifacts produced using the `export_wiring_yaml` command from #224:
```bash
docker compose exec netbox python manage.py export_wiring_yaml 81 --output /tmp/after-226-fixed.yaml
```

## Diff excerpt (Switch CRD `portBreakouts`)

**Before:**
```yaml
portBreakouts:
  '1': 2x400g
  '2': 2x400g
portSpeeds:
  1/1: 400g
  1/2: 400g
  2/1: 400g
  2/2: 400g
```

**After:**
```yaml
portBreakouts:
  E1/1: 2x400G
  E1/2: 2x400G
```

## Tests

**14 new unit tests** (`test_breakout_lane_mapping.py`) - all pass (0.089s):
- `BreakoutKeyFormatTestCase` (4): `E1/<port>` prefix for all breakout types
- `BreakoutModeCapitalisationTestCase` (4): uppercase `G` preserved for all modes
- `PortSpeedsNotEmittedTestCase` (4): `portSpeeds`/`portAutoNegs` always empty
- `OddEvenPortSpecTestCase` (2): stride port_spec (`:2`) produces correct keys

**1 updated integration test** in `test_yaml_export_inventory_based.py`:
- `test_switch_crd_includes_port_configuration` updated to assert correct format

## Exact commands run

```bash
# Unit tests
docker compose exec netbox python manage.py test \
  netbox_hedgehog.tests.test_topology_planning.test_breakout_lane_mapping \
  --keepdb --verbosity=2
# → 14/14 OK (0.089s)

# hhfab before/after
docker compose exec netbox python manage.py export_wiring_yaml 81 --output /tmp/before-226.yaml
# → sha256: da5e6666... (BEFORE fix)
docker compose exec netbox python manage.py export_wiring_yaml 81 --output /tmp/after-226-fixed.yaml
# → sha256: dd1d20... (AFTER fix)
# hhfab validate BEFORE: port 34 not found in switch profile
# hhfab validate AFTER:  Fabricator config and wiring are valid
```

## Residual risk

- The 128GPU `ux_case_128gpu_odd_ports.yaml` fixture has `be-rail-leaf` using `port_spec: 1-32` (sequential ports 1-32 including even). The DS5000 profile supports 2x400G on all ports E1/1-E1/64, so this validates correctly. Whether the topology intent should use odd-only ports is a separate design concern (not a validation issue).
- `portSpeeds` / `portAutoNegs` removal: tested against hhfab v0.43.1 which accepts their absence. If future hhfab versions require them, they can be re-added.

Closes #226