### PR TITLE
[DIET-434] Fix: remove InterfaceTemplates from OSFP transceiver ModuleTypes

### DIFF
--- a/netbox_hedgehog/migrations/0049_remove_osfp_interface_templates.py
+++ b/netbox_hedgehog/migrations/0049_remove_osfp_interface_templates.py
@@ -1,0 +1,74 @@
+"""
+Migration 0049: Remove InterfaceTemplates from OSFP transceiver ModuleTypes.
+
+OSFP-400G-DR4 and OSFP-200G-DR4 are pluggable optical transceivers, not NICs.
+They do not add logical interfaces to a device — the device's interfaces come
+from the NIC module type. The InterfaceTemplates seeded by 0048 caused
+duplicate-interface errors during device generation whenever multiple
+transceiver modules were installed on the same server (e.g., one OSFP per
+scale-out rail in XOC-64 → 8 × "port0" on the same device → UNIQUE violation).
+
+Removing the InterfaceTemplates is correct: a Module record in a cage-N bay
+is sufficient to record which transceiver is present; no separate interface
+is needed on the parent device.
+"""
+
+from django.db import migrations
+
+
+def remove_osfp_interface_templates(apps, schema_editor):
+    """Delete InterfaceTemplates from OSFP-400G-DR4 and OSFP-200G-DR4."""
+    Manufacturer = apps.get_model('dcim', 'Manufacturer')
+    ModuleType = apps.get_model('dcim', 'ModuleType')
+    InterfaceTemplate = apps.get_model('dcim', 'InterfaceTemplate')
+
+    try:
+        generic = Manufacturer.objects.get(name='Generic')
+    except Manufacturer.DoesNotExist:
+        return
+
+    osfp_models = ModuleType.objects.filter(
+        manufacturer=generic,
+        model__in=['OSFP-400G-DR4', 'OSFP-200G-DR4'],
+    )
+    InterfaceTemplate.objects.filter(module_type__in=osfp_models).delete()
+
+
+def restore_osfp_interface_templates(apps, schema_editor):
+    """Restore InterfaceTemplates removed by forward migration (for reverse)."""
+    Manufacturer = apps.get_model('dcim', 'Manufacturer')
+    ModuleType = apps.get_model('dcim', 'ModuleType')
+    InterfaceTemplate = apps.get_model('dcim', 'InterfaceTemplate')
+
+    try:
+        generic = Manufacturer.objects.get(name='Generic')
+    except Manufacturer.DoesNotExist:
+        return
+
+    for model_name, iface_type in [
+        ('OSFP-400G-DR4', '400gbase-x-osfp'),
+        ('OSFP-200G-DR4', 'other'),
+    ]:
+        mt = ModuleType.objects.filter(manufacturer=generic, model=model_name).first()
+        if mt is None:
+            continue
+        InterfaceTemplate.objects.get_or_create(
+            module_type=mt,
+            name='port0',
+            defaults={'type': iface_type},
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('netbox_hedgehog', '0048_seed_osfp_transceiver_module_types'),
+        ('dcim', '__latest__'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            remove_osfp_interface_templates,
+            reverse_code=restore_osfp_interface_templates,
+        ),
+    ]

--- a/netbox_hedgehog/test_cases/training_xoc64_1xopg64_mesh_conv_ro_air_2srv.yaml
+++ b/netbox_hedgehog/test_cases/training_xoc64_1xopg64_mesh_conv_ro_air_2srv.yaml
@@ -356,6 +356,21 @@ reference_data:
       logical_ports: 4
       logical_speed: 200
       optic_type: OSFP-800G-4x200G-DR4
+    - id: b_1x25
+      breakout_id: 1x25g
+      from_speed: 25
+      logical_ports: 1
+      logical_speed: 25
+    - id: b_1x10
+      breakout_id: 1x10g
+      from_speed: 10
+      logical_ports: 1
+      logical_speed: 10
+    - id: b_1x1
+      breakout_id: 1x1g
+      from_speed: 1
+      logical_ports: 1
+      logical_speed: 1
 
   module_types:
     - id: nic_xpu_scale_out_8x400
@@ -508,18 +523,21 @@ switch_port_zones:
     zone_name: inb_mgmt_server_25g
     zone_type: server
     port_spec: 1-24
+    breakout_option: b_1x25
     allocation_strategy: sequential
     priority: 10
   - switch_class: oob_leaf
     zone_name: oob_server_1g
     zone_type: oob
     port_spec: 1-48
+    breakout_option: b_1x1
     allocation_strategy: sequential
     priority: 10
   - switch_class: oob_leaf
     zone_name: oob_uplink_10g
     zone_type: oob
     port_spec: 49-56
+    breakout_option: b_1x10
     allocation_strategy: sequential
     priority: 20
 

--- a/netbox_hedgehog/test_cases/training_xoc64_1xopg64_mesh_conv_sh_air_2srv.yaml
+++ b/netbox_hedgehog/test_cases/training_xoc64_1xopg64_mesh_conv_sh_air_2srv.yaml
@@ -356,6 +356,21 @@ reference_data:
       logical_ports: 4
       logical_speed: 200
       optic_type: OSFP-800G-4x200G-DR4
+    - id: b_1x25
+      breakout_id: 1x25g
+      from_speed: 25
+      logical_ports: 1
+      logical_speed: 25
+    - id: b_1x10
+      breakout_id: 1x10g
+      from_speed: 10
+      logical_ports: 1
+      logical_speed: 10
+    - id: b_1x1
+      breakout_id: 1x1g
+      from_speed: 1
+      logical_ports: 1
+      logical_speed: 1
 
   module_types:
     - id: nic_xpu_scale_out_8x400
