### PR TITLE
[DIET-239] Consolidate storage + enforce canonical zone naming in 128GPU YAML

### DIFF
--- a/netbox_hedgehog/test_cases/ux_case_128gpu_odd_ports.yaml
+++ b/netbox_hedgehog/test_cases/ux_case_128gpu_odd_ports.yaml
@@ -289,7 +289,7 @@ reference_data:
 plan:
   name: UX Case 128GPU Odd Ports
   status: draft
-  description: 128 GPU servers with FE redundancy, BE rails, storage split, and odd-port 4x200G breakouts
+  description: 128 GPU servers with FE redundancy, BE rails, consolidated storage, and odd-port 4x200G breakouts
 
 switch_classes:
   - switch_class_id: fe-gpu-leaf
@@ -298,13 +298,7 @@ switch_classes:
     device_type_extension: ds5000_ext
     uplink_ports_per_switch:
     mclag_pair: false
-  - switch_class_id: fe-storage-leaf-a
-    fabric: frontend
-    hedgehog_role: server-leaf
-    device_type_extension: ds5000_ext
-    uplink_ports_per_switch:
-    mclag_pair: false
-  - switch_class_id: fe-storage-leaf-b
+  - switch_class_id: fe-storage-leaf
     fabric: frontend
     hedgehog_role: server-leaf
     device_type_extension: ds5000_ext
@@ -337,70 +331,56 @@ switch_classes:
 
 switch_port_zones:
   - switch_class: fe-gpu-leaf
-    zone_name: server-downlinks
-    zone_type: server
-    port_spec: 1-63:2
-    breakout_option: b_4x200
-    allocation_strategy: sequential
-    priority: 100
-  - switch_class: fe-storage-leaf-a
-    zone_name: server-downlinks
-    zone_type: server
-    port_spec: 1-63:2
-    breakout_option: b_4x200
-    allocation_strategy: sequential
-    priority: 100
-  - switch_class: fe-storage-leaf-b
-    zone_name: server-downlinks
+    zone_name: fe-gpu-leaf-downlinks
     zone_type: server
     port_spec: 1-63:2
     breakout_option: b_4x200
     allocation_strategy: sequential
     priority: 100
   - switch_class: fe-gpu-leaf
-    zone_name: uplinks
+    zone_name: fe-gpu-leaf-uplinks
     zone_type: uplink
     port_spec: 2-64:2
     breakout_option: b_1x800
     allocation_strategy: sequential
     priority: 100
-  - switch_class: fe-storage-leaf-a
-    zone_name: uplinks
-    zone_type: uplink
-    port_spec: 2-64:2
-    breakout_option: b_1x800
+  - switch_class: fe-storage-leaf
+    zone_name: fe-storage-leaf-downlinks
+    zone_type: server
+    port_spec: 1-63:2
+    breakout_option: b_4x200
     allocation_strategy: sequential
     priority: 100
-  - switch_class: fe-storage-leaf-b
-    zone_name: uplinks
+  - switch_class: fe-storage-leaf
+    zone_name: fe-storage-leaf-uplinks
     zone_type: uplink
     port_spec: 2-64:2
     breakout_option: b_1x800
     allocation_strategy: sequential
     priority: 100
   - switch_class: fe-spine
-    zone_name: leaf-downlinks
+    zone_name: fe-spine-downlinks
     zone_type: fabric
     port_spec: 1-64
     breakout_option: b_1x800
     allocation_strategy: sequential
     priority: 100
   - switch_class: be-rail-leaf
-    zone_name: server-downlinks
+    zone_name: be-leaf-downlinks
     zone_type: server
-    port_spec: 1-63:2
+    port_spec: 1-33
     breakout_option: b_2x400
     allocation_strategy: sequential
     priority: 100
   - switch_class: be-rail-leaf
     zone_name: backend-uplinks
     zone_type: uplink
-    port_spec: 2-64:2
+    port_spec: 33-64
     breakout_option: b_1x800
     allocation_strategy: sequential
     priority: 100
   - switch_class: be-spine
-    zone_name: leaf-downlinks
+    zone_name: be-spine-downlinks
     zone_type: fabric
     port_spec: 1-64
     breakout_option: b_1x800
