### PR TITLE
[DIET-328] Align publish_ra_assets.sh with current flat training-ra layout

### DIFF
--- a/docs/RA_ASSET_PUBLISHING.md
+++ b/docs/RA_ASSET_PUBLISHING.md
@@ -1,12 +1,12 @@
 # RA Asset Publishing
 
-Final RA assets should be published into the composition directory for each
-variant inside the `training-ra` or `inference-ra` repository.
-
-To avoid clobbering top-level placeholder files while the pipeline is still
-being refined, generated outputs are copied into a `generated/` subtree.
+Final RA assets are published into the composition directory for each variant
+inside the `training-ra` or `inference-ra` repository.
 
 ## Destination Layout
+
+Assets are published directly into the composition directory using a flat
+layout.  There is no `generated/` wrapper.
 
 Example (two-fabric plan with `backend` and `frontend` managed fabrics):
 
@@ -15,76 +15,88 @@ training-ra/compositions/OPG-128/clos-ro--.../
   README.md
   bom.yaml
   connectivity-map.csv
-  wiring.yaml
+  wiring.yaml          ← top-level placeholder (hand-authored)
   vpc.yaml
   diagrams/
-  generated/
-    inputs/
-      topology-plan.yaml
-      topology-plan.test-case.yaml
-      translation-notes.md
-      source-links.txt
-    netbox/
-      inventory.json
-      interface-connections.csv
-    wiring/
-      wiring-backend.yaml
-      wiring-frontend.yaml
+    README.md
     hhfab/
-      hhfab_validate_backend.log
-      hhfab_validate_frontend.log
-      hhfab_validate.log        ← combined summary
       backend.drawio
