### PR TITLE
[DIET-235] Single-command 128GPU validation golden path pipeline

### DIFF
--- a/netbox_hedgehog/management/commands/validate_case_128gpu_pipeline.py
+++ b/netbox_hedgehog/management/commands/validate_case_128gpu_pipeline.py
@@ -1,0 +1,198 @@
+"""
+Single-command 128GPU validation golden path pipeline (DIET-235).
+
+Runs the full end-to-end golden path for the 128GPU regression case:
+  1. setup_case_128gpu_odd_ports --clean --generate
+  2. export_wiring_yaml <plan_id> --output <base>.yaml            (full artifact)
+  3. export_wiring_yaml <plan_id> --output <base> --split-by-fabric  (frontend + backend)
+  4. hhfab validate full artifact
+  5. hhfab validate frontend artifact
+  6. hhfab validate backend artifact
+
+Prints a structured summary block and exits non-zero on any failure.
+
+Usage:
+    docker compose exec netbox python manage.py validate_case_128gpu_pipeline
+    docker compose exec netbox python manage.py validate_case_128gpu_pipeline \\
+        --output-dir /tmp/128gpu-artifacts
+    docker compose exec netbox python manage.py validate_case_128gpu_pipeline \\
+        --skip-setup  # use existing generated plan (skip step 1)
+
+Exit codes:
+    0 - All steps passed
+    1 - Any step failed (setup, export, or hhfab validation)
+"""
+
+import hashlib
+import os
+import sys
+import tempfile
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand, CommandError
+
+from netbox_hedgehog.models.topology_planning import TopologyPlan
+from netbox_hedgehog.services import hhfab
+
+PLAN_NAME = "UX Case 128GPU Odd Ports"
+_FABRICS = ('frontend', 'backend')
+
+
+class Command(BaseCommand):
+    help = "Run the full 128GPU wiring export + hhfab validation pipeline"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--output-dir',
+            default=None,
+            metavar='DIR',
+            help='Directory for wiring artifacts. Defaults to a temporary directory.',
+        )
+        parser.add_argument(
+            '--skip-setup',
+            action='store_true',
+            default=False,
+            help='Skip setup_case_128gpu_odd_ports --clean --generate (use existing plan).',
+        )
+
+    def handle(self, *args, **options):
+        output_dir = options['output_dir']
+        skip_setup = options['skip_setup']
+
+        # --- Step 1: Setup ---
+        if not skip_setup:
+            self.stdout.write("[1/6] Setting up 128GPU case (--clean --generate)...")
+            try:
+                call_command(
+                    'setup_case_128gpu_odd_ports',
+                    clean=True,
+                    generate=True,
+                    stdout=self.stdout,
+                    stderr=self.stderr,
+                )
+            except (CommandError, Exception) as e:
+                raise CommandError(f"Setup failed: {e}")
+        else:
+            self.stdout.write("[1/6] Skipping setup (--skip-setup).")
+
+        # --- Resolve plan ---
+        try:
+            plan = TopologyPlan.objects.get(name=PLAN_NAME)
+        except TopologyPlan.DoesNotExist:
+            raise CommandError(
+                f"Plan '{PLAN_NAME}' not found. Run without --skip-setup to create it."
+            )
+
+        self.stdout.write(f"      plan_id: {plan.pk}  name: {plan.name}")
+
+        # --- Prepare output directory ---
+        _tmpdir = None
+        if output_dir is None:
+            _tmpdir = tempfile.mkdtemp(prefix=f'128gpu-pipeline-{plan.pk}-')
+            output_dir = _tmpdir
+        else:
+            os.makedirs(output_dir, exist_ok=True)
+
+        full_path = os.path.join(output_dir, '128gpu-full.yaml')
+        split_base = os.path.join(output_dir, '128gpu')
+        split_paths = {fab: f"{split_base}-{fab}.yaml" for fab in _FABRICS}
+
+        # --- Step 2: Export full artifact ---
+        self.stdout.write(f"[2/6] Exporting full artifact -> {full_path}")
+        try:
+            call_command(
+                'export_wiring_yaml',
+                str(plan.pk),
+                '--output', full_path,
+                stdout=self.stdout,
+                stderr=self.stderr,
+            )
+        except CommandError as e:
+            raise CommandError(f"Full export failed: {e}")
+
+        # --- Step 3: Export split artifacts ---
+        self.stdout.write(f"[3/6] Exporting split artifacts -> {split_base}-{{frontend,backend}}.yaml")
+        try:
+            call_command(
+                'export_wiring_yaml',
+                str(plan.pk),
+                '--output', split_base,
+                split_by_fabric=True,
+                stdout=self.stdout,
+                stderr=self.stderr,
+            )
+        except CommandError as e:
+            raise CommandError(f"Split export failed: {e}")
+
+        # --- Steps 4-6: hhfab validation ---
+        hhfab_available = hhfab.is_hhfab_available()
+        if not hhfab_available:
+            self.stdout.write(self.style.WARNING(
+                "[4-6/6] hhfab not found in PATH - validation skipped.\n"
+                "        Install hhfab to enable: curl -fsSL https://i.hhdev.io/hhfab | bash"
+            ))
+
+        validation_results = {}  # label -> (success, sha256, path)
+
+        artifacts = [('full', full_path)] + [(fab, split_paths[fab]) for fab in _FABRICS]
+        step = 4
+        for label, path in artifacts:
+            self.stdout.write(f"[{step}/6] hhfab validate [{label}] -> {path}")
+            step += 1
+
+            sha256 = _sha256_of_file(path)
+
+            if not hhfab_available:
+                validation_results[label] = (None, sha256, path)  # None = skipped
+                continue
+
+            with open(path, 'r', encoding='utf-8') as f:
+                content = f.read()
+            success, _, stderr = hhfab.validate_yaml(content)
+            if not success:
+                self.stdout.write(self.style.ERROR(f"      [FAIL] {label}: {stderr.strip()}"))
+            else:
+                self.stdout.write(f"      [PASS] {label}")
+            validation_results[label] = (success, sha256, path)
+
+        # --- Summary block ---
+        self._print_summary(plan, validation_results, hhfab_available)
+
+        # --- Overall result ---
+        failures = [k for k, (ok, _, _) in validation_results.items() if ok is False]
+        if failures:
+            raise CommandError(
+                f"Pipeline FAILED. hhfab validation failed for: {', '.join(failures)}"
+            )
+
+        self.stdout.write(self.style.SUCCESS("\n[PASS] Pipeline complete - all steps passed."))
+
+    def _print_summary(self, plan, results, hhfab_available):
+        self.stdout.write("\n" + "=" * 60)
+        self.stdout.write("128GPU Pipeline Summary")
+        self.stdout.write("=" * 60)
+        self.stdout.write(f"  plan_id : {plan.pk}")
+        self.stdout.write(f"  plan    : {plan.name}")
+        self.stdout.write("")
+        self.stdout.write("  Artifacts:")
+        for label, (ok, sha256, path) in results.items():
+            if ok is None:
+                status = "SKIPPED (hhfab unavailable)"
+            elif ok:
+                status = "PASS"
+            else:
+                status = "FAIL"
+            self.stdout.write(f"    [{label}]")
+            self.stdout.write(f"      path   : {path}")
+            self.stdout.write(f"      sha256 : {sha256}")
+            self.stdout.write(f"      hhfab  : {status}")
+        self.stdout.write("=" * 60)
+
+
+def _sha256_of_file(path):
+    """Return hex sha256 of file contents, or 'ERROR' if unreadable."""
+    try:
+        with open(path, 'rb') as f:
+            return hashlib.sha256(f.read()).hexdigest()
+    except OSError:
+        return 'ERROR'