@@ -441,16 +421,10 @@ server_classes:
     quantity: 32
     gpus_per_server: 8
     server_device_type: gpu_server_fe_be
-  - server_class_id: storage-a
-    description: Storage appliances 1-9
+  - server_class_id: storage
+    description: Storage appliances (18 total)
     category: storage
-    quantity: 9
-    gpus_per_server: 0
-    server_device_type: storage_server_200g
-  - server_class_id: storage-b
-    description: Storage appliances 10-18
-    category: storage
-    quantity: 9
+    quantity: 18
     gpus_per_server: 0
     server_device_type: storage_server_200g
   - server_class_id: admin-node
@@ -493,7 +467,7 @@ server_connections:
     ports_per_connection: 2
     hedgehog_conn_type: unbundled
     distribution: alternating
-    target_zone: fe-gpu-leaf/server-downlinks
+    target_zone: fe-gpu-leaf/fe-gpu-leaf-downlinks
     speed: 200
     port_type: data
   - server_class: gpu-with-backend
@@ -504,7 +478,7 @@ server_connections:
     ports_per_connection: 2
     hedgehog_conn_type: unbundled
     distribution: alternating
-    target_zone: fe-gpu-leaf/server-downlinks
+    target_zone: fe-gpu-leaf/fe-gpu-leaf-downlinks
     speed: 200
     port_type: data
   - server_class: gpu-with-backend
@@ -515,7 +489,7 @@ server_connections:
     ports_per_connection: 1
     hedgehog_conn_type: unbundled
     distribution: rail-optimized
-    target_zone: be-rail-leaf/server-downlinks
+    target_zone: be-rail-leaf/be-leaf-downlinks
     speed: 400
     rail: 0
     port_type: data
@@ -527,7 +501,7 @@ server_connections:
     ports_per_connection: 1
     hedgehog_conn_type: unbundled
     distribution: rail-optimized
-    target_zone: be-rail-leaf/server-downlinks
+    target_zone: be-rail-leaf/be-leaf-downlinks
     speed: 400
     rail: 1
     port_type: data
@@ -539,7 +513,7 @@ server_connections:
     ports_per_connection: 1
     hedgehog_conn_type: unbundled
     distribution: rail-optimized
-    target_zone: be-rail-leaf/server-downlinks
+    target_zone: be-rail-leaf/be-leaf-downlinks
     speed: 400
     rail: 2
     port_type: data
@@ -551,7 +525,7 @@ server_connections:
     ports_per_connection: 1
     hedgehog_conn_type: unbundled
     distribution: rail-optimized
-    target_zone: be-rail-leaf/server-downlinks
+    target_zone: be-rail-leaf/be-leaf-downlinks
     speed: 400
     rail: 3
     port_type: data
@@ -563,7 +537,7 @@ server_connections:
     ports_per_connection: 1
     hedgehog_conn_type: unbundled
     distribution: rail-optimized
-    target_zone: be-rail-leaf/server-downlinks
+    target_zone: be-rail-leaf/be-leaf-downlinks
     speed: 400
     rail: 4
     port_type: data
@@ -575,7 +549,7 @@ server_connections:
     ports_per_connection: 1
     hedgehog_conn_type: unbundled
     distribution: rail-optimized
-    target_zone: be-rail-leaf/server-downlinks
+    target_zone: be-rail-leaf/be-leaf-downlinks
     speed: 400
     rail: 5
     port_type: data
@@ -587,7 +561,7 @@ server_connections:
     ports_per_connection: 1
     hedgehog_conn_type: unbundled
     distribution: rail-optimized
-    target_zone: be-rail-leaf/server-downlinks
+    target_zone: be-rail-leaf/be-leaf-downlinks
     speed: 400
     rail: 6
     port_type: data
@@ -599,11 +573,11 @@ server_connections:
     ports_per_connection: 1
     hedgehog_conn_type: unbundled
     distribution: rail-optimized
-    target_zone: be-rail-leaf/server-downlinks
+    target_zone: be-rail-leaf/be-leaf-downlinks
     speed: 400
     rail: 7
     port_type: data
-  - server_class: storage-a
+  - server_class: storage
     connection_id: fe-storage
     connection_name: storage-frontend
     nic_module_type: nic_bf3
@@ -611,18 +585,7 @@ server_connections:
     ports_per_connection: 2
     hedgehog_conn_type: bundled
     distribution: same-switch
