### PR TITLE
[DIET-326] Fix RA pipeline: preserve all per-fabric wiring artifacts

### DIFF
--- a/docs/RA_ASSET_PUBLISHING.md
+++ b/docs/RA_ASSET_PUBLISHING.md
@@ -8,7 +8,7 @@ being refined, generated outputs are copied into a `generated/` subtree.
 
 ## Destination Layout
 
-Example:
+Example (two-fabric plan with `backend` and `frontend` managed fabrics):
 
 ```text
 training-ra/compositions/OPG-128/clos-ro--.../
@@ -28,19 +28,35 @@ training-ra/compositions/OPG-128/clos-ro--.../
       inventory.json
       interface-connections.csv
     wiring/
-      full.yaml
-      backend.yaml
-      frontend.yaml
+      wiring-backend.yaml
+      wiring-frontend.yaml
     hhfab/
-      backend.validate.txt
+      hhfab_validate_backend.log
+      hhfab_validate_frontend.log
+      hhfab_validate.log        ← combined summary
       backend.drawio
-      frontend.validate.txt
       frontend.drawio
     logs/
       ingest.log
       generate.log
-      export.log
-      diagram.log
+      wiring_export.log
+```
+
+The exact fabric names in `wiring/` depend on the managed fabrics defined in the
+topology plan.  The pipeline preserves **all** per-fabric artifacts emitted by
+`export_wiring_yaml --split-by-fabric`.  No wiring artifact is deleted, even if
+hhfab validation for that fabric fails.  Validation failures are recorded in
+`hhfab/hhfab_validate_<fabric>.log` alongside the preserved artifact.
+
+For a single-fabric backend-only plan the layout would be:
+
+```text
+    wiring/
+      wiring-backend.yaml
+    hhfab/
+      hhfab_validate_backend.log
+      hhfab_validate.log
+      backend.drawio
 ```
 
 ## Publisher Script

--- a/scripts/run_ra_pipeline.sh
+++ b/scripts/run_ra_pipeline.sh
@@ -81,16 +81,17 @@ cd "$NETBOX_DIR" && docker compose cp "netbox:${CONTAINER_TMP}/netbox/." "$ARTIF
 if [[ "$FE_ONLY" == "false" ]]; then
   echo "[4/7] Exporting wiring YAMLs..."
   cd "$NETBOX_DIR" && docker compose exec -T netbox sh -c "mkdir -p ${CONTAINER_TMP}/wiring_tmp" 2>/dev/null || true
-  # FE wiring will fail (known mclag gap) — capture error, continue
+  # Export all per-fabric wiring artifacts.  Some fabrics (e.g. frontend with mclag gap) may fail;
+  # capture the error to the log and continue — the successful artifacts are preserved.
   RUN export_wiring_yaml "$PLAN_ID" --split-by-fabric --output "${CONTAINER_TMP}/wiring_tmp/wiring" >> "$ARTIFACT_DIR/logs/wiring_export.log" 2>&1 || true
-  # Move wiring files into wiring_tmp dir, then copy to host
-  cd "$NETBOX_DIR" && docker compose exec -T netbox sh -c "
-    ls ${CONTAINER_TMP}/wiring_tmp-*.yaml 2>/dev/null && mv ${CONTAINER_TMP}/wiring_tmp-*.yaml ${CONTAINER_TMP}/wiring_tmp/ 2>/dev/null || true
-  " 2>/dev/null || true
+  # Copy all wiring files to the host artifact dir.
+  # NOTE: --split-by-fabric writes <base>-<fabric>.yaml inside the base directory, so the
+  # container source for docker compose cp is the wiring_tmp/ directory itself.
   cd "$NETBOX_DIR" && docker compose cp "netbox:${CONTAINER_TMP}/wiring_tmp/." "$ARTIFACT_DIR/wiring/" 2>/dev/null || echo "  WARN: cp wiring failed"
-  # Keep only backend wiring files (FE export fails with known mclag gap)
-  find "$ARTIFACT_DIR/wiring/" -name "wiring-frontend*.yaml" -delete 2>/dev/null || true
-  WIRING_FILES=$(find "$ARTIFACT_DIR/wiring/" -name "*.yaml" 2>/dev/null | sort)
+  # All per-fabric artifacts are preserved — do NOT delete any wiring-<fabric>.yaml files here.
+  # If hhfab cannot validate a particular fabric artifact, that gap is recorded in the hhfab logs
+  # (see step 5) and documented in translation-notes; the artifact itself is kept.
+  WIRING_FILES=$(find "$ARTIFACT_DIR/wiring/" -name "wiring-*.yaml" 2>/dev/null | sort)
   echo "  Wiring files: $(echo "$WIRING_FILES" | wc -l | tr -d ' ')"
 else
   echo "[4/7] Skipping wiring export (FE-only variant — known mclag gap applies)"
