### PR TITLE
[DIET-330] Fix frontend wiring export: SwitchGroup CRD no longer requires PlanMCLAGDomain

### DIFF
--- a/docs/RA_ASSET_PUBLISHING.md
+++ b/docs/RA_ASSET_PUBLISHING.md
@@ -1,12 +1,12 @@
 # RA Asset Publishing
 
-Final RA assets should be published into the composition directory for each
-variant inside the `training-ra` or `inference-ra` repository.
-
-To avoid clobbering top-level placeholder files while the pipeline is still
-being refined, generated outputs are copied into a `generated/` subtree.
+Final RA assets are published into the composition directory for each variant
+inside the `training-ra` or `inference-ra` repository.
 
 ## Destination Layout
+
+Assets are published directly into the composition directory using a flat
+layout.  There is no `generated/` wrapper.
 
 Example (two-fabric plan with `backend` and `frontend` managed fabrics):
 
@@ -15,76 +15,88 @@ training-ra/compositions/OPG-128/clos-ro--.../
   README.md
   bom.yaml
   connectivity-map.csv
-  wiring.yaml
+  wiring.yaml          ← top-level placeholder (hand-authored)
   vpc.yaml
   diagrams/
-  generated/
-    inputs/
-      topology-plan.yaml
-      topology-plan.test-case.yaml
-      translation-notes.md
-      source-links.txt
-    netbox/
-      inventory.json
-      interface-connections.csv
-    wiring/
-      wiring-backend.yaml
-      wiring-frontend.yaml
+    README.md
     hhfab/
-      hhfab_validate_backend.log
-      hhfab_validate_frontend.log
-      hhfab_validate.log        ← combined summary
       backend.drawio
       frontend.drawio