-    target_zone: fe-storage-leaf-a/server-downlinks
-    speed: 200
-    port_type: data
-  - server_class: storage-b
-    connection_id: fe-storage
-    connection_name: storage-frontend
-    nic_module_type: nic_bf3
-    port_index: 0
-    ports_per_connection: 2
-    hedgehog_conn_type: bundled
-    distribution: same-switch
-    target_zone: fe-storage-leaf-b/server-downlinks
+    target_zone: fe-storage-leaf/fe-storage-leaf-downlinks
     speed: 200
     port_type: data
   - server_class: admin-node
@@ -683,6 +646,6 @@ server_connections:
 
 expected:
   counts:
-    server_classes: 9
-    switch_classes: 7
-    connections: 17
+    server_classes: 8
+    switch_classes: 6
+    connections: 16

--- a/netbox_hedgehog/tests/test_topology_planning/test_case_128gpu_command.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_case_128gpu_command.py
@@ -66,9 +66,9 @@ class Case128GpuCommandTestCase(TestCase):
             server_class__plan=self.plan
         ).count()
 
-        self.assertEqual(server_count, 9)
-        self.assertEqual(switch_count, 7)
-        self.assertEqual(connection_count, 17)
+        self.assertEqual(server_count, 8)
+        self.assertEqual(switch_count, 6)
+        self.assertEqual(connection_count, 16)
 
     def test_generate_preview_page_loads(self):
         self.client.force_login(self.superuser)
@@ -479,3 +479,146 @@ class FeBorderLeafTestCase(TestCase):
         # Despite having an uplink zone, the explicit 0 overrides zone-derived count
         count = get_uplink_port_count(border)
         self.assertEqual(count, 0, "Standalone leaf (uplink_ports_per_switch=0) must contribute 0 spine demand")