@@ -114,9 +115,14 @@ elif [[ -n "$LIQUID_CLONE_OF" ]] && [[ -d "$LIQUID_CLONE_OF" ]]; then
     echo "(Per-fabric validate logs copied from air variant; topology identical.)" >> "$ARTIFACT_DIR/hhfab/hhfab_validate.log"
   fi
 else
-  WIRING_FILES_LIST=$(find "$ARTIFACT_DIR/wiring/" -name "wiring-backend*.yaml" -o -name "wiring-backend-plane*.yaml" 2>/dev/null | sort)
+  # Iterate over ALL per-fabric wiring artifacts discovered in the wiring/ dir.
+  # We do not filter by fabric name — backend, frontend, or any arbitrary managed-fabric name
+  # is treated identically here.  If hhfab cannot validate a specific fabric (e.g. frontend
+  # with the known mclag gap), the failure is captured in a per-fabric log file and the
+  # artifact is still kept.  See issue #326.
+  WIRING_FILES_LIST=$(find "$ARTIFACT_DIR/wiring/" -name "wiring-*.yaml" 2>/dev/null | sort)
   if [[ -z "$WIRING_FILES_LIST" ]]; then
-    echo "No backend wiring files found; skipping hhfab." > "$ARTIFACT_DIR/hhfab/hhfab_validate.log"
+    echo "No per-fabric wiring files found; skipping hhfab." > "$ARTIFACT_DIR/hhfab/hhfab_validate.log"
   else
     for WIRING_F in $WIRING_FILES_LIST; do
       FABRIC_NAME=$(basename "$WIRING_F" .yaml | sed 's/^wiring-//')
@@ -125,13 +131,20 @@ else
       mkdir -p "$HHFAB_WORK"
       cp "$WIRING_F" "${HHFAB_WORK}/wiring.yaml"
       pushd "$HHFAB_WORK" > /dev/null
+      VALIDATE_LOG="${ARTIFACT_DIR}/hhfab/hhfab_validate_${FABRIC_NAME}.log"
       hhfab init --dev --force > "${ARTIFACT_DIR}/hhfab/hhfab_init_${FABRIC_NAME}.log" 2>&1 || true
-      hhfab validate >> "${ARTIFACT_DIR}/hhfab/hhfab_validate.log" 2>&1 || true
+      if hhfab validate > "$VALIDATE_LOG" 2>&1; then
+        echo "  [hhfab] ${FABRIC_NAME}: validate OK"
+      else
+        echo "  [hhfab] ${FABRIC_NAME}: validate FAILED (see ${VALIDATE_LOG}; artifact preserved)"
+      fi
       hhfab diagram > "${ARTIFACT_DIR}/hhfab/hhfab_diagram_${FABRIC_NAME}.log" 2>&1 || true
       find . -name "*.drawio" -exec cp {} "${ARTIFACT_DIR}/hhfab/${FABRIC_NAME}.drawio" \; 2>/dev/null || true
       popd > /dev/null
       rm -rf "$HHFAB_WORK"
     done
+    # Write a combined validate summary for easy review
+    cat "${ARTIFACT_DIR}/hhfab/hhfab_validate_"*.log > "${ARTIFACT_DIR}/hhfab/hhfab_validate.log" 2>/dev/null || true
   fi
 fi
 
@@ -147,28 +160,31 @@ cat > "$ARTIFACT_DIR/inputs/translation-notes.md" << NOTES_EOF
 - Site slug: ${SITE_SLUG}
 - Device count: ${DEVICE_COUNT:-unknown}
 
-## Known Gaps
+## Wiring Artifacts
+All managed-fabric wiring artifacts produced by --split-by-fabric are preserved in
+wiring/. Each wiring-<fabric>.yaml file is independently consumable.
+See hhfab/ for per-fabric validation logs (hhfab_validate_<fabric>.log).
 
-### Frontend Wiring Export
-Frontend wiring YAML export fails with:
-  "Switch references group 'fe-mclag' but no PlanMCLAGDomain exists"
-This is a pre-existing DIET gap affecting all DS5000 L3MH variants.
-Backend wiring exported and validated successfully.
+If a fabric's wiring export or hhfab validation failed, the artifact is still
+preserved and the failure is recorded in the corresponding log file.
+Known gap: frontend (DS5000 L3MH variants) export may fail with a mclag gap —
+"Switch references group 'fe-mclag' but no PlanMCLAGDomain exists". This is
+tracked as a pre-existing DIET gap. The artifact is kept even if export partially
+failed; see wiring_export.log for the full error.
 