-      frontend.drawio
-    logs/
-      ingest.log
-      generate.log
-      wiring_export.log
+      hhfab_validate_backend.log     ← present only when validation failed
+      hhfab_validate_frontend.log    ← present (documents gap or success)
+  wiring/
+    wiring-backend.yaml
+    wiring-frontend.yaml             ← absent while MCLAG gap exists; see note
 ```
 
-The exact fabric names in `wiring/` depend on the managed fabrics defined in the
-topology plan.  The pipeline preserves **all** per-fabric artifacts emitted by
-`export_wiring_yaml --split-by-fabric`.  No wiring artifact is deleted, even if
-hhfab validation for that fabric fails.  Validation failures are recorded in
-`hhfab/hhfab_validate_<fabric>.log` alongside the preserved artifact.
+For a dual-plane backend plan the wiring/ and diagrams/hhfab/ directories
+would contain `backend-plane-a` and `backend-plane-b` entries instead.
 
-For a single-fabric backend-only plan the layout would be:
+For a single-backend, FE-only plan the wiring/ directory contains only
+`WIRING_GAP.txt` (no wiring YAML is exportable).
 
-```text
-    wiring/
-      wiring-backend.yaml
-    hhfab/
-      hhfab_validate_backend.log
-      hhfab_validate.log
-      backend.drawio
-```
+### What `publish_ra_assets.sh` copies
+
+| Artifact source              | Destination                          |
+|------------------------------|--------------------------------------|
+| `wiring/`                    | `<comp>/wiring/` (full dir replace)  |
+| `hhfab/*.drawio`             | `<comp>/diagrams/hhfab/`             |
+| `hhfab/hhfab_validate_*.log` | `<comp>/diagrams/hhfab/`             |
+
+Pipeline-internal artifacts (`inputs/`, `netbox/`, `logs/`) are **not**
+published to the composition directory.
+
+### Frontend wiring gap note
+
+All current training variants have both `backend` and `frontend` managed
+fabrics.  The `export_wiring_yaml --split-by-fabric` command attempts to
+export both fabrics but the frontend export fails with:
+
+> Switch references group 'fe-mclag' but no PlanMCLAGDomain exists
+
+As a result `wiring-frontend.yaml` is absent from `wiring/`.  This is a
+known pre-existing DIET gap (DS5000 L3MH MCLAG domain not modeled).  Each
+variant documents the situation in `diagrams/hhfab/hhfab_validate_frontend.log`.
 
 ## Publisher Script
-
-Use:
 
 ```bash
 cd /home/ubuntu/afewell-hh/hh-netbox-plugin
 scripts/publish_ra_assets.sh \
-  --artifact-root <local-artifact-root> \
+  --artifact-root <pipeline-artifact-root> \
   --composition-dir <ra-composition-dir>
 ```
 
-The script copies these sections when present:
-
-- `inputs/`
-- `netbox/`
-- `wiring/`
-- `hhfab/`
-- `logs/`
-
-Each destination section is replaced atomically at the directory level by
-removing the existing section and copying the source section fresh.
+The script is safe to run repeatedly — it replaces destination directories
+atomically so there are no stale files from prior runs.
 
 ## Recommended Flow
 
-1. Generate all local artifacts under the standard pipeline artifact root.
+1. Generate all local artifacts under the standard pipeline artifact root
+   (`/tmp/ra_pipeline/<case_id>/`).
 2. Review the generated files locally.
-3. Publish into the target RA composition directory with the script above.
-4. Review the `generated/` subtree in the RA repo.
+3. Publish into the target RA composition directory:
+   ```bash
+   scripts/publish_ra_assets.sh \
+     --artifact-root /tmp/ra_pipeline/<case_id> \
+     --composition-dir /path/to/training-ra/compositions/<variant>
+   ```
+4. Review the `wiring/` and `diagrams/hhfab/` changes in the RA repo.
 5. Commit/push from the RA repo once the bundle is accepted.
+
+The `run_ra_pipeline.sh` script calls `publish_ra_assets.sh` automatically
+as its final step; the `--composition-dir` argument controls the destination.
+
+## Verification
+
+After publishing, verify the artifact layout with:
+
+```bash
+# Check wiring files landed correctly
+ls <comp>/wiring/
+
+# Check hhfab diagrams and validation logs landed correctly
+ls <comp>/diagrams/hhfab/
+
+# Run the pipeline-level contract checker against the local artifact root
+scripts/verify_ra_artifacts.sh --artifact-root /tmp/ra_pipeline/<case_id>
+```

--- a/docs/RA_ASSET_PUBLISHING.md
+++ b/docs/RA_ASSET_PUBLISHING.md
@@ -21,8 +21,8 @@ training-ra/compositions/OPG-128/clos-ro--.../
     README.md
     hhfab/
       backend.drawio
-      hhfab_validate_backend.log     ← present only when validation failed
-      hhfab_validate_frontend.log    ← present (documents gap or success)
+      hhfab_validate_backend.log     ← present for every exported fabric
+      hhfab_validate_frontend.log    ← present for every exported fabric
   wiring/
     wiring-backend.yaml
     wiring-frontend.yaml             ← absent while MCLAG gap exists; see note
@@ -47,15 +47,15 @@ published to the composition directory.
 
 ### Frontend wiring gap note
 
-All current training variants have both `backend` and `frontend` managed
-fabrics.  The `export_wiring_yaml --split-by-fabric` command attempts to
-export both fabrics but the frontend export fails with:
+When a plan includes a `frontend` fabric, `export_wiring_yaml --split-by-fabric`
+attempts to export it, but the export fails for DS5000 L3MH topologies with:
 
 > Switch references group 'fe-mclag' but no PlanMCLAGDomain exists
 
-As a result `wiring-frontend.yaml` is absent from `wiring/`.  This is a
-known pre-existing DIET gap (DS5000 L3MH MCLAG domain not modeled).  Each
-variant documents the situation in `diagrams/hhfab/hhfab_validate_frontend.log`.
+As a result `wiring-frontend.yaml` is absent from `wiring/` for those variants.
+This is a known pre-existing DIET gap (DS5000 L3MH MCLAG domain not modeled).
+Each affected variant documents the situation in
+`diagrams/hhfab/hhfab_validate_frontend.log`.
 
 ## Publisher Script
 

--- a/scripts/publish_ra_assets.sh
+++ b/scripts/publish_ra_assets.sh
@@ -1,27 +1,28 @@
 #!/usr/bin/env bash
 #
-# publish_ra_assets.sh
+# publish_ra_assets.sh — publish RA pipeline artifacts into a training-ra/inference-ra
+# composition directory using the current flat asset layout.
 #
-# Copy a locally generated RA artifact bundle into the final per-variant
-# composition folder inside the training-ra or inference-ra repository.
-#
-# Expected source layout:
+# Source layout (pipeline artifact root):
 #   <artifact_root>/
-#     inputs/
-#     netbox/
-#     wiring/
-#     hhfab/
-#     logs/
+#     wiring/wiring-*.yaml          (per-fabric wiring; may include WIRING_GAP.txt)
+#     hhfab/<fabric>.drawio         (hhfab diagrams)
+#     hhfab/hhfab_validate_<f>.log  (per-fabric hhfab validation results)
+#     inputs/  netbox/  logs/       (pipeline-local; NOT published)
 #
-# Destination layout:
-#   <composition_dir>/generated/
-#     inputs/
-#     netbox/
-#     wiring/
-#     hhfab/
-#     logs/
+# Destination layout (flat, matches current training-ra structure):
+#   <composition_dir>/
+#     wiring/wiring-*.yaml
+#     diagrams/hhfab/<fabric>.drawio
+#     diagrams/hhfab/hhfab_validate_<fabric>.log
 #
-# The destination is replaced directory-by-directory for deterministic updates.
+# Each destination section is replaced atomically at the directory level so
+# repeated runs are deterministic and leave no stale files behind.
+#
+# Usage:
+#   scripts/publish_ra_assets.sh \
+#     --artifact-root <path> \
+#     --composition-dir <path>
 
 set -euo pipefail
 
@@ -34,7 +35,7 @@ Usage:
 
 Example:
   scripts/publish_ra_assets.sh \
-    --artifact-root /tmp/ra-artifacts/training/OPG-128/clos-ro--example \
+    --artifact-root /tmp/ra_pipeline/training_opg128_clos_ro_air_2srv \
     --composition-dir /home/ubuntu/afewell-hh/training-ra/compositions/OPG-128/clos-ro--example
 EOF
 }
@@ -79,30 +80,40 @@ if [[ ! -d "$COMPOSITION_DIR" ]]; then
   exit 1
 fi
 
-DEST_ROOT="${COMPOSITION_DIR}/generated"
-mkdir -p "$DEST_ROOT"
+WIRING_SRC="${ARTIFACT_ROOT}/wiring"
+HHFAB_SRC="${ARTIFACT_ROOT}/hhfab"
+PUBLISHED=0
 
-copy_section() {
-  local section="$1"
-  local src="${ARTIFACT_ROOT}/${section}"
-  local dst="${DEST_ROOT}/${section}"
+# --- wiring/ → <comp>/wiring/ ---
+# Atomic directory replace: removes stale files from prior runs.
+if [[ -d "$WIRING_SRC" ]]; then
+  WIRING_DEST="${COMPOSITION_DIR}/wiring"
+  rm -rf "$WIRING_DEST"
+  mkdir -p "$WIRING_DEST"
+  cp -a "${WIRING_SRC}/." "${WIRING_DEST}/"
+  echo "  wiring/         →  ${WIRING_DEST}"
+  PUBLISHED=$((PUBLISHED + 1))
+fi
 
-  if [[ ! -d "$src" ]]; then
-    return 0
-  fi
+# --- hhfab/ → <comp>/diagrams/hhfab/ ---
+# Only publishes: *.drawio diagrams and hhfab_validate_*.log files.
+# Pipeline-internal logs (hhfab_init_*.log, hhfab_diagram_*.log, hhfab_validate.log)
+# are not included in the published composition.
+if [[ -d "$HHFAB_SRC" ]]; then
+  HHFAB_DEST="${COMPOSITION_DIR}/diagrams/hhfab"
+  rm -rf "$HHFAB_DEST"
+  mkdir -p "$HHFAB_DEST"
+  find "$HHFAB_SRC" -maxdepth 1 \( -name "*.drawio" -o -name "hhfab_validate_*.log" \) \
+    -exec cp {} "${HHFAB_DEST}/" \;
+  echo "  hhfab/          →  ${HHFAB_DEST}"
+  PUBLISHED=$((PUBLISHED + 1))
+fi
 
-  rm -rf "$dst"
-  mkdir -p "$dst"
-  cp -a "${src}/." "$dst/"
-}
+if [[ "$PUBLISHED" -eq 0 ]]; then
+  echo "WARNING: nothing published — wiring/ and hhfab/ both absent from $ARTIFACT_ROOT" >&2
+  exit 1
+fi
 
-copy_section "inputs"
-copy_section "netbox"
-copy_section "wiring"
-copy_section "hhfab"
-copy_section "logs"
-
-echo "Published generated assets:"
+echo "Published RA assets:"
 echo "  source:      $ARTIFACT_ROOT"
-echo "  destination: $DEST_ROOT"
-
+echo "  destination: $COMPOSITION_DIR"


### PR DESCRIPTION
## Summary

Fixes the RA publisher script so it matches the current `training-ra` flat composition layout, making the official publish path usable end-to-end without ad-hoc copy workarounds.

**Root cause:** `publish_ra_assets.sh` wrote all assets under `<comp>/generated/`, but `training-ra` was reorganized (as part of the PR #7 asset refresh) to a flat layout with no `generated/` wrapper.

## Changes

### `scripts/publish_ra_assets.sh`

New source → destination mapping:

| Artifact source | Destination |
|---|---|
| `wiring/` | `<comp>/wiring/` (full dir replace) |
| `hhfab/*.drawio` | `<comp>/diagrams/hhfab/` |
| `hhfab/hhfab_validate_*.log` | `<comp>/diagrams/hhfab/` |

Pipeline-internal dirs (`inputs/`, `netbox/`, `logs/`) are not published.
Internal hhfab logs (`hhfab_init_*.log`, `hhfab_diagram_*.log`, `hhfab_validate.log`) are not published.
Each destination section is atomically replaced so repeated runs leave no stale files.

### `docs/RA_ASSET_PUBLISHING.md`

- Rewritten to show the flat destination layout (no `generated/`)
- Source → destination mapping table
- Frontend MCLAG gap note
- Verification commands section

## Approach

Single-layout update. The `generated/` convention was a WIP safeguard while the pipeline was being defined; it has been fully superseded. No multi-layout mode is needed.

## Verification commands

```bash
# Unit verification: single-backend variant
TEST_COMP=$(mktemp -d) && mkdir -p "$TEST_COMP"
scripts/publish_ra_assets.sh \
  --artifact-root /tmp/ra_pipeline/training_opg128_clos_ro_air_2srv \
  --composition-dir "$TEST_COMP"
ls "$TEST_COMP/wiring/"          # → wiring-backend.yaml
ls "$TEST_COMP/diagrams/hhfab/"  # → backend.drawio, hhfab_validate_backend.log
rm -rf "$TEST_COMP"

# Dual-plane variant
TEST_COMP=$(mktemp -d) && mkdir -p "$TEST_COMP"
scripts/publish_ra_assets.sh \
  --artifact-root /tmp/ra_pipeline/training_opg256_dual_plane_air_2srv \
  --composition-dir "$TEST_COMP"
ls "$TEST_COMP/wiring/"          # → wiring-backend-plane-a.yaml, wiring-backend-plane-b.yaml
ls "$TEST_COMP/diagrams/hhfab/"  # → backend-plane-a.drawio, backend-plane-b.drawio, validate logs
rm -rf "$TEST_COMP"

# End-to-end through run_ra_pipeline.sh
TEST_COMP=$(mktemp -d) && mkdir -p "$TEST_COMP"
scripts/run_ra_pipeline.sh \
  --case training_opg64_clos_ro_air_2srv \
  --site opg64-e2e-test \
  --composition-dir "$TEST_COMP"
find "$TEST_COMP" | sort  # → wiring/ and diagrams/hhfab/ only; no generated/
rm -rf "$TEST_COMP"
```

## Residual risks

- `OPG-64` composition still has a `generated/` subtree from the old layout (not cleaned up in this PR — separate structural cleanup).
- Liquid clone variants produce no `hhfab_validate_*.log` files (hhfab validation is skipped); `diagrams/hhfab/` will only contain the copied drawio. This is correct behavior and handled gracefully.
- `hhfab_validate_backend.log` is now published for every variant (previously omitted from training-ra). For variants where backend hhfab passes cleanly, this adds a small log file. Acceptable — it makes the validation audit trail complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)