+
+
+class CanonicalStorageZoneRegressionTestCase(TestCase):
+    """
+    Regression guard: canonical 128GPU case must stay storage-consolidated with
+    correct zone names and port specs. Fails immediately on any re-split or revert.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        call_command("setup_case_128gpu_odd_ports", stdout=StringIO())
+        cls.plan = TopologyPlan.objects.get(name=PLAN_NAME)
+
+    # -------------------------------------------------------------------------
+    # Storage consolidation: no *-a/*-b split classes allowed
+    # -------------------------------------------------------------------------
+
+    def test_no_split_storage_switch_classes(self):
+        """fe-storage-leaf-a and fe-storage-leaf-b must not exist (storage is consolidated)."""
+        self.assertFalse(
+            PlanSwitchClass.objects.filter(plan=self.plan, switch_class_id='fe-storage-leaf-a').exists(),
+            "fe-storage-leaf-a must not exist; storage switch is consolidated to fe-storage-leaf",
+        )
+        self.assertFalse(
+            PlanSwitchClass.objects.filter(plan=self.plan, switch_class_id='fe-storage-leaf-b').exists(),
+            "fe-storage-leaf-b must not exist; storage switch is consolidated to fe-storage-leaf",
+        )
+
+    def test_no_split_storage_server_classes(self):
+        """storage-a and storage-b must not exist (storage is consolidated)."""
+        self.assertFalse(
+            PlanServerClass.objects.filter(plan=self.plan, server_class_id='storage-a').exists(),
+            "storage-a must not exist; storage is consolidated to a single 'storage' class",
+        )
+        self.assertFalse(
+            PlanServerClass.objects.filter(plan=self.plan, server_class_id='storage-b').exists(),
+            "storage-b must not exist; storage is consolidated to a single 'storage' class",
+        )
+
+    def test_consolidated_storage_switch_class_exists(self):
+        """Exactly one fe-storage-leaf switch class with correct fabric/role."""
+        sc = PlanSwitchClass.objects.filter(plan=self.plan, switch_class_id='fe-storage-leaf')
+        self.assertEqual(sc.count(), 1, "Exactly one fe-storage-leaf switch class must exist")
+        self.assertEqual(sc.first().fabric, 'frontend')
+        self.assertEqual(sc.first().hedgehog_role, 'server-leaf')
+
+    def test_consolidated_storage_server_class_quantity(self):
+        """Single storage server class with quantity=18."""
+        sc = PlanServerClass.objects.get(plan=self.plan, server_class_id='storage')
+        self.assertEqual(sc.quantity, 18, "Consolidated storage class must have quantity=18")
+
+    def test_exactly_one_storage_connection(self):
+        """Exactly one storage server connection targeting fe-storage-leaf."""
+        sc = PlanServerClass.objects.get(plan=self.plan, server_class_id='storage')
+        conns = PlanServerConnection.objects.filter(server_class=sc)
+        self.assertEqual(conns.count(), 1, "storage class must have exactly one connection")
+        storage_leaf = PlanSwitchClass.objects.get(plan=self.plan, switch_class_id='fe-storage-leaf')
+        self.assertEqual(
+            conns.first().target_zone.switch_class,
+            storage_leaf,
+            "storage connection must target fe-storage-leaf",
+        )
+
+    # -------------------------------------------------------------------------
+    # Zone naming: required names and port specs
+    # -------------------------------------------------------------------------
+
+    def _get_zone(self, switch_class_id, zone_name):
+        sc = PlanSwitchClass.objects.get(plan=self.plan, switch_class_id=switch_class_id)
+        return SwitchPortZone.objects.get(switch_class=sc, zone_name=zone_name)
+
+    def test_be_rail_leaf_uplinks_zone_port_spec(self):
+        """be-rail-leaf/backend-uplinks must have port_spec 33-64."""
+        zone = self._get_zone('be-rail-leaf', 'backend-uplinks')
+        self.assertEqual(zone.port_spec, '33-64')
+
+    def test_be_rail_leaf_downlinks_zone_name_and_port_spec(self):
+        """be-rail-leaf server zone must be named be-leaf-downlinks with port_spec 1-33."""
+        zone = self._get_zone('be-rail-leaf', 'be-leaf-downlinks')
+        self.assertEqual(zone.zone_type, 'server')
+        self.assertEqual(zone.port_spec, '1-33')
+        # old generic name must not exist
+        sc = PlanSwitchClass.objects.get(plan=self.plan, switch_class_id='be-rail-leaf')
+        self.assertFalse(
+            SwitchPortZone.objects.filter(switch_class=sc, zone_name='server-downlinks').exists(),
+            "Generic 'server-downlinks' zone must not exist on be-rail-leaf",
+        )
+
+    def test_be_spine_downlinks_zone_name(self):
+        """be-spine fabric zone must be named be-spine-downlinks."""
+        zone = self._get_zone('be-spine', 'be-spine-downlinks')
+        self.assertEqual(zone.zone_type, 'fabric')
+        sc = PlanSwitchClass.objects.get(plan=self.plan, switch_class_id='be-spine')
+        self.assertFalse(
+            SwitchPortZone.objects.filter(switch_class=sc, zone_name='leaf-downlinks').exists(),
+            "Generic 'leaf-downlinks' zone must not exist on be-spine",
+        )
+
+    def test_fe_gpu_leaf_zone_names(self):
+        """fe-gpu-leaf zones must use fe-gpu-leaf-downlinks and fe-gpu-leaf-uplinks."""
+        self._get_zone('fe-gpu-leaf', 'fe-gpu-leaf-downlinks')
+        self._get_zone('fe-gpu-leaf', 'fe-gpu-leaf-uplinks')
+        sc = PlanSwitchClass.objects.get(plan=self.plan, switch_class_id='fe-gpu-leaf')
+        self.assertFalse(
+            SwitchPortZone.objects.filter(switch_class=sc, zone_name='server-downlinks').exists(),
+            "Generic 'server-downlinks' must not exist on fe-gpu-leaf",
+        )
+        self.assertFalse(
+            SwitchPortZone.objects.filter(switch_class=sc, zone_name='uplinks').exists(),
+            "Generic 'uplinks' must not exist on fe-gpu-leaf",
+        )
+
+    def test_fe_spine_downlinks_zone_name(self):
+        """fe-spine fabric zone must be named fe-spine-downlinks."""
+        zone = self._get_zone('fe-spine', 'fe-spine-downlinks')
+        self.assertEqual(zone.zone_type, 'fabric')
+        sc = PlanSwitchClass.objects.get(plan=self.plan, switch_class_id='fe-spine')
+        self.assertFalse(
+            SwitchPortZone.objects.filter(switch_class=sc, zone_name='leaf-downlinks').exists(),
+            "Generic 'leaf-downlinks' zone must not exist on fe-spine",
+        )
+
+    def test_fe_storage_leaf_zone_names(self):
+        """fe-storage-leaf must have fe-storage-leaf-downlinks and fe-storage-leaf-uplinks."""
+        self._get_zone('fe-storage-leaf', 'fe-storage-leaf-downlinks')
+        self._get_zone('fe-storage-leaf', 'fe-storage-leaf-uplinks')
+
+    def test_canonical_counts_from_yaml(self):
+        """Plan counts must match expected.counts in canonical YAML (DIET-239 persistence rule)."""
+        from netbox_hedgehog.tests.test_topology_planning.case_128gpu_helpers import expected_128gpu_counts
+        expected = expected_128gpu_counts()
+        self.assertEqual(
+            PlanServerClass.objects.filter(plan=self.plan).count(),
+            expected['server_classes'],
+        )
+        self.assertEqual(
+            PlanSwitchClass.objects.filter(plan=self.plan).count(),
+            expected['switch_classes'],
+        )
+        self.assertEqual(
+            PlanServerConnection.objects.filter(server_class__plan=self.plan).count(),
+            expected['connections'],
+        )

--- a/netbox_hedgehog/tests/test_topology_planning/test_regression_uc_case_128.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_regression_uc_case_128.py
@@ -1,18 +1,18 @@
 """