--- a/netbox_hedgehog/tests/test_topology_planning/test_128gpu_pipeline_command.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_128gpu_pipeline_command.py
@@ -1,0 +1,521 @@
+"""
+Integration tests for validate_case_128gpu_pipeline management command (DIET-235).
+
+Three test classes:
+
+  PipelineHappyPathTestCase
+    - Full pipeline with a real (but minimal) generated plan using --skip-setup.
+    - Verifies summary block content: plan_id, paths, sha256, PASS markers.
+    - Does NOT run setup_case_128gpu_odd_ports (too slow for unit suite).
+    - hhfab gate tests are skipped if hhfab is not available.
+
+  PipelineHHFabUnavailableTestCase
+    - Patches hhfab.is_hhfab_available() to return False.
+    - Verifies the command reports SKIPPED (not FAIL) and exits cleanly.
+
+  PipelineExportFailureTestCase
+    - Patches export_wiring_yaml call_command to raise CommandError.
+    - Verifies the failure propagates immediately with an actionable message.
+
+## Invariants
+- Unchanged: generator, export, and validation logic.
+- Changed: new pipeline orchestration command only.
+
+## Running locally
+
+    cd /home/ubuntu/afewell-hh/netbox-docker
+
+    # Integration tests (fast, use existing plan)
+    docker compose exec netbox python manage.py test \\
+        netbox_hedgehog.tests.test_topology_planning.test_128gpu_pipeline_command \\
+        --keepdb --verbosity=2
+
+    # Full golden path (uses real 128GPU setup - slow, ~5 min)
+    docker compose exec netbox python manage.py validate_case_128gpu_pipeline
+
+    # Skip setup if 128GPU plan is already generated
+    docker compose exec netbox python manage.py validate_case_128gpu_pipeline --skip-setup
+
+    # Write artifacts to a specific directory
+    docker compose exec netbox python manage.py validate_case_128gpu_pipeline \\
+        --skip-setup --output-dir /tmp/my-artifacts
+"""
+
+import os
+import tempfile
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from dcim.models import DeviceRole, DeviceType, InterfaceTemplate, Manufacturer, Site
+
+from netbox_hedgehog.choices import (
+    AllocationStrategyChoices,
+    ConnectionDistributionChoices,
+    ConnectionTypeChoices,
+    FabricTypeChoices,
+    GenerationStatusChoices,
+    HedgehogRoleChoices,
+    PortZoneTypeChoices,
+    ServerClassCategoryChoices,
+)
+from netbox_hedgehog.models.topology_planning import (
+    BreakoutOption,
+    DeviceTypeExtension,
+    PlanServerClass,
+    PlanServerConnection,
+    PlanSwitchClass,
+    SwitchPortZone,
+    TopologyPlan,
+)
+from netbox_hedgehog.services import hhfab
+from netbox_hedgehog.services.device_generator import DeviceGenerator
+
+
+PLAN_NAME = "UX Case 128GPU Odd Ports"
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture: reuses the minimal _HHFabGateBase pattern - one fe-leaf,
+# one server, fully generated. Named differently to avoid DB conflicts.
+# ---------------------------------------------------------------------------
+class _PipelineBase(TestCase):
+    """
+    Minimal generated plan used as the 'existing plan' when --skip-setup is passed.
+
+    We inject the PLAN_NAME so the pipeline command can find it via get(name=PLAN_NAME),
+    then restore it after each test class.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        # We need the plan to be findable by the pipeline command's PLAN_NAME lookup.
+        # Create a plan with that exact name for the test run.
+        TopologyPlan.objects.filter(name=PLAN_NAME).delete()
+
+        manufacturer, _ = Manufacturer.objects.get_or_create(
+            name='Celestica-Pipeline',
+            defaults={'slug': 'celestica-pipeline'}
+        )
+        nvidia, _ = Manufacturer.objects.get_or_create(
+            name='NVIDIA-Pipeline',
+            defaults={'slug': 'nvidia-pipeline'}
+        )
+
+        server_type, _ = DeviceType.objects.get_or_create(
+            manufacturer=manufacturer,
+            model='GPU-Server-Pipeline',
+            defaults={'slug': 'gpu-server-pipeline'}
+        )
+        for tpl_name in ('p0', 'p1'):
+            InterfaceTemplate.objects.get_or_create(
+                device_type=server_type,
+                name=tpl_name,
+                defaults={'type': '200gbase-x-qsfp56'}
+            )
+
+        switch_type, _ = DeviceType.objects.get_or_create(
+            manufacturer=manufacturer,
+            model='DS5000-Pipeline',
+            defaults={'slug': 'ds5000-pipeline'}
+        )
+        device_ext, _ = DeviceTypeExtension.objects.update_or_create(
+            device_type=switch_type,
+            defaults={
+                'mclag_capable': False,
+                'hedgehog_roles': ['server-leaf'],
+                'native_speed': 800,
+                'supported_breakouts': ['1x800g', '2x400g', '4x200g'],
+                'uplink_ports': 0,
+                'hedgehog_profile_name': 'celestica-ds5000',
+            }
+        )
+
+        # Use canonical breakout IDs so hhfab accepts the emitted breakout names.
+        breakout_4x200, _ = BreakoutOption.objects.get_or_create(
+            breakout_id='4x200g',
+            defaults={'from_speed': 800, 'logical_ports': 4, 'logical_speed': 200, 'optic_type': 'QSFP-DD'}
+        )
+        breakout_1x800, _ = BreakoutOption.objects.get_or_create(
+            breakout_id='1x800g',
+            defaults={'from_speed': 800, 'logical_ports': 1, 'logical_speed': 800, 'optic_type': 'QSFP-DD'}
+        )
+
+        server_role, _ = DeviceRole.objects.get_or_create(
+            name='Server-Pipeline', defaults={'slug': 'server', 'color': 'aa1409'}
+        )
+        site, _ = Site.objects.get_or_create(
+            name='Pipeline-Site', defaults={'slug': 'pipeline-site'}
+        )
+
+        from dcim.models import ModuleType
+        nic_module_type, created = ModuleType.objects.get_or_create(
+            manufacturer=nvidia,
+            model='BlueField-3-Pipeline',
+        )
+        if created:
+            for n in ('m0', 'm1'):
+                InterfaceTemplate.objects.create(
+                    module_type=nic_module_type, name=n, type='other'
+                )
+
+        cls.plan = TopologyPlan.objects.create(
+            name=PLAN_NAME,
+            customer_name='Pipeline Test',
+        )
+
+        server_class = PlanServerClass.objects.create(
+            plan=cls.plan,
+            server_class_id='pl-fe-gpu',
+            server_device_type=server_type,
+            category=ServerClassCategoryChoices.GPU,
+            quantity=1,
+            gpus_per_server=8,
+        )
+        switch_class = PlanSwitchClass.objects.create(
+            plan=cls.plan,
+            switch_class_id='pl-fe-leaf',
+            fabric=FabricTypeChoices.FRONTEND,
+            hedgehog_role=HedgehogRoleChoices.SERVER_LEAF,
+            device_type_extension=device_ext,
+            uplink_ports_per_switch=0,
+            mclag_pair=False,
+            calculated_quantity=1,
+            override_quantity=1,
+        )
+        server_zone = SwitchPortZone.objects.create(
+            switch_class=switch_class,
+            zone_name='server',
+            zone_type=PortZoneTypeChoices.SERVER,
+            port_spec='1-48',
+            breakout_option=breakout_4x200,
+            allocation_strategy=AllocationStrategyChoices.SEQUENTIAL,
+            priority=100,
+        )
+        SwitchPortZone.objects.create(
+            switch_class=switch_class,
+            zone_name='uplink',
+            zone_type=PortZoneTypeChoices.UPLINK,
+            port_spec='49-50',
+            breakout_option=breakout_1x800,
+            allocation_strategy=AllocationStrategyChoices.SEQUENTIAL,
+            priority=200,
+        )
+        PlanServerConnection.objects.create(
+            server_class=server_class,
+            connection_id='frontend',
+            nic_module_type=nic_module_type,
+            port_index=0,
+            ports_per_connection=2,
+            hedgehog_conn_type=ConnectionTypeChoices.UNBUNDLED,
+            distribution=ConnectionDistributionChoices.SAME_SWITCH,
+            target_zone=server_zone,
+            speed=200,
+        )
+
+        generator = DeviceGenerator(plan=cls.plan, site=site)
+        generator.generate_all()
+
+
+# ---------------------------------------------------------------------------
+# Test class 1: Happy path (real exports, real hhfab if available)
+# ---------------------------------------------------------------------------
+class PipelineHappyPathTestCase(_PipelineBase):
+    """
+    Happy path tests for validate_case_128gpu_pipeline --skip-setup.
+
+    Uses the minimal generated plan from _PipelineBase as the 'existing plan'.
+    hhfab validation tests are skipped if hhfab is not available.
+    """
+
+    def _run_pipeline(self, extra_args=None):
+        """Helper: run pipeline with --skip-setup in a temp dir, return (stdout, tmpdir)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = StringIO()
+            args = ['validate_case_128gpu_pipeline', '--skip-setup', '--output-dir', tmpdir]
+            if extra_args:
+                args.extend(extra_args)
+            call_command(*args, stdout=out)
+            return out.getvalue(), tmpdir
+
+    def test_pipeline_exits_cleanly(self):
+        """Pipeline command completes without raising CommandError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = StringIO()
+            call_command(
+                'validate_case_128gpu_pipeline',
+                '--skip-setup',
+                '--output-dir', tmpdir,
+                stdout=out,
+            )
+
+    def test_pipeline_writes_full_artifact(self):
+        """Pipeline writes 128gpu-full.yaml to output dir."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            call_command(
+                'validate_case_128gpu_pipeline',
+                '--skip-setup', '--output-dir', tmpdir,
+                stdout=StringIO(),
+            )
+            full_path = os.path.join(tmpdir, '128gpu-full.yaml')
+            self.assertTrue(os.path.exists(full_path), "128gpu-full.yaml must be written")
+            self.assertGreater(os.path.getsize(full_path), 0)
+
+    def test_pipeline_writes_split_artifacts(self):
+        """Pipeline writes 128gpu-frontend.yaml and 128gpu-backend.yaml."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            call_command(
+                'validate_case_128gpu_pipeline',
+                '--skip-setup', '--output-dir', tmpdir,
+                stdout=StringIO(),
+            )
+            for fabric in ('frontend', 'backend'):
+                path = os.path.join(tmpdir, f'128gpu-{fabric}.yaml')
+                # frontend artifact expected; backend may be empty for a fe-only plan
+                # Both paths must exist (export_wiring_yaml always writes them)
+                self.assertTrue(
+                    os.path.exists(path),
+                    f"128gpu-{fabric}.yaml must be written by --split-by-fabric"
+                )
+
+    def test_pipeline_summary_includes_plan_id(self):
+        """Summary block includes the plan_id."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = StringIO()
+            call_command(
+                'validate_case_128gpu_pipeline',
+                '--skip-setup', '--output-dir', tmpdir,
+                stdout=out,
+            )
+        output = out.getvalue()
+        self.assertIn(str(self.plan.pk), output, "Summary must include plan_id")
+
+    def test_pipeline_summary_includes_sha256(self):
+        """Summary block includes sha256 for each artifact."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = StringIO()
+            call_command(
+                'validate_case_128gpu_pipeline',
+                '--skip-setup', '--output-dir', tmpdir,
+                stdout=out,
+            )
+        output = out.getvalue()
+        sha256_lines = [ln for ln in output.splitlines() if 'sha256' in ln]
+        self.assertGreaterEqual(
+            len(sha256_lines), 3,
+            "Summary must include sha256 for full + frontend + backend artifacts"
+        )
+
+    def test_pipeline_summary_includes_artifact_labels(self):
+        """Summary block includes [full], [frontend], [backend] labels."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = StringIO()
+            call_command(
+                'validate_case_128gpu_pipeline',
+                '--skip-setup', '--output-dir', tmpdir,
+                stdout=out,
+            )
+        output = out.getvalue()
+        for label in ('[full]', '[frontend]', '[backend]'):
+            self.assertIn(label, output, f"Summary must include {label} label")
+
+    @unittest.skipUnless(hhfab.is_hhfab_available(), "hhfab not installed")
+    def test_pipeline_hhfab_pass_in_summary(self):
+        """When hhfab is available, summary shows PASS for each artifact."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = StringIO()
+            call_command(
+                'validate_case_128gpu_pipeline',
+                '--skip-setup', '--output-dir', tmpdir,
+                stdout=out,
+            )
+        output = out.getvalue()
+        pass_lines = [ln for ln in output.splitlines() if 'hhfab  : PASS' in ln]
+        self.assertGreaterEqual(
+            len(pass_lines), 1,
+            "At least one artifact must show 'hhfab  : PASS' in summary"
+        )
+
+    @unittest.skipUnless(hhfab.is_hhfab_available(), "hhfab not installed")
+    def test_pipeline_overall_pass_message(self):
+        """When all validations pass, final PASS message is printed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = StringIO()
+            call_command(
+                'validate_case_128gpu_pipeline',
+                '--skip-setup', '--output-dir', tmpdir,
+                stdout=out,
+            )
+        self.assertIn('[PASS] Pipeline complete', out.getvalue())
+
+    def test_pipeline_plan_not_found_raises_error(self):
+        """--skip-setup with no existing plan raises CommandError."""
+        with patch(
+            'netbox_hedgehog.management.commands.validate_case_128gpu_pipeline.TopologyPlan.objects.get',
+            side_effect=TopologyPlan.DoesNotExist,
+        ):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with self.assertRaises(CommandError) as ctx:
+                    call_command(
+                        'validate_case_128gpu_pipeline',
+                        '--skip-setup', '--output-dir', tmpdir,
+                        stdout=StringIO(),
+                    )
+        self.assertIn("not found", str(ctx.exception).lower())
+
+
+# ---------------------------------------------------------------------------
+# Test class 2: hhfab unavailable path
+# ---------------------------------------------------------------------------
+class PipelineHHFabUnavailableTestCase(_PipelineBase):
+    """
+    Tests for when hhfab is not installed.
+
+    Patches hhfab.is_hhfab_available() to return False so the command
+    takes the 'skip validation' branch regardless of the local environment.
+    """
+
+    def test_hhfab_unavailable_command_completes(self):
+        """Pipeline completes without CommandError when hhfab is unavailable."""
+        with patch(
+            'netbox_hedgehog.management.commands.validate_case_128gpu_pipeline.hhfab.is_hhfab_available',
+            return_value=False,
+        ):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                out = StringIO()
+                # Should not raise
+                call_command(
+                    'validate_case_128gpu_pipeline',
+                    '--skip-setup', '--output-dir', tmpdir,
+                    stdout=out,
+                )
+
+    def test_hhfab_unavailable_shows_skip_message(self):
+        """When hhfab is unavailable, output mentions hhfab not found."""
+        with patch(
+            'netbox_hedgehog.management.commands.validate_case_128gpu_pipeline.hhfab.is_hhfab_available',
+            return_value=False,
+        ):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                out = StringIO()
+                call_command(
+                    'validate_case_128gpu_pipeline',
+                    '--skip-setup', '--output-dir', tmpdir,
+                    stdout=out,
+                )
+        output = out.getvalue()
+        self.assertIn('hhfab', output.lower())
+        self.assertIn('skip', output.lower())
+
+    def test_hhfab_unavailable_summary_shows_skipped(self):
+        """Summary shows SKIPPED (not FAIL) for each artifact when hhfab is unavailable."""
+        with patch(
+            'netbox_hedgehog.management.commands.validate_case_128gpu_pipeline.hhfab.is_hhfab_available',
+            return_value=False,
+        ):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                out = StringIO()
+                call_command(
+                    'validate_case_128gpu_pipeline',
+                    '--skip-setup', '--output-dir', tmpdir,
+                    stdout=out,
+                )
+        output = out.getvalue()
+        skipped_lines = [ln for ln in output.splitlines() if 'SKIPPED' in ln]
+        self.assertGreaterEqual(
+            len(skipped_lines), 3,
+            "Summary must show SKIPPED for each of the 3 artifacts"
+        )
+
+    def test_hhfab_unavailable_artifacts_still_written(self):
+        """Even when hhfab is unavailable, export artifacts are still written."""
+        with patch(
+            'netbox_hedgehog.management.commands.validate_case_128gpu_pipeline.hhfab.is_hhfab_available',
+            return_value=False,
+        ):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                call_command(
+                    'validate_case_128gpu_pipeline',
+                    '--skip-setup', '--output-dir', tmpdir,
+                    stdout=StringIO(),
+                )
+                self.assertTrue(os.path.exists(os.path.join(tmpdir, '128gpu-full.yaml')))
+
+
+# ---------------------------------------------------------------------------
+# Test class 3: Export failure propagation
+# ---------------------------------------------------------------------------
+class PipelineExportFailureTestCase(_PipelineBase):
+    """
+    Tests that export failures propagate immediately with actionable errors.
+
+    Patches call_command to raise CommandError on the export step, verifying
+    the pipeline command wraps and re-raises with context.
+    """
+
+    def test_full_export_failure_raises_command_error(self):
+        """CommandError from export_wiring_yaml (full) propagates as 'Full export failed'."""
+        original_call = __import__('django.core.management', fromlist=['call_command']).call_command
+
+        def _patched_call(cmd, *args, **kwargs):
+            if cmd == 'export_wiring_yaml' and not kwargs.get('split_by_fabric'):
+                raise CommandError("Simulated export disk failure")
+            return original_call(cmd, *args, **kwargs)
+
+        with patch(
+            'netbox_hedgehog.management.commands.validate_case_128gpu_pipeline.call_command',
+            side_effect=_patched_call,
+        ):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with self.assertRaises(CommandError) as ctx:
+                    call_command(
+                        'validate_case_128gpu_pipeline',
+                        '--skip-setup', '--output-dir', tmpdir,
+                        stdout=StringIO(),
+                    )
+        self.assertIn('Full export failed', str(ctx.exception))
+
+    def test_split_export_failure_raises_command_error(self):
+        """CommandError from export_wiring_yaml (split) propagates as 'Split export failed'."""
+        original_call = __import__('django.core.management', fromlist=['call_command']).call_command
+
+        def _patched_call(cmd, *args, **kwargs):
+            if cmd == 'export_wiring_yaml' and kwargs.get('split_by_fabric'):
+                raise CommandError("Simulated split export failure")
+            return original_call(cmd, *args, **kwargs)
+
+        with patch(
+            'netbox_hedgehog.management.commands.validate_case_128gpu_pipeline.call_command',
+            side_effect=_patched_call,
+        ):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with self.assertRaises(CommandError) as ctx:
+                    call_command(
+                        'validate_case_128gpu_pipeline',
+                        '--skip-setup', '--output-dir', tmpdir,
+                        stdout=StringIO(),
+                    )
+        self.assertIn('Split export failed', str(ctx.exception))
+
+    def test_hhfab_validation_failure_raises_command_error(self):
+        """hhfab returning success=False raises CommandError naming the failed artifact."""
+        with patch(
+            'netbox_hedgehog.management.commands.validate_case_128gpu_pipeline.hhfab.is_hhfab_available',
+            return_value=True,
+        ), patch(
+            'netbox_hedgehog.management.commands.validate_case_128gpu_pipeline.hhfab.validate_yaml',
+            return_value=(False, '', 'simulated hhfab error'),
+        ):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with self.assertRaises(CommandError) as ctx:
+                    call_command(
+                        'validate_case_128gpu_pipeline',
+                        '--skip-setup', '--output-dir', tmpdir,
+                        stdout=StringIO(),
+                    )
+        self.assertIn('Pipeline FAILED', str(ctx.exception))
+        self.assertIn('full', str(ctx.exception))  # first failed artifact named


