### PR TITLE
[DIET-265] GREEN: HHG class + FE spine zone YAML implementation

### DIFF
--- a/netbox_hedgehog/test_cases/ux_case_128gpu_odd_ports.yaml
+++ b/netbox_hedgehog/test_cases/ux_case_128gpu_odd_ports.yaml
@@ -536,7 +536,7 @@ switch_port_zones:
   - switch_class: fe-spine
     zone_name: fe-spine-downlinks
     zone_type: fabric
-    port_spec: 1-64
+    port_spec: 2-63
     breakout_option: b_1x800
     allocation_strategy: sequential
     priority: 100
@@ -1004,7 +1004,7 @@ contract:
       - switch_class: fe-spine
         zone_name: fe-spine-downlinks
         zone_type: fabric
-        port_spec: "1-64"
+        port_spec: "2-63"
       - switch_class: fe-spine
         zone_name: fe-spine-200G-downlinks
         zone_type: server

--- a/netbox_hedgehog/tests/test_topology_planning/test_128gpu_oob_integration.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_128gpu_oob_integration.py
@@ -458,17 +458,19 @@ class OobMgmtDeviceGenerationTestCase(TestCase):
 
     def test_device_count_includes_oob_mgmt(self):
         """
-        Total device count must be 173: 169 existing + 4 oob-mgmt-leaf instances (computed).
-        Base: 14 switches (be-rail×4, be-spine×2, fe-border×2, fe-gpu×2, fe-spine×2,
-              fe-storage×2) + 155 servers (153 original + 2 HHG) = 169.
+        Total device count must be 174: 170 managed switches + 4 oob-mgmt-leaf + 2 HHG.
+        Managed switches: be-rail×4, be-spine×2, fe-border×2, fe-gpu×2, fe-spine×3,
+        fe-storage×2 = 17. Plus 153 original servers + 2 HHG = 155. Plus 4 oob-mgmt = 174.
+        Note: fe-spine has 3 instances (not 2) because port_spec: 2-63 leaves 62 fabric
+        ports per spine and ceil(128 leaf uplinks / 62) = 3.
         """
         try:
             state = self.plan.generation_state
         except Exception:
             self.skipTest("No GenerationState found - generation may not have run")
         self.assertEqual(
-            state.device_count, 173,
-            f"Expected 173 devices (169 base + 4 oob-mgmt + 2 HHG), got {state.device_count}",
+            state.device_count, 174,
+            f"Expected 174 devices (17 managed + 4 oob-mgmt + 153 servers + 2 HHG), got {state.device_count}",
         )
 
 

--- a/netbox_hedgehog/tests/test_topology_planning/test_hhg_class.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_hhg_class.py
@@ -194,13 +194,10 @@ class HhgYamlDefinitionTestCase(TestCase):
     # T-HHG-9: fe-spine-downlinks port_spec changed from 1-64 to 2-63
     # -------------------------------------------------------------------------
 
-    def test_fe_spine_downlinks_port_spec_is_1_64(self):
-        """fe-spine-downlinks port_spec must remain 1-64.
-        Port 1 (200G server zone) and port 64 (100G server zone) are allocated by higher-priority
-        server zones using breakout sub-ports (E1/1/1, E1/1/2 etc.), which have distinct names
-        from the fabric zone's E1/1 interface. The port allocator tracks state per (switch, zone),
-        so zones don't conflict. The fabric zone must retain full 64-port capacity for 2-spine
-        topology (ceil(128 leaf uplinks / 64) = 2)."""
+    def test_fe_spine_downlinks_port_spec_is_2_63(self):
+        """fe-spine-downlinks port_spec must be 2-63.
+        Ports 1 and 64 are dedicated to server zones (200G and 100G respectively) and must not
+        be shared with the fabric zone to avoid dual allocation of the same physical port."""
         qs = SwitchPortZone.objects.filter(
             switch_class__plan=self.plan,
             zone_name='fe-spine-downlinks',
@@ -211,8 +208,8 @@ class HhgYamlDefinitionTestCase(TestCase):
         )
         zone = qs.first()
         self.assertEqual(
-            zone.port_spec, '1-64',
-            "fe-spine-downlinks port_spec must be 1-64 (full capacity required for 2-spine topology)",
+            zone.port_spec, '2-63',
+            "fe-spine-downlinks port_spec must be 2-63 (ports 1 and 64 reserved for server zones)",
         )
 
     # -------------------------------------------------------------------------
@@ -373,7 +370,13 @@ class HhgGenerationTestCase(TestCase):
     # -------------------------------------------------------------------------
 
     def test_hhg_alternating_distribution(self):
-        """Each fe-spine must have exactly 2 HHG primary connections (alternating distribution)."""
+        """HHG connections use alternating distribution across fe-spine instances.
+        With 2 HHG servers and 3 spine switches (ceil(128 leaf uplinks / 62 fabric ports) = 3),
+        alternating distributes by server_index % num_spines:
+        - hhg-001 (index 0) → spine-01: 2 connections
+        - hhg-002 (index 1) → spine-02: 2 connections
+        - spine-03: 0 HHG connections (no server at index 2)
+        Assertion: exactly 2 spines receive HHG connections, each with exactly 2."""
         hhg_ids = set(Device.objects.filter(
             custom_field_data__hedgehog_plan_id=str(self.plan.pk),
             role__slug='server',
@@ -386,6 +389,7 @@ class HhgGenerationTestCase(TestCase):
             custom_field_data__hedgehog_role='spine',
         ))
 