-Regression test for UC Case 128 GPU Odd Ports (DIET-165 Phase 4)
-
-This test ensures backward compatibility after implementing the Phase 3 spec
-changes for NIC modeling + multi-homing (issue #164).
+Regression test for UC Case 128 GPU Odd Ports (canonical DIET case)
 
 The test validates that:
 1. The Case 128 GPU plan can still be created
-2. Device generation still produces the same counts (158 devices, 548 interfaces, 804 cables)
+2. Device generation produces the verified canonical counts:
+   165 devices, 1010 interfaces, 786 cables
+   (verified via setup_case_128gpu_odd_ports --clean --generate --report, DIET-239)
 3. YAML generation still produces valid Hedgehog configuration
 4. hhfab validation still passes (if hhfab is available)
 
-This is the 1 regression test specified in the Phase 3 spec addendum.
+Canonical topology: 96 gpu-fe-only + 32 gpu-with-backend + 18 storage + 7 border servers
+                    + 11 DS5000 switches + 1 DS3000 fe-border-leaf = 165 devices
 
-SLOW TEST: This test generates 158 devices + 548 interfaces + 804 cables.
+SLOW TEST: Generates 165 devices, 1010 interfaces, 786 cables.
 Execution time: 10-15 minutes.
 
 Run separately with: python manage.py test --tag=slow --keepdb
@@ -50,7 +50,7 @@ class UCCase128GPURegressionTestCase(TestCase):
 
     This test serves as a backward compatibility guarantee.
 
-    SLOW TEST: Generates 158 devices, 548 interfaces, 804 cables.
+    SLOW TEST: Generates 165 devices, 1010 interfaces, 786 cables.
     Execution time: 10-15 minutes.
 
     Run with: python manage.py test --tag=slow --keepdb
@@ -129,28 +129,31 @@ class UCCase128GPURegressionTestCase(TestCase):
         result = generator.generate_all()
 
         # Validate counts match expected baseline
-        # Breakdown: 153 servers (96 gpu-fe-only + 32 gpu-with-backend + 18 storage + 7 border)
-        #            + 13 switches (12 DS5000 + 1 DS3000 fe-border-leaf)
+        # Breakdown: 157 servers (96 gpu-fe-only + 32 gpu-with-backend + 18 storage + 7 border)
+        #            + 11 DS5000 switches + 1 DS3000 fe-border-leaf = 165 devices total
+        # Verified via: setup_case_128gpu_odd_ports --clean --generate --report
         self.assertEqual(
             result.device_count,
-            166,
-            f"Expected 166 devices, got {result.device_count}. "
+            165,
+            f"Expected 165 devices, got {result.device_count}. "
             "This indicates a regression in device generation logic."
         )
 
         # Interface count: switch downlinks + fabric uplinks/downlinks + border server interfaces
+        # Verified via: setup_case_128gpu_odd_ports --clean --generate --report
         self.assertEqual(
             result.interface_count,
-            1074,
-            f"Expected 1074 interfaces, got {result.interface_count}. "
+            1010,
+            f"Expected 1010 interfaces, got {result.interface_count}. "
             "This indicates a regression in interface generation logic."
         )
 
-        # Cable count: server-to-switch + fabric (leaf-spine) + MCLAG + border server cables
+        # Cable count: server-to-switch + fabric (leaf-spine) + border server cables
+        # Verified via: setup_case_128gpu_odd_ports --clean --generate --report
         self.assertEqual(
             result.cable_count,
-            818,
-            f"Expected 818 cables, got {result.cable_count}. "
+            786,
+            f"Expected 786 cables, got {result.cable_count}. "
             "This indicates a regression in cable generation logic."
         )
 


### PR DESCRIPTION
## Summary

Implements the fixed canonical 128GPU requirements isolated during #238 review.

**Storage consolidation:**
- Removed `fe-storage-leaf-a`/`fe-storage-leaf-b` (split switch classes)
- Removed `storage-a`/`storage-b` (split server classes, qty=9 each)
- Added single `fe-storage-leaf` (qty=1) + `storage` server class (qty=18, one connection to `fe-storage-leaf/fe-storage-leaf-downlinks`)

**Zone naming (all zones now class-prefixed, no generic reuse):**
| Old | New |
|---|---|
| `fe-gpu-leaf/server-downlinks` | `fe-gpu-leaf/fe-gpu-leaf-downlinks` |
| `fe-gpu-leaf/uplinks` | `fe-gpu-leaf/fe-gpu-leaf-uplinks` |
| `fe-spine/leaf-downlinks` | `fe-spine/fe-spine-downlinks` |
| `be-spine/leaf-downlinks` | `be-spine/be-spine-downlinks` |
| `be-rail-leaf/server-downlinks` (ports 1-63:2) | `be-rail-leaf/be-leaf-downlinks` (ports 1-33) |
| `be-rail-leaf/backend-uplinks` (ports 2-64:2) | `be-rail-leaf/backend-uplinks` (ports 33-64) |

**Expected counts updated:** server_classes=8, switch_classes=6, connections=16

## Validation

Commands run:
```
docker compose exec -T netbox python manage.py setup_case_128gpu_odd_ports --clean --generate --report
docker compose exec -T netbox python manage.py test netbox_hedgehog.tests.test_topology_planning.test_case_128gpu_command --keepdb
```

Generation output (verified canonical counts):
```
165 devices, 1010 interfaces, 786 cables
```

Test results: **31/31 pass**

## Regression tests added (CanonicalStorageZoneRegressionTestCase)

- `test_no_split_storage_switch_classes` - fails if fe-storage-leaf-a/b reappear
- `test_no_split_storage_server_classes` - fails if storage-a/b reappear
- `test_consolidated_storage_switch_class_exists` - asserts single fe-storage-leaf
- `test_consolidated_storage_server_class_quantity` - asserts qty=18
- `test_exactly_one_storage_connection` - asserts single connection to fe-storage-leaf
- `test_be_rail_leaf_uplinks_zone_port_spec` - asserts port_spec=33-64
- `test_be_rail_leaf_downlinks_zone_name_and_port_spec` - asserts be-leaf-downlinks + port_spec=1-33
- `test_be_spine_downlinks_zone_name` - asserts be-spine-downlinks
- `test_fe_gpu_leaf_zone_names` - asserts fe-gpu-leaf-downlinks + fe-gpu-leaf-uplinks
- `test_fe_spine_downlinks_zone_name` - asserts fe-spine-downlinks
- `test_fe_storage_leaf_zone_names` - asserts fe-storage-leaf-downlinks + fe-storage-leaf-uplinks
- `test_canonical_counts_from_yaml` - counts derive from YAML expected.counts (persistence rule)

## Invariants

**Unchanged:** device_generator.py, topology_calculations.py, all model/migration files, hhfab validation logic

**Changed:** `ux_case_128gpu_odd_ports.yaml`, `test_case_128gpu_command.py`, `test_regression_uc_case_128.py` (verified counts: 165 devices / 1010 interfaces / 786 cables)

Closes #239