### PR TITLE
[DIET-332] Fix rail-domain allocation for XOC-1024

### DIFF
--- a/netbox_hedgehog/services/device_generator.py
+++ b/netbox_hedgehog/services/device_generator.py
@@ -302,13 +302,22 @@ class DeviceGenerator:
                             f"No switch instances available for {switch_class.switch_class_id}."
                         )
 
-                    # Pre-calculate total_rails for rail-optimized connections
+                    # Pre-calculate total_rails and servers_per_domain for rail-optimized connections
                     total_rails = None
+                    servers_per_domain = None
                     if connection_def.distribution == ConnectionDistributionChoices.RAIL_OPTIMIZED:
                         total_rails = self._get_total_rails_for_target(
                             server_class,
                             zone,
                         )
+                        num_sw = len(switch_instances)
+                        if total_rails and num_sw >= total_rails:
+                            # Domain-based: compute how many servers fit in one first-hop rail domain.
+                            # Each domain has total_rails switches (one per rail); each switch serves
+                            # zone_capacity / ports_per_connection servers for its rail.
+                            zone_capacity = self.port_allocator.capacity_for_zone(zone)
+                            ppc = connection_def.ports_per_connection or 1
+                            servers_per_domain = max(1, zone_capacity // ppc)
 
                     module = nic_to_module.get(connection_def.nic_id)
                     if module is None:
@@ -335,6 +344,7 @@ class DeviceGenerator:
                             port_index,
                             rail=connection_def.rail,
                             total_rails=total_rails,
+                            servers_per_domain=servers_per_domain,
                         )
                         switch_port = self.port_allocator.allocate(
                             switch_device.name,
@@ -1043,6 +1053,7 @@ class DeviceGenerator:
         port_index: int,
         rail: int | None = None,
         total_rails: int | None = None,
+        servers_per_domain: int | None = None,
     ) -> Device:
         if len(switch_instances) == 1:
             return switch_instances[0]
@@ -1052,9 +1063,22 @@ class DeviceGenerator:
         if distribution == ConnectionDistributionChoices.SAME_SWITCH:
             return switch_instances[server_index % len(switch_instances)]
         if distribution == ConnectionDistributionChoices.RAIL_OPTIMIZED:
-            # Rail-optimized: all servers' NIC at position N connect to same switch(es)
-            # Algorithm: rails_per_switch = ceil(total_rails / num_switches)
-            #            switch_index = rail // rails_per_switch
+            # Rail-optimized: all servers' NIC at position N connect to the same rail's switch.
+            # Two sub-cases:
+            #
+            # A) num_switches < total_rails (capacity-sharing):
+            #    Multiple rails are served by one switch. Map by:
+            #        rails_per_switch = ceil(total_rails / num_switches)
+            #        switch_index = rail // rails_per_switch
+            #    server_index is irrelevant here (all servers share same mapping).
+            #
+            # B) num_switches >= total_rails (domain-based / repeated first-hop domains):
+            #    Each domain has exactly total_rails switches (one per rail).
+            #    Domains repeat when server demand exceeds one switch's capacity.
+            #        domain_index = server_index // servers_per_domain
+            #        switch_index = domain_index * total_rails + rail
+            #    This ensures servers 0..N-1 use domain 0 and servers N..2N-1 use domain 1,
+            #    each domain using the same rail→switch-within-domain mapping.
             if rail is None:
                 raise ValidationError(
                     "Rail number required for rail-optimized distribution"
@@ -1065,9 +1089,23 @@ class DeviceGenerator:
                 )
 
             num_switches = len(switch_instances)
-            rails_per_switch = math.ceil(total_rails / num_switches)
-            switch_index = rail // rails_per_switch
 
+            if num_switches >= total_rails:
+                # Domain-based: repeated first-hop rail domains
+                if servers_per_domain is None or servers_per_domain <= 0:
+                    raise ValidationError(
+                        "servers_per_domain required for rail-optimized distribution "
+                        "when num_switches >= total_rails"
+                    )
+                domain_index = server_index // servers_per_domain
+                switch_index = domain_index * total_rails + rail
+            else:
+                # Capacity-sharing: multiple rails map to one switch
+                rails_per_switch = math.ceil(total_rails / num_switches)
+                switch_index = rail // rails_per_switch
+
+            # Safety clamp — should never fire for well-formed plans
+            switch_index = min(switch_index, num_switches - 1)
             return switch_instances[switch_index]
 
         return switch_instances[server_index % len(switch_instances)]

