### PR TITLE
[DIET-215] Fix GenerationState snapshot test fixtures

### DIFF
--- a/netbox_hedgehog/tests/test_topology_planning/test_models_generation_state.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_models_generation_state.py
@@ -26,6 +26,8 @@ from netbox_hedgehog.models.topology_planning import (
 )
 from dcim.models import DeviceType, Manufacturer
 
+from netbox_hedgehog.utils.snapshot_builder import build_plan_snapshot
+
 
 class GenerationStateModelTestCase(TestCase):
     """Test suite for GenerationState model"""
@@ -203,16 +205,8 @@ class GenerationStateModelTestCase(TestCase):
             server_device_type=server_dt
         )
 
-        # Create snapshot matching current state
-        snapshot = {
-            'server_classes': [
-                {
-                    'server_class_id': 'gpu-b200',
-                    'quantity': 96
-                }
-            ],
-            'switch_classes': []
-        }
+        # Capture real snapshot from current DB state
+        snapshot = build_plan_snapshot(plan)
 
         state = GenerationState.objects.create(
             plan=plan,
@@ -242,16 +236,8 @@ class GenerationStateModelTestCase(TestCase):
             server_device_type=server_dt
         )
 
-        # Create snapshot with old quantity
-        snapshot = {
-            'server_classes': [
-                {
-                    'server_class_id': 'gpu-b200',
-                    'quantity': 96
-                }
-            ],
-            'switch_classes': []
-        }
+        # Capture real snapshot before modification
+        snapshot = build_plan_snapshot(plan)
 
         state = GenerationState.objects.create(
             plan=plan,
@@ -286,16 +272,8 @@ class GenerationStateModelTestCase(TestCase):
             server_device_type=server_dt
         )
 
-        # Create snapshot with one server class
-        snapshot = {
-            'server_classes': [
-                {
-                    'server_class_id': 'gpu-b200',
-                    'quantity': 96
-                }
-            ],
-            'switch_classes': []
-        }
+        # Capture real snapshot before adding second class
+        snapshot = build_plan_snapshot(plan)
 
         state = GenerationState.objects.create(
             plan=plan,
@@ -341,14 +319,8 @@ class GenerationStateModelTestCase(TestCase):
             server_device_type=server_dt
         )
 
-        # Create snapshot with both
-        snapshot = {
-            'server_classes': [
-                {'server_class_id': 'gpu-b200', 'quantity': 96},
-                {'server_class_id': 'storage-a', 'quantity': 32}
-            ],
-            'switch_classes': []
-        }
+        # Capture real snapshot before removing a class
+        snapshot = build_plan_snapshot(plan)
 
         state = GenerationState.objects.create(
             plan=plan,
@@ -377,16 +349,8 @@ class GenerationStateModelTestCase(TestCase):
             override_quantity=12
         )
 
-        # Create snapshot
-        snapshot = {
-            'server_classes': [],
-            'switch_classes': [
-                {
-                    'switch_class_id': 'fe-leaf',
-                    'effective_quantity': 12
-                }
-            ]
-        }
+        # Capture real snapshot before modification
+        snapshot = build_plan_snapshot(plan)
 
         state = GenerationState.objects.create(
             plan=plan,
@@ -600,7 +564,7 @@ class TopologyPlanPropertiesTestCase(TestCase):
             device_count=0,
             interface_count=0,
             cable_count=0,
-            snapshot={'server_classes': [], 'switch_classes': []},
+            snapshot=build_plan_snapshot(plan),
             status='generated'
         )
 
@@ -619,14 +583,13 @@ class TopologyPlanPropertiesTestCase(TestCase):
             slug="gpu-server"
         )
 
-        # Create initial state
-        snapshot = {'server_classes': [], 'switch_classes': []}
+        # Capture real snapshot before adding server class
         GenerationState.objects.create(
             plan=plan,
             device_count=0,
             interface_count=0,
             cable_count=0,
-            snapshot=snapshot,
+            snapshot=build_plan_snapshot(plan),
             status='generated'
         )
 


### PR DESCRIPTION
## Summary

Fixes false-positive `is_dirty()` / `needs_regeneration` behavior caused by stale hand-crafted snapshot fixtures in `test_models_generation_state.py`.

Hand-crafted snapshots used a 2-key shape (`server_classes`, `switch_classes`). `build_plan_snapshot()` always produces 5 keys (`server_classes`, `switch_classes`, `connections`, `port_zones`, `mclag_domains`). `compare_snapshots()` does strict equality, so any stored 2-key snapshot never matched the real output — `is_dirty()` returned `True` unconditionally regardless of whether the plan had actually changed.

**Before:** 2 clean-state tests failed (`assertFalse(state.is_dirty())`); 5 dirty-state tests passed only because the false positive fired before any mutation was applied.

**Fix:** Replace all 7 hand-crafted snapshot dicts with `build_plan_snapshot(plan)` called after plan objects are created and before `GenerationState` is saved. Clean tests now store the real current-state snapshot; dirty tests capture the pre-mutation state so `is_dirty()` detects the actual change.

**No production code changed.** `is_dirty()`, `build_plan_snapshot()`, `compare_snapshots()`, and `needs_regeneration` are all correct and untouched.

## Files Changed

- `netbox_hedgehog/tests/test_topology_planning/test_models_generation_state.py` — adds import, replaces 7 hand-crafted snapshot dicts

## Test Results

**Targeted — `test_models_generation_state`:**
```
Ran 21 tests in 1.344s
OK
```
21/21 GREEN (was: 2 failures)

**Guard — `test_bom_comparison`:**
```
Ran 22 tests in 27.653s
OK
```
22/22 GREEN (unchanged — `test_stale_warning_shown_when_plan_dirty` continues to pass; `snapshot={}` still differs from the real 5-key output)

Closes #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)