-$(if [[ "$FE_ONLY" == "true" ]]; then echo "### FE-Only Variant
+$(if [[ "$FE_ONLY" == "true" ]]; then echo "## FE-Only Variant
 This variant has no backend fabric by RA design. Only a frontend fabric is defined.
-Frontend wiring export also blocked by the mclag gap above.
-hhfab validation not applicable (no backend wiring available)."; fi)
+Wiring export and hhfab validation are skipped (FE-only; no backend wiring available).
+Frontend wiring export is also blocked by the known mclag gap above."; fi)
 
-$(if [[ -n "$LIQUID_CLONE_OF" ]]; then echo "### Liquid Cooling Variant
+$(if [[ -n "$LIQUID_CLONE_OF" ]]; then echo "## Liquid Cooling Variant
 This variant is topologically identical to the corresponding air-cooled variant.
 Cooling medium and rack density differ only (not modeled in DIET).
 Reference air-cooled variant for the same wiring topology."; fi)
 
-## SH Distribution Shim (if applicable)
-Single-homed backend variants use rail-optimized distribution (rails 0-7) as a
-structural shim. DIET has no per-server SH distribution; this approximates the
-intent. Document deviation in RA notes.
+## SH Distribution Note (if applicable)
+Single-homed scale-out variants use same-switch grouped-per-leaf distribution.
+Servers are allocated in contiguous blocks per leaf (first N/2 → leaf A, rest → leaf B).
 
 ## XOC Composition Note (if applicable)
 XOC variants are modeled as a single scaled DIET plan with the combined server

--- a/scripts/verify_ra_artifacts.sh
+++ b/scripts/verify_ra_artifacts.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# verify_ra_artifacts.sh — Artifact-collection regression checker for the RA pipeline
+#
+# Verifies that a completed RA pipeline artifact root:
+#   1. Contains at least one wiring-<fabric>.yaml file
+#   2. Does NOT contain backend-only files with legacy names (wiring-backend only)
+#      while also containing other per-fabric export output (i.e. no deletion of
+#      non-backend artifacts happened)
+#   3. Has a corresponding hhfab_validate_<fabric>.log for every wiring file
+#      (hhfab was attempted for every fabric, not just backend-named ones)
+#
+# This is a post-run contract check, not a substitute for a full pipeline run.
+# See also: issue #326 (RA pipeline drops per-fabric wiring artifacts)
+#
+# Usage:
+#   scripts/verify_ra_artifacts.sh --artifact-root <path>
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — one or more checks failed
+
+set -uo pipefail
+
+ARTIFACT_ROOT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --artifact-root) ARTIFACT_ROOT="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$ARTIFACT_ROOT" ]]; then
+  echo "Usage: $0 --artifact-root <path>" >&2
+  exit 1
+fi
+
+if [[ ! -d "$ARTIFACT_ROOT" ]]; then
+  echo "Artifact root does not exist: $ARTIFACT_ROOT" >&2
+  exit 1
+fi
+
+WIRING_DIR="${ARTIFACT_ROOT}/wiring"
+HHFAB_DIR="${ARTIFACT_ROOT}/hhfab"
+PASS=true
+
+echo "=== Verifying RA artifact root: $ARTIFACT_ROOT ==="
+
+# --- Check 1: wiring/ exists and is non-empty ---
+if [[ ! -d "$WIRING_DIR" ]]; then
+  echo "FAIL: wiring/ directory missing"
+  PASS=false
+else
+  WIRING_FILES=$(find "$WIRING_DIR" -name "wiring-*.yaml" 2>/dev/null | sort)
+  WIRING_COUNT=$(echo "$WIRING_FILES" | grep -c . || true)
+  if [[ "$WIRING_COUNT" -eq 0 ]]; then
+    echo "FAIL: no wiring-*.yaml files found under wiring/"
+    PASS=false
+  else
+    echo "OK:   wiring/ contains $WIRING_COUNT file(s):"
+    echo "$WIRING_FILES" | sed 's/^/        /'
+  fi
+fi
+
+# --- Check 2: no frontend artifact was silently deleted ---
+# If the export log mentions a frontend fabric and the wiring file is absent,
+# that is evidence of the old deletion behavior.
+if [[ -f "${ARTIFACT_ROOT}/logs/wiring_export.log" ]]; then
+  EXPORTED_FABRICS=$(grep -oE "wiring-[a-z0-9_-]+\.yaml" "${ARTIFACT_ROOT}/logs/wiring_export.log" \
+    | sed 's/wiring-//; s/\.yaml//' | sort -u)
+  for FAB in $EXPORTED_FABRICS; do
+    EXPECTED="${WIRING_DIR}/wiring-${FAB}.yaml"
+    if [[ ! -f "$EXPECTED" ]]; then
+      echo "FAIL: wiring-${FAB}.yaml was mentioned in export log but is absent from wiring/"
+      echo "      This suggests the artifact was deleted post-export (issue #326 regression)"
+      PASS=false
+    else
+      echo "OK:   wiring-${FAB}.yaml present (exported and preserved)"
+    fi
+  done
+fi
+
+# --- Check 3: hhfab validate log exists for every wiring file ---
+if [[ -d "$HHFAB_DIR" && "$WIRING_COUNT" -gt 0 ]]; then
+  for WIRING_F in $WIRING_FILES; do
+    FABRIC=$(basename "$WIRING_F" .yaml | sed 's/^wiring-//')
+    VALIDATE_LOG="${HHFAB_DIR}/hhfab_validate_${FABRIC}.log"
+    if [[ ! -f "$VALIDATE_LOG" ]]; then
+      echo "FAIL: no hhfab_validate_${FABRIC}.log — hhfab was not attempted for fabric '${FABRIC}'"
+      echo "      This suggests hhfab iteration still uses backend-only filename patterns (issue #326)"
+      PASS=false
+    else
+      echo "OK:   hhfab_validate_${FABRIC}.log present"
+    fi
+  done
+fi
+
+# --- Check 4: backend-only filter not in play ---
+# Heuristic: if >1 fabric appears in the wiring/ dir, hhfab logs for ALL fabrics must exist.
+# A pipeline that only ran hhfab for backend-named files would be missing non-backend logs.
+if [[ "$WIRING_COUNT" -gt 1 ]] && [[ -d "$HHFAB_DIR" ]]; then
+  HHFAB_LOG_COUNT=$(find "$HHFAB_DIR" -name "hhfab_validate_*.log" 2>/dev/null | grep -v hhfab_validate\.log | wc -l | tr -d ' ')
+  if [[ "$HHFAB_LOG_COUNT" -lt "$WIRING_COUNT" ]]; then
+    echo "FAIL: $WIRING_COUNT wiring files but only $HHFAB_LOG_COUNT hhfab validate logs"
+    echo "      hhfab was not attempted for all fabrics (backend-only filter may still be active)"
+    PASS=false
+  else
+    echo "OK:   hhfab validate attempted for all $WIRING_COUNT fabric(s)"
+  fi
+fi
+
+echo ""
+if [[ "$PASS" == "true" ]]; then
+  echo "=== All checks PASSED ==="
+  exit 0
+else
+  echo "=== One or more checks FAILED ==="
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes three bugs in `scripts/run_ra_pipeline.sh` that combined to drop non-backend wiring artifacts from the RA pipeline output, contradicting the per-managed-fabric split-export contract established in issues #287/#292.

- Removes `find ... -name "wiring-frontend*.yaml" -delete` — artifacts are never deleted
- Changes hhfab iteration from `wiring-backend*.yaml` filter to `wiring-*.yaml` (all discovered fabrics)
- Removes dead container-side `ls/mv wiring_tmp-*.yaml` block that looked at wrong path

Also updates `docs/RA_ASSET_PUBLISHING.md` to show `wiring-<fabric>.yaml` naming (not hardcoded `backend.yaml`/`frontend.yaml`), and adds `scripts/verify_ra_artifacts.sh` — a post-run contract checker that confirms all exported fabrics are preserved and hhfab was attempted for each.

## Test plan

- [ ] Run `scripts/verify_ra_artifacts.sh --artifact-root <path>` against a simulated old-pipeline layout → FAIL expected
- [ ] Run against a corrected layout (both wiring files + both hhfab logs present) → PASS expected
- [ ] Run a multi-managed-fabric plan through the full pipeline; confirm `wiring/` contains one file per managed fabric
- [ ] Confirm `hhfab/` contains `hhfab_validate_<fabric>.log` for every wiring file, including non-backend fabrics
- [ ] Confirm no wiring artifact is deleted even when hhfab validation fails for a fabric

## Residual gaps

- Frontend mclag gap: `wiring-frontend.yaml` export may still fail on DS5000 L3MH plans. The pipeline now preserves the partial artifact and records the failure in logs.
- Existing `training-ra` published assets are still backend-only and need a regeneration pass after this merges (follow-up noted in #326).

🤖 Generated with [Claude Code](https://claude.com/claude-code)