+        spine_hhg_counts = {}
         for spine in spine_devices:
             count = 0
             for cable in self.all_cables:
@@ -398,10 +402,19 @@ class HhgGenerationTestCase(TestCase):
                 if (a_dev_id == spine.id and b_dev_id in hhg_ids) or \
                    (b_dev_id == spine.id and a_dev_id in hhg_ids):
                     count += 1
+            spine_hhg_counts[spine.name] = count
+
+        spines_with_hhg = {name: count for name, count in spine_hhg_counts.items() if count > 0}
+        self.assertEqual(
+            len(spines_with_hhg), 2,
+            f"Exactly 2 fe-spines must receive HHG connections (alternating across 2 servers), "
+            f"got: {spine_hhg_counts}",
+        )
+        for name, count in spines_with_hhg.items():
             self.assertEqual(
                 count, 2,
-                f"Each fe-spine must have exactly 2 HHG primary connections (alternating distribution); "
-                f"{spine.name} has {count}",
+                f"Each HHG-connected fe-spine must have exactly 2 HHG connections; "
+                f"{name} has {count}",
             )
 
     # -------------------------------------------------------------------------
@@ -442,15 +455,20 @@ class HhgGenerationTestCase(TestCase):
     # T-HHG-18: total device count is 173
     # -------------------------------------------------------------------------
 
-    def test_device_count_is_173(self):
-        """Total device count must be 173 (171 base + 2 HHG)."""
+    def test_device_count_is_174(self):
+        """Total device count must be 174.
+        Base 171 + 2 HHG servers + 1 extra fe-spine.
+        The extra spine arises because port_spec: 2-63 gives 62 fabric ports per spine,
+        and ceil(128 leaf uplinks / 62) = 3 spines (vs 2 with full 64-port zone).
+        This is the architecturally correct result: ports 1 and 64 are dedicated to server
+        zones, leaving 62 ports for leaf fabric."""
         try:
             state = self.plan.generation_state
         except Exception:
             self.skipTest("No GenerationState found - generation may not have run")
         self.assertEqual(
-            state.device_count, 173,
-            f"Expected 173 devices (171 base + 2 HHG), got {state.device_count}",
+            state.device_count, 174,
+            f"Expected 174 devices (171 base + 2 HHG + 1 extra fe-spine), got {state.device_count}",
         )
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary (Option A -- re-aligned to approved port_spec: 2-63)

- Adds HHG server class (2 servers, 200G to fe-spine, IPMI to oob-mgmt) to the canonical 128GPU YAML case
- Adds fe-spine-200G-downlinks (port 1, b_4x200) and fe-spine-100G-downlinks (port 64, b_8x100) zones on fe-spine
- Sets port_spec: 2-63 on fe-spine-downlinks per approved Phase 2 spec (#263)
- Adds fe-spine redundancy_type=eslag (required for distribution: alternating validation)
- Adds hhg_server_dt device type, nic_cx7_dual_200g module type, b_8x100 breakout option
- All changes are YAML-only

## Architecture (Option A)

port_spec: 2-63 on fe-spine-downlinks gives 62 usable fabric ports per spine.
With 128 leaf uplinks: ceil(128 / 62) = 3 fe-spine instances required. This is the correct architectural outcome when ports 1 and 64 are reserved for dedicated server zones.

The 2 HHG servers distribute via alternating: fe-spine-01 and fe-spine-02 each get 2 HHG connections; fe-spine-03 gets 0 (only 4 total connections). Correct behavior.

GenerationState.interface_count tracks only switch-side interfaces. Delta from 1243: +4 spine HHG sub-interfaces + 2 oob-mgmt = 1249.

## Verified generation counts

docker compose exec -T netbox python manage.py setup_case_128gpu_odd_ports --clean --generate --report
-> 174 devices, 1249 interfaces, 985 cables.

- devices: 174 (167 base + 4 oob-mgmt-leaf + 2 HHG + 1 third fe-spine)
- interfaces: 1249 (+6 switch-side from baseline 1243)
- cables: 985 (+6 HHG: 4 spine + 2 oob-mgmt)

## HHG export behavior

Server CRDs: hhg-001, hhg-002
4 unbundled HHG Connection CRDs (spine-01 and spine-02 only):
  hhg-001/fe-spine-port0 -> fe-spine-01/E1/1/1
  hhg-001/fe-spine-port1 -> fe-spine-02/E1/1/1
  hhg-002/fe-spine-port0 -> fe-spine-01/E1/1/2
  hhg-002/fe-spine-port1 -> fe-spine-02/E1/1/2
HHG BMC->oob-mgmt: 0 Connection CRDs (server<->surrogate invariant preserved)
oob-mgmt: 4 Server CRDs preserved
fe-spine Switch CRDs: fe-spine-01, fe-spine-02, fe-spine-03 (all 3)

## Test results

Ran 43 tests in 2751s -- OK (43/43 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)