### PR TITLE
[DIET-258] Fix port-zone overlap: shared fe-border-25g zone (interim fix)

### DIFF
--- a/netbox_hedgehog/test_cases/ux_case_128gpu_odd_ports.yaml
+++ b/netbox_hedgehog/test_cases/ux_case_128gpu_odd_ports.yaml
@@ -535,17 +535,17 @@ switch_port_zones:
     allocation_strategy: sequential
     priority: 100
   - switch_class: fe-border-leaf
-    zone_name: fe-border-25g-downlinks
+    zone_name: fe-border-100g-downlinks
     zone_type: server
-    port_spec: 1-4
-    breakout_option: b_4x25
+    port_spec: 1-13
+    breakout_option: b_1x100
     allocation_strategy: sequential
     priority: 100
   - switch_class: fe-border-leaf
-    zone_name: fe-border-100g-downlinks
+    zone_name: fe-border-25g-shared
     zone_type: server
-    port_spec: 5-16
-    breakout_option: b_1x100
+    port_spec: 14-16
+    breakout_option: b_4x25
     allocation_strategy: sequential
     priority: 100
   - switch_class: fe-border-leaf
@@ -555,13 +555,6 @@ switch_port_zones:
     breakout_option: b_1x100
     allocation_strategy: sequential
     priority: 200
-  - switch_class: fe-border-leaf
-    zone_name: fe-border-oob-downlinks
-    zone_type: oob
-    port_spec: 17-20
-    breakout_option: b_1x100
-    allocation_strategy: sequential
-    priority: 300
   - switch_class: oob-mgmt-leaf
     zone_name: oob-mgmt-downlinks
     zone_type: oob
@@ -576,7 +569,7 @@ switch_port_zones:
     breakout_option: b_1x25
     allocation_strategy: sequential
     priority: 100
-    peer_zone: fe-border-leaf/fe-border-oob-downlinks
+    peer_zone: fe-border-leaf/fe-border-25g-shared
 
 server_classes:
   - server_class_id: gpu-fe-only
@@ -766,7 +759,7 @@ server_connections:
     ports_per_connection: 2
     hedgehog_conn_type: unbundled
     distribution: alternating
-    target_zone: fe-border-leaf/fe-border-25g-downlinks
+    target_zone: fe-border-leaf/fe-border-25g-shared
     speed: 25
     port_type: data
   - server_class: host-lfm-ctrl

--- a/netbox_hedgehog/tests/test_topology_planning/test_128gpu_oob_integration.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_128gpu_oob_integration.py
@@ -114,24 +114,35 @@ class OobMgmtSwitchClassStructureTestCase(TestCase):
         )
 
     # -------------------------------------------------------------------------
-    # T5-A-5: fe-border-leaf has an oob-type zone for managed<->surrogate uplinks
-    # Expected failure: YAML fe-border-leaf has no oob zone.
+    # T5-A-5: fe-border-leaf has a zone that serves as peer_zone target for oob-mgmt uplinks.
+    # Approved design (#258 interim fix): a shared 25G breakout zone (fe-border-25g-shared,
+    # ports 14-16) is used for both admin-node downlinks and oob-mgmt surrogate uplinks.
+    # No dedicated OOB-type zone on fe-border-leaf is required.
     # -------------------------------------------------------------------------
 
     def test_fe_border_leaf_has_oob_zone(self):
-        """fe-border-leaf must have an OOB-type zone for oob-mgmt uplink ports."""
+        """fe-border-leaf must have the shared 25G zone that serves as oob-mgmt peer_zone target.
+
+        Approved design: fe-border-25g-shared (ports 14-16, 4x25G) is shared between
+        admin-node data connections and oob-mgmt surrogate uplinks. No separate OOB-type
+        zone on fe-border-leaf is needed — the peer_zone FK on oob-mgmt-uplinks provides
+        the explicit target reference.
+        """
         border = PlanSwitchClass.objects.filter(
             plan=self.plan, switch_class_id='fe-border-leaf'
         ).first()
         self.assertIsNotNone(border, "fe-border-leaf must exist")