--- a/netbox_hedgehog/services/port_allocator.py
+++ b/netbox_hedgehog/services/port_allocator.py
@@ -67,6 +67,10 @@ class PortAllocatorV2:
         self._cursors[key] = cursor + count
         return allocated
 
+    def capacity_for_zone(self, zone) -> int:
+        """Return total logical port capacity for a zone (all ports, no allocation consumed)."""
+        return len(self._build_sequence(zone))
+
     def _build_sequence(self, zone) -> list[PortSlot]:
         ports = PortSpecification(zone.port_spec).parse()
         ordered_ports = self._apply_strategy(zone, ports)

--- a/netbox_hedgehog/tests/test_topology_planning/test_device_generator.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_device_generator.py
@@ -177,3 +177,182 @@ class DeviceGeneratorTestCase(TestCase):
         self.assertTrue(Site.objects.filter(slug='hedgehog').exists())
         self.assertTrue(DeviceRole.objects.filter(slug='server').exists())
         self.assertTrue(DeviceRole.objects.filter(slug='leaf').exists())
+
+
+class RailDomainAllocationTestCase(TestCase):
+    """
+    Regression tests for DIET-332: rail-domain allocation.
+
+    Two complementary behaviors:
+    1. Multiple rails share one switch when num_switches < total_rails (capacity-sharing).
+       This was always supported; regression guard only.
+    2. One rail spans multiple switches via repeated first-hop rail domains when
+       num_switches >= total_rails (domain-based allocation).
+       This is the new behavior that fixes XOC-1024 generation.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.manufacturer, _ = Manufacturer.objects.get_or_create(
+            name='Celestica-RailDomain',
+            defaults={'slug': 'celestica-raildomain'},
+        )
+        cls.server_type, _ = DeviceType.objects.get_or_create(
+            manufacturer=cls.manufacturer,
+            model='SRV-RD-01',
+            defaults={'slug': 'srv-rd-01', 'u_height': 2},
+        )
+        cls.switch_type, _ = DeviceType.objects.get_or_create(
+            manufacturer=cls.manufacturer,
+            model='SW-RD-01',
+            defaults={'slug': 'sw-rd-01', 'u_height': 1},
+        )
+        cls.device_ext, _ = DeviceTypeExtension.objects.get_or_create(
+            device_type=cls.switch_type,
+            defaults={
+                'mclag_capable': False,
+                'hedgehog_roles': ['server-leaf'],
+                'supported_breakouts': [],
+                'native_speed': 400,
+                'uplink_ports': 0,
+            },
+        )
+
+    def _make_rail_plan(self, num_servers, num_rails, ports_per_switch):
+        """
+        Create a minimal plan with rail-optimized backend connections.
+
+        num_switches = (num_servers * num_rails) // ports_per_switch
+        (assumes even division for simplicity)
+        """
+        import math
+        num_switches = math.ceil(num_servers * num_rails / ports_per_switch)
+        plan = TopologyPlan.objects.create(
+            name=f'RD-{num_servers}srv-{num_rails}rail-{ports_per_switch}cap',
+            customer_name='Test',
+        )
+        switch_class = PlanSwitchClass.objects.create(
+            plan=plan,
+            switch_class_id='be-rail-leaf',
+            fabric='backend',
+            hedgehog_role='server-leaf',
+            device_type_extension=self.device_ext,
+            uplink_ports_per_switch=0,
+            calculated_quantity=num_switches,
+        )
+        zone = SwitchPortZone.objects.create(
+            switch_class=switch_class,
+            zone_name='be-server-ports',
+            zone_type='server',
+            port_spec=f'1-{ports_per_switch}',
+            allocation_strategy='sequential',
+        )
+        server_class = PlanServerClass.objects.create(
+            plan=plan,
+            server_class_id='gpu-server',
+            server_device_type=self.server_type,
+            quantity=num_servers,
+        )
+        for rail in range(num_rails):
+            PlanServerConnection.objects.create(
+                server_class=server_class,
+                connection_id=f'BE-RAIL-{rail}',
+                nic=get_test_server_nic(server_class, nic_id=f'nic-rail-{rail}'),
+                port_index=0,
+                ports_per_connection=1,
+                hedgehog_conn_type='unbundled',
+                distribution='rail-optimized',
+                target_zone=zone,
+                speed=400,
+                rail=rail,
+            )
+        return plan, switch_class, zone, num_switches
+
+    def test_multiple_rails_share_switch_when_capacity_allows(self):
+        """
+        Regression guard: capacity-sharing (num_switches < total_rails).
+
+        4 servers, 4 rails, 8 ports per switch → 2 switches.
+        2 switches < 4 rails → rails 0-1 share switch 0, rails 2-3 share switch 1.
+        Each switch must handle 4 servers × 2 rails × 1 port = 8 ports.
+        Generation must succeed.
+        """
+        plan, _, _, num_switches = self._make_rail_plan(
+            num_servers=4, num_rails=4, ports_per_switch=8
+        )
+        self.assertEqual(num_switches, 2)
+        generator = DeviceGenerator(plan)
+        result = generator.generate_all()
+        # 2 switches + 4 servers = 6 devices
+        self.assertEqual(result.device_count, 6)
+        # Each switch should have 8 interfaces (4 servers × 2 rails)
+        switch_devices = list(Device.objects.filter(
+            role__slug='leaf',
+            tags__slug='hedgehog-generated',
+        ).order_by('name'))
+        self.assertEqual(len(switch_devices), 2)
+        for sw in switch_devices:
+            iface_count = Interface.objects.filter(
+                device=sw, tags__slug='hedgehog-generated'
+            ).count()
+            self.assertEqual(iface_count, 8, f"{sw.name} expected 8 interfaces")
+
+    def test_repeated_rail_domains_when_demand_exceeds_switch_capacity(self):
+        """
+        New behavior (DIET-332): domain-based allocation (num_switches >= total_rails).
+
+        8 servers, 2 rails, 2 ports per switch → 8 switches.
+        8 switches >= 2 rails → 4 domains of 2 servers each.
+        - domain 0: servers 0-1 → switches 0 (rail-0) and 1 (rail-1)
+        - domain 1: servers 2-3 → switches 2 (rail-0) and 3 (rail-1)
+        - domain 2: servers 4-5 → switches 4 (rail-0) and 5 (rail-1)
+        - domain 3: servers 6-7 → switches 6 (rail-0) and 7 (rail-1)
+        Each switch must receive exactly 2 interfaces (one per server in its domain).
+        Without the fix, all 8 servers would pile onto switches 0 and 1, exhausting
+        capacity and raising "only 0 remain in zone 'be-server-ports'".
+        """
+        plan, _, _, num_switches = self._make_rail_plan(
+            num_servers=8, num_rails=2, ports_per_switch=2
+        )
+        self.assertEqual(num_switches, 8)
+        generator = DeviceGenerator(plan)
+        result = generator.generate_all()
+        # 8 switches + 8 servers = 16 devices
+        self.assertEqual(result.device_count, 16)
+        # Each switch should have exactly 2 interfaces (one per server in its domain)
+        switch_devices = list(Device.objects.filter(
+            role__slug='leaf',
+            tags__slug='hedgehog-generated',
+        ).order_by('name'))
+        self.assertEqual(len(switch_devices), 8)
+        for sw in switch_devices:
+            iface_count = Interface.objects.filter(
+                device=sw, tags__slug='hedgehog-generated'
+            ).count()
+            self.assertEqual(iface_count, 2, f"{sw.name} expected 2 interfaces (domain model)")
+
+    def test_single_domain_rail_optimized_succeeds(self):
+        """
+        Boundary: num_switches == total_rails → one domain, all servers in it.
+
+        4 servers, 2 rails, 4 ports per switch → 2 switches (== total_rails).
+        servers_per_domain = 4; all servers fit in domain 0.
+        Each switch: 4 interfaces (4 servers × 1 rail).
+        """
+        plan, _, _, num_switches = self._make_rail_plan(
+            num_servers=4, num_rails=2, ports_per_switch=4
+        )
+        self.assertEqual(num_switches, 2)
+        generator = DeviceGenerator(plan)
+        result = generator.generate_all()
+        self.assertEqual(result.device_count, 6)  # 2 switches + 4 servers
+        switch_devices = list(Device.objects.filter(
+            role__slug='leaf',
+            tags__slug='hedgehog-generated',
+        ).order_by('name'))
+        self.assertEqual(len(switch_devices), 2)
+        for sw in switch_devices:
+            iface_count = Interface.objects.filter(
+                device=sw, tags__slug='hedgehog-generated'
+            ).count()
+            self.assertEqual(iface_count, 4, f"{sw.name} expected 4 interfaces")


### PR DESCRIPTION
## Summary

- **Root cause**: `_select_switch_instance` used `switch_index = rail // ceil(total_rails / num_switches)`, which maps all 8 rails onto switches 0-7 even when 16 switches exist, exhausting capacity and leaving 8 switches unused
- **Fix**: when `num_switches >= total_rails`, use repeated first-hop rail domain model: `domain_index = server_index // servers_per_domain; switch_index = domain_index * total_rails + rail`
- **New helper**: `PortAllocatorV2.capacity_for_zone(zone)` exposes zone logical port count so the generator can compute `servers_per_domain` without duplicating topology-calc logic

## Implementation model for repeated first-hop rail domains

For XOC-1024 (16 be-rail-leaf, 8 rails, zone capacity 64 per switch, 128 servers):
- `servers_per_domain = 64 // 1 = 64`
- Domain 0 (switches 0-7): servers 0-63 → each switch handles exactly 64 connections (its capacity)
- Domain 1 (switches 8-15): servers 64-127 → same pattern repeated
- Total: all 16 switches used, each at full capacity, no overflow

The original capacity-sharing path (`num_switches < total_rails`: rails share a switch) is fully preserved.

## XOC-1024 validation

- **clos-ro variant**: `training_xoc1024_2xopg512_clos_ro_air_2srv` — generation succeeded, 155 devices created (16 be-rail-leaf + 8 be-spine + 2 fe-leaf + 1 fe-spine + 128 compute servers)
- **dual-plane variant**: `training_xoc1024_2xopg512_dual_plane_air_2srv` — generation started successfully (same domain model applies to both planes independently)

## Test plan

- [x] New `RailDomainAllocationTestCase` (3 tests):
  - `test_multiple_rails_share_switch_when_capacity_allows` — regression guard for capacity-sharing path
  - `test_repeated_rail_domains_when_demand_exceeds_switch_capacity` — new domain-based path; verifies each switch gets exactly 2 connections (not 8 which would overflow capacity of 2)
  - `test_single_domain_rail_optimized_succeeds` — boundary: num_switches == total_rails
- [x] Existing `test_rail_optimized_distribution_allows_rail_sharing` in `test_topology_calculations` — still passes
- [x] All 7 device_generator tests pass

```bash
# Targeted run — 7 tests, all pass
docker compose exec -T netbox python manage.py test \
  netbox_hedgehog.tests.test_topology_planning.test_device_generator \
  --keepdb

# Rail-sharing regression guard
docker compose exec -T netbox python manage.py test \
  netbox_hedgehog.tests.test_topology_planning.test_topology_calculations.CalculateSwitchQuantityTestCase.test_rail_optimized_distribution_allows_rail_sharing \
  --keepdb
```

## Files changed

- `netbox_hedgehog/services/port_allocator.py` — `capacity_for_zone()` method
- `netbox_hedgehog/services/device_generator.py` — domain-based switch selector logic
- `netbox_hedgehog/tests/test_topology_planning/test_device_generator.py` — `RailDomainAllocationTestCase`

## Residual risks

- Dual-plane full validation pending (generation was still running when PR opened; same code path applies identically)
- XOC-512 not explicitly tested end-to-end here (covered by the `test_single_domain_rail_optimized_succeeds` boundary test which is equivalent)
- `servers_per_domain` uses integer division; if zone capacity is not evenly divisible by `ports_per_connection` the last server in a domain may overflow. This is an edge case that doesn't affect any current training cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)