@@ -510,18 +525,21 @@ switch_port_zones:
     zone_name: inb_mgmt_server_25g
     zone_type: server
     port_spec: 1-24
+    breakout_option: b_1x25
     allocation_strategy: sequential
     priority: 10
   - switch_class: oob_leaf
     zone_name: oob_server_1g
     zone_type: oob
     port_spec: 1-48
+    breakout_option: b_1x1
     allocation_strategy: sequential
     priority: 10
   - switch_class: oob_leaf
     zone_name: oob_uplink_10g
     zone_type: oob
     port_spec: 49-56
+    breakout_option: b_1x10
     allocation_strategy: sequential
     priority: 20
 

--- a/netbox_hedgehog/tests/test_topology_planning/test_osfp_seed.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_osfp_seed.py
@@ -95,20 +95,28 @@ class OSFPTransceiverSeedTestCase(TestCase):
         self.assertEqual(data.get('breakout_topology'), '1x')
 
     # ------------------------------------------------------------------
-    # T4: OSFP-400G-DR4 has one InterfaceTemplate of type 400gbase-x-osfp
+    # T4: OSFP-400G-DR4 has no InterfaceTemplates (transceivers are optics,
+    #     not NICs — they do not add logical interfaces to the parent device)
     # ------------------------------------------------------------------
 
-    def test_osfp_400g_dr4_interface_template(self):
-        """OSFP-400G-DR4 has exactly one InterfaceTemplate: port0 (400gbase-x-osfp)."""
+    def test_osfp_400g_dr4_no_interface_templates(self):
+        """
+        OSFP-400G-DR4 has zero InterfaceTemplates after migration 0049.
+
+        Transceivers are physical optics installed in NIC cage bays. The
+        parent device's interfaces come from the NIC module type, not from
+        the transceiver. Adding interface templates to transceiver ModuleTypes
+        causes duplicate-interface errors when multiple transceivers are
+        installed on the same server (e.g., 8 rails × port0 = 8 collisions).
+        """
         generic = self._get_generic()
         mt = ModuleType.objects.filter(
             manufacturer=generic, model='OSFP-400G-DR4'
         ).first()
         self.assertIsNotNone(mt)
         templates = list(mt.interfacetemplates.all())
-        self.assertEqual(len(templates), 1)
-        self.assertEqual(templates[0].name, 'port0')
-        self.assertEqual(templates[0].type, '400gbase-x-osfp')
+        self.assertEqual(len(templates), 0,
+                         "OSFP-400G-DR4 must have no InterfaceTemplates (migration 0049)")
 
     # ------------------------------------------------------------------
     # T5: OSFP-200G-DR4 exists with correct profile
@@ -151,19 +159,24 @@ class OSFPTransceiverSeedTestCase(TestCase):
         self.assertEqual(data.get('breakout_topology'), '1x')
 
     # ------------------------------------------------------------------
-    # T7: OSFP-200G-DR4 has one InterfaceTemplate
+    # T7: OSFP-200G-DR4 has no InterfaceTemplates (same rationale as T4)
     # ------------------------------------------------------------------
 
-    def test_osfp_200g_dr4_interface_template(self):
-        """OSFP-200G-DR4 has exactly one InterfaceTemplate: port0."""
+    def test_osfp_200g_dr4_no_interface_templates(self):
+        """
+        OSFP-200G-DR4 has zero InterfaceTemplates after migration 0049.
+
+        See T4 for the full rationale. Transceivers do not add logical
+        interfaces to the parent device; the NIC module provides those.
+        """
         generic = self._get_generic()
         mt = ModuleType.objects.filter(
             manufacturer=generic, model='OSFP-200G-DR4'
         ).first()
         self.assertIsNotNone(mt)
         templates = list(mt.interfacetemplates.all())
-        self.assertEqual(len(templates), 1)
-        self.assertEqual(templates[0].name, 'port0')
+        self.assertEqual(len(templates), 0,
+                         "OSFP-200G-DR4 must have no InterfaceTemplates (migration 0049)")
 
     # ------------------------------------------------------------------
     # T8: OSFP-200G-DR4 is NOT QSFP112 (documents resolved intent)


### PR DESCRIPTION
## Summary

- Migration 0049 removes InterfaceTemplates from `OSFP-400G-DR4` and `OSFP-200G-DR4`
- These module types represent pluggable optical transceivers, not NICs; they don't add logical interfaces to the parent device
- The seeded `port0` templates caused `duplicate key value violates unique constraint "dcim_interface_unique_device_name"` errors when multiple transceivers were installed on the same server (e.g., 8 scale-out rails × `port0` on one compute server)
- Also fixes both XOC-64 case files: adds `b_1x25`, `b_1x10`, `b_1x1` breakout options and assigns them to `inb_mgmt_server_25g`, `oob_server_1g`, `oob_uplink_10g` zones that previously had no `breakout_option` (blocked switch quantity calculation)
- Tests T4 and T7 in `test_osfp_seed.py` updated to assert zero InterfaceTemplates

## Verification

- Migration 0049 applied locally; `test_osfp_seed` 9/9 pass
- `generate_devices` for XOC-64 RO plan succeeds: 25 devices, 130 interfaces, 128 cables
- FK verification: 21 total connections, 11 with non-null `transceiver_module_type` (8 scale-out + 3 soc-storage — matches spec)

## Closes

Follow-up fix for hh-netbox-plugin#434 (migration 0048).

🤖 Generated with [Claude Code](https://claude.com/claude-code)