-        oob_zone = SwitchPortZone.objects.filter(
+        shared_zone = SwitchPortZone.objects.filter(
             switch_class=border,
-            zone_type=PortZoneTypeChoices.OOB,
+            zone_name='fe-border-25g-shared',
         ).first()
         self.assertIsNotNone(
-            oob_zone,
-            "fe-border-leaf must have at least one OOB-type zone for managed<->surrogate uplinks",
+            shared_zone,
+            "fe-border-leaf must have fe-border-25g-shared zone (shared 4x25G, ports 14-16) "
+            "for admin-node downlinks and oob-mgmt surrogate uplinks",
         )
+        self.assertEqual(shared_zone.port_spec, '14-16',
+                         "Shared 25G zone must use ports 14-16 (non-overlapping with uplinks 17-32)")
 
     # -------------------------------------------------------------------------
     # T5-A-6: oob-mgmt-leaf has an oob-type downlink zone (for server IPMI connections)

--- a/netbox_hedgehog/tests/test_topology_planning/test_case_128gpu_command.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_case_128gpu_command.py
@@ -378,21 +378,28 @@ class FeBorderLeafTestCase(TestCase):
         )
 
     def test_fe_border_leaf_port_zones(self):
-        """fe-border-leaf must have 25G and 100G downlink zones with correct breakout options."""
+        """fe-border-leaf must have shared 25G and 100G downlink zones (non-overlapping layout).
+
+        Approved layout (DS3000): E1/1-13=100G downlinks, E1/14-16=shared 4x25G, E1/17-32=uplinks.
+        """
         border = PlanSwitchClass.objects.get(plan=self.plan, switch_class_id='fe-border-leaf')
         zones = {z.zone_name: z for z in SwitchPortZone.objects.filter(switch_class=border)}
 
-        self.assertIn('fe-border-25g-downlinks', zones, "25G downlink zone must exist")
+        self.assertIn('fe-border-25g-shared', zones, "Shared 25G zone must exist")
         self.assertIn('fe-border-100g-downlinks', zones, "100G downlink zone must exist")
+        self.assertNotIn('fe-border-oob-downlinks', zones,
+                         "Dedicated OOB zone must not exist (overlap removed)")
 
-        z25 = zones['fe-border-25g-downlinks']
+        z25 = zones['fe-border-25g-shared']
         self.assertEqual(z25.zone_type, 'server')
+        self.assertEqual(z25.port_spec, '14-16', "Shared 25G zone must use ports 14-16")
         self.assertIsNotNone(z25.breakout_option)
         self.assertEqual(z25.breakout_option.breakout_id, '4x25g',
-                         "25G zone must use 4x25G breakout for admin node connections")
+                         "Shared 25G zone must use 4x25G breakout")
 
         z100 = zones['fe-border-100g-downlinks']
         self.assertEqual(z100.zone_type, 'server')
+        self.assertEqual(z100.port_spec, '1-13', "100G downlink zone must use ports 1-13")
         self.assertIsNotNone(z100.breakout_option)
         self.assertEqual(z100.breakout_option.breakout_id, '1x100g',
                          "100G zone must use native 1x100G for controller/exo connections")
@@ -438,7 +445,7 @@ class FeBorderLeafTestCase(TestCase):
         self.assertEqual(conn.speed, 25, "admin-node connection must be 25G")
         self.assertEqual(
             conn.target_zone.zone_name,
-            'fe-border-25g-downlinks',
+            'fe-border-25g-shared',
             "admin-node must connect to 25G breakout zone",
         )
 


### PR DESCRIPTION
## Summary

Resolves the port-zone overlap flagged in PR #257 (DIET-254 Phase 5).

The `fe-border-oob-downlinks` zone (ports 17-20) overlapped with `fe-border-uplinks` (ports 17-32) on the DS3000 fe-border-leaf switch. This was an approved interim fix (#258).

**Approved layout (DS3000 fe-border-leaf):**
- E1/1–13: `fe-border-100g-downlinks` (was 5–16)
- E1/14–16: `fe-border-25g-shared` (new shared zone, 4x25G — admin-node downlinks + oob-mgmt uplinks)
- E1/17–32: `fe-border-uplinks` (unchanged)

## Files changed

- `netbox_hedgehog/test_cases/ux_case_128gpu_odd_ports.yaml` — zone layout restructure; `peer_zone` and admin-node `target_zone` updated to `fe-border-25g-shared`
- `netbox_hedgehog/tests/test_topology_planning/test_case_128gpu_command.py` — zone name + port_spec assertions updated; overlap absence asserted
- `netbox_hedgehog/tests/test_topology_planning/test_128gpu_oob_integration.py` — T5-A-5 updated: checks `fe-border-25g-shared` (port_spec 14-16) instead of a dedicated OOB zone

## Generation counts (unchanged)

- Devices: 171, Interfaces: 1243, Cables: 979

## Test plan

- [x] Fast suites (`test_export_fabric_scoped` + `test_managed_fabric_export`): 70/70 OK (78s)
- [x] Slow suites (`test_128gpu_oob_integration` + `test_case_128gpu_command`): 43/43 OK (2802s)

## Closes

- Resolves port-zone overlap concern from #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)