### PR DESCRIPTION
Closes #235.

## Summary

Adds `validate_case_128gpu_pipeline` management command: one command to run the full 128GPU golden path — setup, full export, split export, and hhfab validation of all three artifacts — with a structured summary block.

## Usage

```bash
# Full golden path (~5 min: includes device generation)
docker compose exec netbox python manage.py validate_case_128gpu_pipeline

# Skip setup if 128GPU plan is already generated (fast, ~30s)
docker compose exec netbox python manage.py validate_case_128gpu_pipeline --skip-setup

# Write artifacts to a specific directory
docker compose exec netbox python manage.py validate_case_128gpu_pipeline \
    --skip-setup --output-dir /tmp/my-artifacts
```

## Pipeline Steps

1. `setup_case_128gpu_odd_ports --clean --generate` (skippable via `--skip-setup`)
2. `export_wiring_yaml <plan_id> --output <base>.yaml` (full artifact)
3. `export_wiring_yaml <plan_id> --output <base> --split-by-fabric` (frontend + backend)
4. `hhfab validate` full artifact
5. `hhfab validate` frontend artifact
6. `hhfab validate` backend artifact

## Summary Block (example output)

```
============================================================
128GPU Pipeline Summary
============================================================
  plan_id : 81
  plan    : UX Case 128GPU Odd Ports

  Artifacts:
    [full]
      path   : /tmp/128gpu-pipeline-81-.../128gpu-full.yaml
      sha256 : dd1d20db34d52d0335583fc6353026d737ccd6d65d4f15abc321a5581ae33164
      hhfab  : PASS
    [frontend]
      path   : /tmp/128gpu-pipeline-81-.../128gpu-frontend.yaml
      sha256 : 7779e40b059070f9592a89301e83438dfb51703a375d559e5c603ca0fe39cacb
      hhfab  : PASS
    [backend]
      path   : /tmp/128gpu-pipeline-81-.../128gpu-backend.yaml
      sha256 : 9dd68f0726486dde308d2b50fc651ad423ed6a4ea4d834d0f1041e1aecbe7ce6
      hhfab  : PASS
============================================================

[PASS] Pipeline complete - all steps passed.
```