-    logs/
-      ingest.log
-      generate.log
-      wiring_export.log
+      hhfab_validate_backend.log     ← present for every exported fabric
+      hhfab_validate_frontend.log    ← present for every exported fabric
+  wiring/
+    wiring-backend.yaml
+    wiring-frontend.yaml
 ```
 
-The exact fabric names in `wiring/` depend on the managed fabrics defined in the
-topology plan.  The pipeline preserves **all** per-fabric artifacts emitted by
-`export_wiring_yaml --split-by-fabric`.  No wiring artifact is deleted, even if
-hhfab validation for that fabric fails.  Validation failures are recorded in
-`hhfab/hhfab_validate_<fabric>.log` alongside the preserved artifact.
+For a dual-plane backend plan the wiring/ and diagrams/hhfab/ directories
+would contain `backend-plane-a` and `backend-plane-b` entries instead.
 
-For a single-fabric backend-only plan the layout would be:
+For a single-backend, FE-only plan the wiring/ directory contains only
+`WIRING_GAP.txt` (no wiring YAML is exportable).
 
-```text
-    wiring/
-      wiring-backend.yaml
-    hhfab/
-      hhfab_validate_backend.log
-      hhfab_validate.log
-      backend.drawio
-```
+### What `publish_ra_assets.sh` copies
+
+| Artifact source              | Destination                          |
+|------------------------------|--------------------------------------|
+| `wiring/`                    | `<comp>/wiring/` (full dir replace)  |
+| `hhfab/*.drawio`             | `<comp>/diagrams/hhfab/`             |
+| `hhfab/hhfab_validate_*.log` | `<comp>/diagrams/hhfab/`             |
+
+Pipeline-internal artifacts (`inputs/`, `netbox/`, `logs/`) are **not**
+published to the composition directory.
+
+### Frontend wiring note
+
+When a plan includes a `frontend` fabric, `export_wiring_yaml --split-by-fabric`
+attempts to export it.  Prior to Issue #330 the frontend export failed for
+DS5000 L3MH topologies with:
+
+> Switch references group 'fe-mclag' but no PlanMCLAGDomain exists
+
+This is now fixed.  Each variant documents the export outcome in
+`diagrams/hhfab/hhfab_validate_frontend.log`.
 
 ## Publisher Script
-
-Use:
 
 ```bash
 cd /home/ubuntu/afewell-hh/hh-netbox-plugin
 scripts/publish_ra_assets.sh \
-  --artifact-root <local-artifact-root> \
+  --artifact-root <pipeline-artifact-root> \
   --composition-dir <ra-composition-dir>
 ```
 
-The script copies these sections when present:
-
-- `inputs/`
-- `netbox/`
-- `wiring/`
-- `hhfab/`
-- `logs/`
-
-Each destination section is replaced atomically at the directory level by
-removing the existing section and copying the source section fresh.
+The script is safe to run repeatedly — it replaces destination directories
+atomically so there are no stale files from prior runs.
 
 ## Recommended Flow
 
-1. Generate all local artifacts under the standard pipeline artifact root.
+1. Generate all local artifacts under the standard pipeline artifact root
+   (`/tmp/ra_pipeline/<case_id>/`).
 2. Review the generated files locally.
-3. Publish into the target RA composition directory with the script above.
-4. Review the `generated/` subtree in the RA repo.
+3. Publish into the target RA composition directory:
+   ```bash
+   scripts/publish_ra_assets.sh \
+     --artifact-root /tmp/ra_pipeline/<case_id> \
+     --composition-dir /path/to/training-ra/compositions/<variant>
+   ```
+4. Review the `wiring/` and `diagrams/hhfab/` changes in the RA repo.
 5. Commit/push from the RA repo once the bundle is accepted.
+
+The `run_ra_pipeline.sh` script calls `publish_ra_assets.sh` automatically
+as its final step; the `--composition-dir` argument controls the destination.
+
+## Verification
+
+After publishing, verify the artifact layout with:
+
+```bash
+# Check wiring files landed correctly
+ls <comp>/wiring/
+
+# Check hhfab diagrams and validation logs landed correctly
+ls <comp>/diagrams/hhfab/
+
+# Run the pipeline-level contract checker against the local artifact root
+scripts/verify_ra_artifacts.sh --artifact-root /tmp/ra_pipeline/<case_id>
+```

--- a/docs/RA_ASSET_PUBLISHING.md
+++ b/docs/RA_ASSET_PUBLISHING.md
@@ -8,7 +8,7 @@ being refined, generated outputs are copied into a `generated/` subtree.
 
 ## Destination Layout
 
-Example:
+Example (two-fabric plan with `backend` and `frontend` managed fabrics):
 
 ```text
 training-ra/compositions/OPG-128/clos-ro--.../
@@ -28,19 +28,35 @@ training-ra/compositions/OPG-128/clos-ro--.../
       inventory.json
       interface-connections.csv
     wiring/
-      full.yaml
-      backend.yaml
-      frontend.yaml
+      wiring-backend.yaml
+      wiring-frontend.yaml
     hhfab/
-      backend.validate.txt
+      hhfab_validate_backend.log
+      hhfab_validate_frontend.log
+      hhfab_validate.log        ← combined summary
       backend.drawio
-      frontend.validate.txt
       frontend.drawio
     logs/
       ingest.log
       generate.log
-      export.log
-      diagram.log
+      wiring_export.log
+```
+
+The exact fabric names in `wiring/` depend on the managed fabrics defined in the
+topology plan.  The pipeline preserves **all** per-fabric artifacts emitted by
+`export_wiring_yaml --split-by-fabric`.  No wiring artifact is deleted, even if
+hhfab validation for that fabric fails.  Validation failures are recorded in
+`hhfab/hhfab_validate_<fabric>.log` alongside the preserved artifact.
+
+For a single-fabric backend-only plan the layout would be:
+
+```text
+    wiring/
+      wiring-backend.yaml
+    hhfab/
+      hhfab_validate_backend.log
+      hhfab_validate.log
+      backend.drawio
 ```
 
 ## Publisher Script

--- a/netbox_hedgehog/services/yaml_generator.py
+++ b/netbox_hedgehog/services/yaml_generator.py
@@ -1510,46 +1510,31 @@ class YAMLGenerator:
         Args:
             referenced_group_names: The set of group names that appear in spec.groups of
                 the Switch CRDs included in this export artifact. Only groups in this set
-                are emitted. A ValidationError is raised if a referenced group has no
-                corresponding PlanMCLAGDomain (dangling Switch.spec.groups reference).
+                are emitted.
 
         Returns:
             List of SwitchGroup CRD dicts with empty spec: {}
 
         NOTE: Per authoritative Hedgehog schema, SwitchGroup has EMPTY spec (marker object only).
         Switch membership is tracked via Switch CRD spec.groups field, NOT in SwitchGroup.
+        PlanMCLAGDomain records are NOT required for export. The group name from the Switch
+        CRD is the only data needed to emit the SwitchGroup CRD (Issue #330).
         """
-        from ..models.topology_planning import PlanMCLAGDomain
-
         if not referenced_group_names:
             return []
 
-        # Build a lookup of all PlanMCLAGDomain entries for this plan.
-        domain_map = {
-            d.switch_group_name: d
-            for d in PlanMCLAGDomain.objects.filter(plan=self.plan)
-        }
-
-        switchgroup_crds = []
-
-        for group_name in sorted(referenced_group_names):
-            if group_name not in domain_map:
-                raise ValidationError(
-                    f"Switch references group '{group_name}' but no PlanMCLAGDomain "
-                    f"exists with that switch_group_name for this plan."
-                )
-            domain = domain_map[group_name]
-            switchgroup_crds.append({
+        return [
+            {
                 'apiVersion': 'wiring.githedgehog.com/v1beta1',
                 'kind': 'SwitchGroup',
                 'metadata': {
-                    'name': domain.switch_group_name,
+                    'name': group_name,
                     'namespace': 'default'
                 },
                 'spec': {}  # Empty spec per authoritative schema
-            })
-
-        return switchgroup_crds
+            }
+            for group_name in sorted(referenced_group_names)
+        ]
 
 
 def generate_yaml_for_plan(plan: TopologyPlan, fabric: str = None) -> str:

--- a/netbox_hedgehog/tests/test_topology_planning/test_yaml_export_inventory_based.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_yaml_export_inventory_based.py
@@ -1351,6 +1351,132 @@ class YAMLExportRedundancyCRDsTestCase(YAMLExportTestBase):
         links = bundled_crds[0]['spec']['bundled']['links']
         self.assertEqual(len(links), 2)
 
+    # ------------------------------------------------------------------ #
+    # Issue #330 — SwitchGroup export must not require PlanMCLAGDomain   #
+    # ------------------------------------------------------------------ #
+
+    def test_switchgroup_emitted_without_mclag_domain_record(self):
+        """
+        A switch class with redundancy_group set but NO PlanMCLAGDomain must
+        still produce a SwitchGroup CRD on export (Issue #330).
+
+        This is the root cause of the DS5000 L3MH frontend wiring export failure:
+        ingest never creates PlanMCLAGDomain, so _generate_switchgroups() always
+        raises ValidationError for any switch class with redundancy_group set.
+        """
+        from netbox_hedgehog.services.yaml_generator import generate_yaml_for_plan
+
+        plan = TopologyPlan.objects.create(
+            name='MCLAG No-Domain Export Plan',
+            created_by=self.user,
+        )
+
+        PlanSwitchClass.objects.create(
+            plan=plan,
+            switch_class_id='fe-gpu-leaf',
+            fabric=FabricTypeChoices.FRONTEND,
+            hedgehog_role=HedgehogRoleChoices.SERVER_LEAF,
+            device_type_extension=self.device_ext,
+            calculated_quantity=2,
+            redundancy_type='mclag',
+            redundancy_group='fe-mclag',
+        )
+
+        self._create_switch_device(plan, 'fe-gpu-leaf-01', 'fe-gpu-leaf')
+        self._create_switch_device(plan, 'fe-gpu-leaf-02', 'fe-gpu-leaf')
+
+        self._create_generation_state(plan, device_count=2, interface_count=0, cable_count=0)
+
+        # Must not raise — previously raised:
+        # "Switch references group 'fe-mclag' but no PlanMCLAGDomain exists"
+        yaml_str = generate_yaml_for_plan(plan, fabric='frontend')
+        documents = list(yaml.safe_load_all(yaml_str))
+        switchgroups = [doc for doc in documents if doc and doc.get('kind') == 'SwitchGroup']
+        self.assertEqual(len(switchgroups), 1)
+        self.assertEqual(switchgroups[0]['metadata']['name'], 'fe-mclag')
+        self.assertEqual(switchgroups[0]['spec'], {})
+
+    def test_switchgroup_emitted_without_mclag_domain_split_by_fabric(self):
+        """
+        Per-fabric export (fabric='frontend') with a switch class that has
+        redundancy_group set but no PlanMCLAGDomain must succeed (Issue #330).
+
+        This covers the exact path used by export_wiring_yaml --split-by-fabric.
+        """
+        from netbox_hedgehog.services.yaml_generator import generate_yaml_for_plan
+
+        plan = TopologyPlan.objects.create(
+            name='MCLAG No-Domain Split-Fabric Plan',
+            created_by=self.user,
+        )
+
+        PlanSwitchClass.objects.create(
+            plan=plan,
+            switch_class_id='fe-gpu-leaf',
+            fabric=FabricTypeChoices.FRONTEND,
+            hedgehog_role=HedgehogRoleChoices.SERVER_LEAF,
+            device_type_extension=self.device_ext,
+            calculated_quantity=2,
+            redundancy_type='mclag',
+            redundancy_group='fe-mclag',
+        )
+
+        self._create_switch_device(plan, 'fe-leaf-01', 'fe-gpu-leaf')
+        self._create_switch_device(plan, 'fe-leaf-02', 'fe-gpu-leaf')
+
+        self._create_generation_state(plan, device_count=2, interface_count=0, cable_count=0)
+
+        # Must not raise
+        yaml_str = generate_yaml_for_plan(plan, fabric='frontend')
+        documents = list(yaml.safe_load_all(yaml_str))
+        switchgroups = [doc for doc in documents if doc and doc.get('kind') == 'SwitchGroup']
+        self.assertEqual(len(switchgroups), 1)
+        self.assertEqual(switchgroups[0]['metadata']['name'], 'fe-mclag')
+
+    def test_existing_mclag_domain_still_emits_switchgroup(self):
+        """
+        Plans that DO have a PlanMCLAGDomain must still export the SwitchGroup
+        CRD correctly after the fix (regression guard, Issue #330).
+        """
+        from netbox_hedgehog.services.yaml_generator import generate_yaml_for_plan
+
+        plan = TopologyPlan.objects.create(
+            name='MCLAG With-Domain Regression Plan',
+            created_by=self.user,
+        )
+
+        switch_class = PlanSwitchClass.objects.create(
+            plan=plan,
+            switch_class_id='leaf-rg',
+            fabric=FabricTypeChoices.FRONTEND,
+            hedgehog_role=HedgehogRoleChoices.SERVER_LEAF,
+            device_type_extension=self.device_ext,
+            calculated_quantity=2,
+            redundancy_type='mclag',
+            redundancy_group='mclag-legacy',
+        )
+
+        PlanMCLAGDomain.objects.create(
+            plan=plan,
+            domain_id='mclag-legacy',
+            switch_class=switch_class,
+            peer_link_count=2,
+            session_link_count=2,
+            switch_group_name='mclag-legacy',
+        )
+
+        self._create_switch_device(plan, 'leaf-legacy-01', 'leaf-rg')
+        self._create_switch_device(plan, 'leaf-legacy-02', 'leaf-rg')
+
+        self._create_generation_state(plan, device_count=2, interface_count=0, cable_count=0)
+
+        yaml_str = generate_yaml_for_plan(plan, fabric='frontend')
+        documents = list(yaml.safe_load_all(yaml_str))
+        switchgroups = [doc for doc in documents if doc and doc.get('kind') == 'SwitchGroup']
+        self.assertEqual(len(switchgroups), 1)
+        self.assertEqual(switchgroups[0]['metadata']['name'], 'mclag-legacy')
+        self.assertEqual(switchgroups[0]['spec'], {})
+
 
 class YAMLExportUITestCase(YAMLExportTestBase):
     """

--- a/scripts/publish_ra_assets.sh
+++ b/scripts/publish_ra_assets.sh
@@ -1,27 +1,28 @@
 #!/usr/bin/env bash
 #
-# publish_ra_assets.sh
+# publish_ra_assets.sh — publish RA pipeline artifacts into a training-ra/inference-ra
+# composition directory using the current flat asset layout.
 #
-# Copy a locally generated RA artifact bundle into the final per-variant
-# composition folder inside the training-ra or inference-ra repository.
-#
-# Expected source layout:
+# Source layout (pipeline artifact root):
 #   <artifact_root>/
-#     inputs/
-#     netbox/
-#     wiring/
-#     hhfab/
-#     logs/
+#     wiring/wiring-*.yaml          (per-fabric wiring; may include WIRING_GAP.txt)
+#     hhfab/<fabric>.drawio         (hhfab diagrams)
+#     hhfab/hhfab_validate_<f>.log  (per-fabric hhfab validation results)
+#     inputs/  netbox/  logs/       (pipeline-local; NOT published)
 #
-# Destination layout:
-#   <composition_dir>/generated/
-#     inputs/
-#     netbox/
-#     wiring/
-#     hhfab/
-#     logs/
+# Destination layout (flat, matches current training-ra structure):
+#   <composition_dir>/
+#     wiring/wiring-*.yaml
+#     diagrams/hhfab/<fabric>.drawio
+#     diagrams/hhfab/hhfab_validate_<fabric>.log
 #
-# The destination is replaced directory-by-directory for deterministic updates.
+# Each destination section is replaced atomically at the directory level so
+# repeated runs are deterministic and leave no stale files behind.
+#
+# Usage:
+#   scripts/publish_ra_assets.sh \
+#     --artifact-root <path> \
+#     --composition-dir <path>
 
 set -euo pipefail
 
@@ -34,7 +35,7 @@ Usage:
 
 Example:
   scripts/publish_ra_assets.sh \
-    --artifact-root /tmp/ra-artifacts/training/OPG-128/clos-ro--example \
+    --artifact-root /tmp/ra_pipeline/training_opg128_clos_ro_air_2srv \
     --composition-dir /home/ubuntu/afewell-hh/training-ra/compositions/OPG-128/clos-ro--example
 EOF
 }
@@ -79,30 +80,40 @@ if [[ ! -d "$COMPOSITION_DIR" ]]; then
   exit 1
 fi
 
-DEST_ROOT="${COMPOSITION_DIR}/generated"
-mkdir -p "$DEST_ROOT"
+WIRING_SRC="${ARTIFACT_ROOT}/wiring"
+HHFAB_SRC="${ARTIFACT_ROOT}/hhfab"
+PUBLISHED=0
 
-copy_section() {
-  local section="$1"
-  local src="${ARTIFACT_ROOT}/${section}"
-  local dst="${DEST_ROOT}/${section}"
+# --- wiring/ → <comp>/wiring/ ---
+# Atomic directory replace: removes stale files from prior runs.
+if [[ -d "$WIRING_SRC" ]]; then
+  WIRING_DEST="${COMPOSITION_DIR}/wiring"
+  rm -rf "$WIRING_DEST"
+  mkdir -p "$WIRING_DEST"
+  cp -a "${WIRING_SRC}/." "${WIRING_DEST}/"
+  echo "  wiring/         →  ${WIRING_DEST}"
+  PUBLISHED=$((PUBLISHED + 1))
+fi
 
-  if [[ ! -d "$src" ]]; then
-    return 0
-  fi
+# --- hhfab/ → <comp>/diagrams/hhfab/ ---
+# Only publishes: *.drawio diagrams and hhfab_validate_*.log files.
+# Pipeline-internal logs (hhfab_init_*.log, hhfab_diagram_*.log, hhfab_validate.log)
+# are not included in the published composition.
+if [[ -d "$HHFAB_SRC" ]]; then
+  HHFAB_DEST="${COMPOSITION_DIR}/diagrams/hhfab"
+  rm -rf "$HHFAB_DEST"
+  mkdir -p "$HHFAB_DEST"
+  find "$HHFAB_SRC" -maxdepth 1 \( -name "*.drawio" -o -name "hhfab_validate_*.log" \) \
+    -exec cp {} "${HHFAB_DEST}/" \;
+  echo "  hhfab/          →  ${HHFAB_DEST}"
+  PUBLISHED=$((PUBLISHED + 1))
+fi
 
-  rm -rf "$dst"
-  mkdir -p "$dst"
-  cp -a "${src}/." "$dst/"
-}
+if [[ "$PUBLISHED" -eq 0 ]]; then
+  echo "WARNING: nothing published — wiring/ and hhfab/ both absent from $ARTIFACT_ROOT" >&2
+  exit 1
+fi
 
-copy_section "inputs"
-copy_section "netbox"
-copy_section "wiring"
-copy_section "hhfab"
-copy_section "logs"
-
-echo "Published generated assets:"
+echo "Published RA assets:"
 echo "  source:      $ARTIFACT_ROOT"
-echo "  destination: $DEST_ROOT"
-
+echo "  destination: $COMPOSITION_DIR"

--- a/scripts/run_ra_pipeline.sh
+++ b/scripts/run_ra_pipeline.sh
@@ -81,16 +81,17 @@ cd "$NETBOX_DIR" && docker compose cp "netbox:${CONTAINER_TMP}/netbox/." "$ARTIF
 if [[ "$FE_ONLY" == "false" ]]; then
   echo "[4/7] Exporting wiring YAMLs..."
   cd "$NETBOX_DIR" && docker compose exec -T netbox sh -c "mkdir -p ${CONTAINER_TMP}/wiring_tmp" 2>/dev/null || true
-  # FE wiring will fail (known mclag gap) — capture error, continue
+  # Export all per-fabric wiring artifacts.  Some fabrics (e.g. frontend with mclag gap) may fail;
+  # capture the error to the log and continue — the successful artifacts are preserved.
   RUN export_wiring_yaml "$PLAN_ID" --split-by-fabric --output "${CONTAINER_TMP}/wiring_tmp/wiring" >> "$ARTIFACT_DIR/logs/wiring_export.log" 2>&1 || true
-  # Move wiring files into wiring_tmp dir, then copy to host
-  cd "$NETBOX_DIR" && docker compose exec -T netbox sh -c "
-    ls ${CONTAINER_TMP}/wiring_tmp-*.yaml 2>/dev/null && mv ${CONTAINER_TMP}/wiring_tmp-*.yaml ${CONTAINER_TMP}/wiring_tmp/ 2>/dev/null || true
-  " 2>/dev/null || true
+  # Copy all wiring files to the host artifact dir.
+  # NOTE: --split-by-fabric writes <base>-<fabric>.yaml inside the base directory, so the
+  # container source for docker compose cp is the wiring_tmp/ directory itself.
   cd "$NETBOX_DIR" && docker compose cp "netbox:${CONTAINER_TMP}/wiring_tmp/." "$ARTIFACT_DIR/wiring/" 2>/dev/null || echo "  WARN: cp wiring failed"
-  # Keep only backend wiring files (FE export fails with known mclag gap)
-  find "$ARTIFACT_DIR/wiring/" -name "wiring-frontend*.yaml" -delete 2>/dev/null || true
-  WIRING_FILES=$(find "$ARTIFACT_DIR/wiring/" -name "*.yaml" 2>/dev/null | sort)
+  # All per-fabric artifacts are preserved — do NOT delete any wiring-<fabric>.yaml files here.
+  # If hhfab cannot validate a particular fabric artifact, that gap is recorded in the hhfab logs
+  # (see step 5) and documented in translation-notes; the artifact itself is kept.
+  WIRING_FILES=$(find "$ARTIFACT_DIR/wiring/" -name "wiring-*.yaml" 2>/dev/null | sort)
   echo "  Wiring files: $(echo "$WIRING_FILES" | wc -l | tr -d ' ')"
 else
   echo "[4/7] Skipping wiring export (FE-only variant — known mclag gap applies)"
@@ -109,9 +110,14 @@ elif [[ -n "$LIQUID_CLONE_OF" ]] && [[ -d "$LIQUID_CLONE_OF" ]]; then
     echo "(Diagrams copied from air variant; topology identical.)" >> "$ARTIFACT_DIR/hhfab/hhfab_validate.log"
   fi
 else
-  WIRING_FILES_LIST=$(find "$ARTIFACT_DIR/wiring/" -name "wiring-backend*.yaml" -o -name "wiring-backend-plane*.yaml" 2>/dev/null | sort)
+  # Iterate over ALL per-fabric wiring artifacts discovered in the wiring/ dir.
+  # We do not filter by fabric name — backend, frontend, or any arbitrary managed-fabric name
+  # is treated identically here.  If hhfab cannot validate a specific fabric (e.g. frontend
+  # with the known mclag gap), the failure is captured in a per-fabric log file and the
+  # artifact is still kept.  See issue #326.
+  WIRING_FILES_LIST=$(find "$ARTIFACT_DIR/wiring/" -name "wiring-*.yaml" 2>/dev/null | sort)
   if [[ -z "$WIRING_FILES_LIST" ]]; then
-    echo "No backend wiring files found; skipping hhfab." > "$ARTIFACT_DIR/hhfab/hhfab_validate.log"
+    echo "No per-fabric wiring files found; skipping hhfab." > "$ARTIFACT_DIR/hhfab/hhfab_validate.log"
   else
     for WIRING_F in $WIRING_FILES_LIST; do
       FABRIC_NAME=$(basename "$WIRING_F" .yaml | sed 's/^wiring-//')
@@ -120,13 +126,20 @@ else
       mkdir -p "$HHFAB_WORK"
       cp "$WIRING_F" "${HHFAB_WORK}/wiring.yaml"
       pushd "$HHFAB_WORK" > /dev/null
+      VALIDATE_LOG="${ARTIFACT_DIR}/hhfab/hhfab_validate_${FABRIC_NAME}.log"
       hhfab init --dev --force > "${ARTIFACT_DIR}/hhfab/hhfab_init_${FABRIC_NAME}.log" 2>&1 || true
-      hhfab validate >> "${ARTIFACT_DIR}/hhfab/hhfab_validate.log" 2>&1 || true
+      if hhfab validate > "$VALIDATE_LOG" 2>&1; then
+        echo "  [hhfab] ${FABRIC_NAME}: validate OK"
+      else
+        echo "  [hhfab] ${FABRIC_NAME}: validate FAILED (see ${VALIDATE_LOG}; artifact preserved)"
+      fi
       hhfab diagram > "${ARTIFACT_DIR}/hhfab/hhfab_diagram_${FABRIC_NAME}.log" 2>&1 || true
       find . -name "*.drawio" -exec cp {} "${ARTIFACT_DIR}/hhfab/${FABRIC_NAME}.drawio" \; 2>/dev/null || true
       popd > /dev/null
       rm -rf "$HHFAB_WORK"
     done
+    # Write a combined validate summary for easy review
+    cat "${ARTIFACT_DIR}/hhfab/hhfab_validate_"*.log > "${ARTIFACT_DIR}/hhfab/hhfab_validate.log" 2>/dev/null || true
   fi
 fi
 
@@ -142,28 +155,31 @@ cat > "$ARTIFACT_DIR/inputs/translation-notes.md" << NOTES_EOF
 - Site slug: ${SITE_SLUG}
 - Device count: ${DEVICE_COUNT:-unknown}
 
-## Known Gaps
+## Wiring Artifacts
+All managed-fabric wiring artifacts produced by --split-by-fabric are preserved in
+wiring/. Each wiring-<fabric>.yaml file is independently consumable.
+See hhfab/ for per-fabric validation logs (hhfab_validate_<fabric>.log).
 
-### Frontend Wiring Export
-Frontend wiring YAML export fails with:
-  "Switch references group 'fe-mclag' but no PlanMCLAGDomain exists"
-This is a pre-existing DIET gap affecting all DS5000 L3MH variants.
-Backend wiring exported and validated successfully.
+If a fabric's wiring export or hhfab validation failed, the artifact is still
+preserved and the failure is recorded in the corresponding log file.
+Known gap: frontend (DS5000 L3MH variants) export may fail with a mclag gap —
+"Switch references group 'fe-mclag' but no PlanMCLAGDomain exists". This is
+tracked as a pre-existing DIET gap. The artifact is kept even if export partially
+failed; see wiring_export.log for the full error.
 
-$(if [[ "$FE_ONLY" == "true" ]]; then echo "### FE-Only Variant
+$(if [[ "$FE_ONLY" == "true" ]]; then echo "## FE-Only Variant
 This variant has no backend fabric by RA design. Only a frontend fabric is defined.
-Frontend wiring export also blocked by the mclag gap above.
-hhfab validation not applicable (no backend wiring available)."; fi)
+Wiring export and hhfab validation are skipped (FE-only; no backend wiring available).
+Frontend wiring export is also blocked by the known mclag gap above."; fi)
 
-$(if [[ -n "$LIQUID_CLONE_OF" ]]; then echo "### Liquid Cooling Variant
+$(if [[ -n "$LIQUID_CLONE_OF" ]]; then echo "## Liquid Cooling Variant
 This variant is topologically identical to the corresponding air-cooled variant.
 Cooling medium and rack density differ only (not modeled in DIET).
 Reference air-cooled variant for the same wiring topology."; fi)
 
-## SH Distribution Shim (if applicable)
-Single-homed backend variants use rail-optimized distribution (rails 0-7) as a
-structural shim. DIET has no per-server SH distribution; this approximates the
-intent. Document deviation in RA notes.
+## SH Distribution Note (if applicable)
+Single-homed scale-out variants use same-switch grouped-per-leaf distribution.
+Servers are allocated in contiguous blocks per leaf (first N/2 → leaf A, rest → leaf B).
 
 ## XOC Composition Note (if applicable)
 XOC variants are modeled as a single scaled DIET plan with the combined server

--- a/scripts/verify_ra_artifacts.sh
+++ b/scripts/verify_ra_artifacts.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# verify_ra_artifacts.sh — Artifact-collection regression checker for the RA pipeline
+#
+# Verifies that a completed RA pipeline artifact root:
+#   1. Contains at least one wiring-<fabric>.yaml file
+#   2. Does NOT contain backend-only files with legacy names (wiring-backend only)
+#      while also containing other per-fabric export output (i.e. no deletion of
+#      non-backend artifacts happened)
+#   3. Has a corresponding hhfab_validate_<fabric>.log for every wiring file
+#      (hhfab was attempted for every fabric, not just backend-named ones)
+#
+# This is a post-run contract check, not a substitute for a full pipeline run.
+# See also: issue #326 (RA pipeline drops per-fabric wiring artifacts)
+#
+# Usage:
+#   scripts/verify_ra_artifacts.sh --artifact-root <path>
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — one or more checks failed
+
+set -uo pipefail
+
+ARTIFACT_ROOT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --artifact-root) ARTIFACT_ROOT="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$ARTIFACT_ROOT" ]]; then
+  echo "Usage: $0 --artifact-root <path>" >&2
+  exit 1
+fi
+
+if [[ ! -d "$ARTIFACT_ROOT" ]]; then
+  echo "Artifact root does not exist: $ARTIFACT_ROOT" >&2
+  exit 1
+fi
+
+WIRING_DIR="${ARTIFACT_ROOT}/wiring"
+HHFAB_DIR="${ARTIFACT_ROOT}/hhfab"
+PASS=true
+
+echo "=== Verifying RA artifact root: $ARTIFACT_ROOT ==="
+
+# --- Check 1: wiring/ exists and is non-empty ---
+if [[ ! -d "$WIRING_DIR" ]]; then
+  echo "FAIL: wiring/ directory missing"
+  PASS=false
+else
+  WIRING_FILES=$(find "$WIRING_DIR" -name "wiring-*.yaml" 2>/dev/null | sort)
+  WIRING_COUNT=$(echo "$WIRING_FILES" | grep -c . || true)
+  if [[ "$WIRING_COUNT" -eq 0 ]]; then
+    echo "FAIL: no wiring-*.yaml files found under wiring/"
+    PASS=false
+  else
+    echo "OK:   wiring/ contains $WIRING_COUNT file(s):"
+    echo "$WIRING_FILES" | sed 's/^/        /'
+  fi
+fi
+
+# --- Check 2: no frontend artifact was silently deleted ---
+# If the export log mentions a frontend fabric and the wiring file is absent,
+# that is evidence of the old deletion behavior.
+if [[ -f "${ARTIFACT_ROOT}/logs/wiring_export.log" ]]; then
+  EXPORTED_FABRICS=$(grep -oE "wiring-[a-z0-9_-]+\.yaml" "${ARTIFACT_ROOT}/logs/wiring_export.log" \
+    | sed 's/wiring-//; s/\.yaml//' | sort -u)
+  for FAB in $EXPORTED_FABRICS; do
+    EXPECTED="${WIRING_DIR}/wiring-${FAB}.yaml"
+    if [[ ! -f "$EXPECTED" ]]; then
+      echo "FAIL: wiring-${FAB}.yaml was mentioned in export log but is absent from wiring/"
+      echo "      This suggests the artifact was deleted post-export (issue #326 regression)"
+      PASS=false
+    else
+      echo "OK:   wiring-${FAB}.yaml present (exported and preserved)"
+    fi
+  done
+fi
+
+# --- Check 3: hhfab validate log exists for every wiring file ---
+if [[ -d "$HHFAB_DIR" && "$WIRING_COUNT" -gt 0 ]]; then
+  for WIRING_F in $WIRING_FILES; do
+    FABRIC=$(basename "$WIRING_F" .yaml | sed 's/^wiring-//')
+    VALIDATE_LOG="${HHFAB_DIR}/hhfab_validate_${FABRIC}.log"
+    if [[ ! -f "$VALIDATE_LOG" ]]; then
+      echo "FAIL: no hhfab_validate_${FABRIC}.log — hhfab was not attempted for fabric '${FABRIC}'"
+      echo "      This suggests hhfab iteration still uses backend-only filename patterns (issue #326)"
+      PASS=false
+    else
+      echo "OK:   hhfab_validate_${FABRIC}.log present"
+    fi
+  done
+fi
+
+# --- Check 4: backend-only filter not in play ---
+# Heuristic: if >1 fabric appears in the wiring/ dir, hhfab logs for ALL fabrics must exist.
+# A pipeline that only ran hhfab for backend-named files would be missing non-backend logs.
+if [[ "$WIRING_COUNT" -gt 1 ]] && [[ -d "$HHFAB_DIR" ]]; then
+  HHFAB_LOG_COUNT=$(find "$HHFAB_DIR" -name "hhfab_validate_*.log" 2>/dev/null | grep -v hhfab_validate\.log | wc -l | tr -d ' ')
+  if [[ "$HHFAB_LOG_COUNT" -lt "$WIRING_COUNT" ]]; then
+    echo "FAIL: $WIRING_COUNT wiring files but only $HHFAB_LOG_COUNT hhfab validate logs"
+    echo "      hhfab was not attempted for all fabrics (backend-only filter may still be active)"
+    PASS=false
+  else
+    echo "OK:   hhfab validate attempted for all $WIRING_COUNT fabric(s)"
+  fi
+fi
+
+echo ""
+if [[ "$PASS" == "true" ]]; then
+  echo "=== All checks PASSED ==="
+  exit 0
+else
+  echo "=== One or more checks FAILED ==="
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Removes the hard `PlanMCLAGDomain` requirement from `_generate_switchgroups()` in `yaml_generator.py`
- `SwitchGroup` CRDs have empty `spec: {}` — no data from `PlanMCLAGDomain` is needed for the CRD output
- Ingest never creates `PlanMCLAGDomain` records, so all DS5000 L3MH plans with `redundancy_group` set on a switch class always failed export with: `"Switch references group 'fe-mclag' but no PlanMCLAGDomain exists"`
- Fix: emit SwitchGroup CRD directly from the referenced group name — `PlanMCLAGDomain` remains for future peer/session link cable generation

## Root Cause

`_generate_switchgroups()` performed a `PlanMCLAGDomain.objects.filter(plan=self.plan)` lookup and raised `ValidationError` when the domain record was missing. But the domain's only used field was `switch_group_name` — which is already available as the key in `referenced_group_names`. The lookup was unnecessary.

## Tests

3 new tests in `YAMLExportRedundancyCRDsTestCase`:
- `test_switchgroup_emitted_without_mclag_domain_record` — no domain record, frontend fabric, SwitchGroup CRD emitted
- `test_switchgroup_emitted_without_mclag_domain_split_by_fabric` — exercises `generate_yaml_for_plan(fabric='frontend')` path used by `export_wiring_yaml --split-by-fabric`
- `test_existing_mclag_domain_still_emits_switchgroup` — regression guard: plans with `PlanMCLAGDomain` still export correctly

58 tests pass in `test_yaml_export_inventory_based` + `test_multi_fabric_independent_wiring`.

## Test commands run

```bash
docker compose exec -T netbox python manage.py test \
  netbox_hedgehog.tests.test_topology_planning.test_yaml_export_inventory_based \
  netbox_hedgehog.tests.test_topology_planning.test_multi_fabric_independent_wiring \
  --keepdb --parallel 4
# 58 tests, OK
```

## Files changed

- `netbox_hedgehog/services/yaml_generator.py` — simplified `_generate_switchgroups()`: removed domain lookup, emit CRD from group name directly
- `netbox_hedgehog/tests/test_topology_planning/test_yaml_export_inventory_based.py` — 3 new tests

## Related

- Closes #330
- Unblocks frontend wiring export for all DS5000 L3MH training variants
- Related: #326 (RA pipeline), #328/#329 (publisher/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)