When hhfab is unavailable, validation is marked `SKIPPED` (not `FAIL`) and artifacts are still exported and verified for completeness.

## Tests (16, all passing)

- **`PipelineHappyPathTestCase`** (9 tests): exits cleanly, all 3 artifacts written, summary includes plan_id / sha256 / artifact labels, hhfab PASS shown, overall PASS message (hhfab tests skip when hhfab unavailable)
- **`PipelineHHFabUnavailableTestCase`** (4 tests): patched `is_hhfab_available=False`; command completes, skip message shown, summary shows SKIPPED for all 3, artifacts still written
- **`PipelineExportFailureTestCase`** (3 tests): patched `call_command` to raise; full export / split export / hhfab failures each propagate as `CommandError` with actionable message

## Commands run

```bash
cd /home/ubuntu/afewell-hh/netbox-docker
docker compose exec netbox python manage.py test \
    netbox_hedgehog.tests.test_topology_planning.test_128gpu_pipeline_command \
    --keepdb --verbosity=2
# Ran 16 tests in 42.977s -- OK

# Manual smoke test (skip-setup used existing 128GPU plan)
docker compose exec netbox python manage.py validate_case_128gpu_pipeline --skip-setup
# [PASS] full, [PASS] frontend, [PASS] backend
```

## Invariant Block

- **Unchanged**: generator, export, and hhfab validation logic; no behavior changes to `export_wiring_yaml`, `validate_wiring_yaml`, or `setup_case_128gpu_odd_ports`.
- **Changed**: new `validate_case_128gpu_pipeline` command + `test_128gpu_pipeline_command.py` only.

## Residual Risk

- The `--skip-setup` path assumes a generated plan exists. Without it, the full setup runs (~5 min). CI usage should use `--skip-setup` after a prior seeding step.
- Known CI infra caveat (#231): Browser UX Tests may be red on main; this PR is validated locally and follows the temporary merge policy.