### PR TITLE
[DIET-448] Unify bootstrap and switch inventory seeding

### DIFF
--- a/netbox_hedgehog/__init__.py
+++ b/netbox_hedgehog/__init__.py
@@ -7,6 +7,20 @@ except ModuleNotFoundError:
     PluginConfig = object  # Dummy base class
 
 
+def _seed_reference_data(sender, **kwargs):
+    """
+    Ensure repo-owned reference data exists after migrate.
+
+    Runs the full load_diet_reference_data path, including the bundled
+    Hedgehog switch-profile import.  That import reads only local files
+    (netbox_hedgehog/fabric_profiles/) so it is deterministic, has no
+    external network dependency, and is safe to run on every migrate.
+    """
+    from django.core.management import call_command
+
+    call_command("load_diet_reference_data", verbosity=0)
+
+
 class HedgehogPluginConfig(PluginConfig):
     name = 'netbox_hedgehog'
     verbose_name = 'Hedgehog Fabric Manager'
@@ -26,5 +40,18 @@ class HedgehogPluginConfig(PluginConfig):
         'fabric_status': 60,  # Cache fabric status for 60 seconds
         'crd_schemas': 3600,  # Cache CRD schemas for 1 hour
     }
+
+    def ready(self):
+        from django.db.models.signals import post_migrate
+
+        super_ready = getattr(super(), "ready", None)
+        if callable(super_ready):
+            super_ready()
+
+        post_migrate.connect(
+            _seed_reference_data,
+            sender=self,
+            dispatch_uid="netbox_hedgehog.seed_reference_data",
+        )
 
 config = HedgehogPluginConfig

--- a/netbox_hedgehog/management/commands/load_diet_reference_data.py
+++ b/netbox_hedgehog/management/commands/load_diet_reference_data.py
@@ -24,7 +24,7 @@ from netbox_hedgehog.models.topology_planning import BreakoutOption, DeviceTypeE
 
 
 class Command(BaseCommand):
-    help = 'Load DIET reference data (BreakoutOptions + baseline switch profiles)'
+    help = 'Load DIET reference data (BreakoutOptions, bundled switch profiles, and static DeviceTypes)'
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -44,6 +44,7 @@ class Command(BaseCommand):
             skip=options.get("skip_switch_profile_import", False)
         )
         management_switch_count = self.seed_management_switch_device_types()
+        server_dt_count = self.seed_generic_server_device_types()
 
         self.stdout.write(self.style.SUCCESS(
             f'\nSuccessfully loaded DIET reference data:'
@@ -52,10 +53,13 @@ class Command(BaseCommand):
             f'  - BreakoutOption: {breakout_count} records created/updated'
         ))
         self.stdout.write(self.style.SUCCESS(
-            f'  - Switch profiles imported: {imported_switch_profiles}'
+            f'  - Switch profiles imported (bundled): {imported_switch_profiles}'
         ))
         self.stdout.write(self.style.SUCCESS(
             f'  - Management switch types ensured: {management_switch_count}'
+        ))
+        self.stdout.write(self.style.SUCCESS(
+            f'  - Generic server DeviceTypes ensured: {server_dt_count}'
         ))
 
     @transaction.atomic
@@ -206,10 +210,93 @@ class Command(BaseCommand):
 
         return 1
 
+    @transaction.atomic
+    def seed_generic_server_device_types(self) -> int:
+        """
+        Ensure the three generic planning-time server DeviceTypes exist.
+
+        These DeviceTypes were previously seeded only by seed_diet_device_types
+        (DIET-448).  Moving them here makes load_diet_reference_data the single
+        canonical reset path for all repo-owned DeviceType seeds.
+
+        - GPU-Server-FE:       2×200G frontend NICs
+        - GPU-Server-FE-BE:    2×200G frontend + 8×400G backend NICs
+        - Storage-Server-200G: 2×200G NICs
+        """
+        generic, _ = Manufacturer.objects.get_or_create(
+            name="Generic",
+            defaults={"slug": "generic"},
+        )
+
+        server_specs = [
+            {
+                "model": "GPU-Server-FE",
+                "slug": "gpu-server-fe",
+                "u_height": 2,
+                "comments": "Generic GPU server with 2×200G frontend NICs",
+                "interfaces": [
+                    ("eth1", "200gbase-x-qsfp56"),
+                    ("eth2", "200gbase-x-qsfp56"),
+                ],
+            },
+            {
+                "model": "GPU-Server-FE-BE",
+                "slug": "gpu-server-fe-be",
+                "u_height": 2,
+                "comments": "Generic GPU server with 2×200G frontend + 8×400G backend NICs",
+                "interfaces": [
+                    ("eth1", "200gbase-x-qsfp56"),
+                    ("eth2", "200gbase-x-qsfp56"),
+                    ("cx7-1", "400gbase-x-qsfpdd"),
+                    ("cx7-2", "400gbase-x-qsfpdd"),
+                    ("cx7-3", "400gbase-x-qsfpdd"),
+                    ("cx7-4", "400gbase-x-qsfpdd"),
+                    ("cx7-5", "400gbase-x-qsfpdd"),
+                    ("cx7-6", "400gbase-x-qsfpdd"),
+                    ("cx7-7", "400gbase-x-qsfpdd"),
+                    ("cx7-8", "400gbase-x-qsfpdd"),
+                ],
+            },
+            {
+                "model": "Storage-Server-200G",
+                "slug": "storage-server-200g",
+                "u_height": 2,
+                "comments": "Generic storage server with 2×200G NICs",
+                "interfaces": [
+                    ("eth1", "200gbase-x-qsfp56"),
+                    ("eth2", "200gbase-x-qsfp56"),
+                ],
+            },
+        ]
+
+        total = 0
+        for spec in server_specs:
+            dt, _ = DeviceType.objects.get_or_create(
+                manufacturer=generic,
+                model=spec["model"],
+                defaults={
+                    "slug": spec["slug"],
+                    "u_height": spec["u_height"],
+                    "is_full_depth": True,
+                    "comments": spec["comments"],
+                },
+            )
+            self._ensure_interfaces(dt, spec["interfaces"])
+            total += 1
+
+        return total
+
     def _ensure_interfaces(
         self, device_type: DeviceType, interface_specs: list[tuple[str, str]]
     ) -> None:
-        """Create missing interface templates for a DeviceType."""
+        """
+        Create missing interface templates for a DeviceType.
+
+        Unlike _ensure_module_type(), this helper intentionally does not prune
+        or retype existing templates. It is used for static seeds where we only
+        want to fill obvious gaps without rewriting any local operator
+        customizations on the DeviceType.
+        """
         existing = set(
             InterfaceTemplate.objects.filter(device_type=device_type).values_list("name", flat=True)
         )

--- a/netbox_hedgehog/management/commands/seed_diet_device_types.py
+++ b/netbox_hedgehog/management/commands/seed_diet_device_types.py
@@ -1,15 +1,19 @@
 """
 Management command to seed DIET DeviceTypes and related objects.
 
-This command creates the standard DIET DeviceTypes used for topology planning:
-- DS5000 switch (64x800G)
-- GPU-Server-FE (2x200G frontend)
-- GPU-Server-FE-BE (2x200G frontend + 8x400G backend)
-- Storage-Server-200G (2x200G)
+DEPRECATED for switch seeding (DIET-448).
+Do NOT call this command from bootstrap or reset scripts.
+The canonical Hedgehog switch inventory is now managed entirely by
+load_diet_reference_data (which calls import_fabric_profiles internally).
 
-Each DeviceType includes:
-- InterfaceTemplates
-- DeviceTypeExtension with native_speed, supported_breakouts, etc.
+The DS5000 switch type seeded here (model="DS5000", slug="ds5000") is a
+legacy artifact that differs from the canonical importer output
+(model="celestica-ds5000", slug="celestica-ds5000") and uses the wrong
+interface type (800gbase-x-qsfpdd instead of 800gbase-x-osfp).
+
+The server DeviceTypes below (GPU-Server-FE, GPU-Server-FE-BE,
+Storage-Server-200G) remain available but are also not called from
+any modern bootstrap path.
 
 This command is idempotent - safe to run multiple times.
 
@@ -19,6 +23,7 @@ Usage:
 
 Reference:
     - Issue #124: Define CI testing strategy
+    - Issue #448: Unify bootstrap and switch inventory seeding (deprecation)
     - Based on setup_case_128gpu_odd_ports.py
 """
 

--- a/netbox_hedgehog/management/commands/seed_diet_device_types.py
+++ b/netbox_hedgehog/management/commands/seed_diet_device_types.py
@@ -1,21 +1,23 @@
 """
 Management command to seed DIET DeviceTypes and related objects.
 
-DEPRECATED for switch seeding (DIET-448).
-Do NOT call this command from bootstrap or reset scripts.
-The canonical Hedgehog switch inventory is now managed entirely by
-load_diet_reference_data (which calls import_fabric_profiles internally).
+DEPRECATED (DIET-448) — do NOT call from bootstrap or reset scripts.
 
-The DS5000 switch type seeded here (model="DS5000", slug="ds5000") is a
-legacy artifact that differs from the canonical importer output
-(model="celestica-ds5000", slug="celestica-ds5000") and uses the wrong
-interface type (800gbase-x-qsfpdd instead of 800gbase-x-osfp).
+All DeviceType seeds previously handled by this command are now managed
+by load_diet_reference_data:
+  - Bundled switch profiles (e.g. celestica-ds5000) via import_fabric_profiles
+  - celestica-es1000 management switch via seed_management_switch_device_types
+  - GPU-Server-FE, GPU-Server-FE-BE, Storage-Server-200G via
+    seed_generic_server_device_types (added DIET-448)
 
-The server DeviceTypes below (GPU-Server-FE, GPU-Server-FE-BE,
-Storage-Server-200G) remain available but are also not called from
-any modern bootstrap path.
+The DS5000 switch type still created here (model="DS5000", slug="ds5000")
+is a legacy artifact:
+  - Different model name from the canonical "celestica-ds5000"
+  - Wrong interface type: 800gbase-x-qsfpdd instead of 800gbase-x-osfp
 
-This command is idempotent - safe to run multiple times.
+This command is retained for historical reference and manual use only.
+It is idempotent and safe to run, but is not called from any bootstrap
+or reset path.
 
 Usage:
     docker compose exec netbox python manage.py seed_diet_device_types

--- a/netbox_hedgehog/tests/test_topology_planning/test_reference_data_bootstrap.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_reference_data_bootstrap.py
@@ -1,0 +1,224 @@
+"""
+Regression tests for DIET-448: canonical switch inventory bootstrap.
+
+Verifies that load_diet_reference_data (without --skip-switch-profile-import)
+deterministically produces the correct Hedgehog switch inventory and that
+populate_transceiver_bays can subsequently operate on that inventory.
+
+Gate 1 — canonical bootstrap path is explicit and defendable.
+Gate 2 — no dual-source DS5000 mapping drift remains.
+Gate 3 — seeded-catalog tests are green.
+"""
+
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from dcim.models import DeviceType, InterfaceTemplate, ModuleBayTemplate, ModuleType, ModuleTypeProfile
+
+
+class CanonicalSwitchInventoryTestCase(TestCase):
+    """
+    Gate 1+2: load_diet_reference_data (no --skip flag) must produce the
+    profile-backed celestica-ds5000 DeviceType with correct interface types.
+    """
+
+    def _seed(self):
+        call_command("load_diet_reference_data", stdout=StringIO())
+
+    def test_canonical_ds5000_slug_exists(self):
+        """load_diet_reference_data creates celestica-ds5000 (canonical slug)."""
+        self._seed()
+        self.assertTrue(
+            DeviceType.objects.filter(slug="celestica-ds5000").exists(),
+            "Expected profile-backed DeviceType with slug 'celestica-ds5000'",
+        )
+
+    def test_canonical_ds5000_has_osfp_interface_templates(self):
+        """celestica-ds5000 OSFP ports must be 800gbase-x-osfp, not qsfpdd."""
+        self._seed()
+        dt = DeviceType.objects.get(slug="celestica-ds5000")
+        osfp_templates = InterfaceTemplate.objects.filter(
+            device_type=dt, type="800gbase-x-osfp"
+        )
+        self.assertEqual(
+            osfp_templates.count(),
+            64,
+            "celestica-ds5000 must have exactly 64 OSFP interface templates "
+            "(E1/1–E1/64, type=800gbase-x-osfp)",
+        )
+
+    def test_canonical_ds5000_has_no_qsfpdd_templates(self):
+        """
+        Regression guard (Gate 2): no qsfpdd templates on celestica-ds5000.
+
+        The legacy seed_diet_device_types command hardcoded 800gbase-x-qsfpdd.
+        The canonical import_fabric_profiles path maps OSFP-800G → 800gbase-x-osfp.
+        This test ensures the drift is gone.
+        """
+        self._seed()
+        dt = DeviceType.objects.get(slug="celestica-ds5000")
+        wrong = InterfaceTemplate.objects.filter(
+            device_type=dt, type="800gbase-x-qsfpdd"
+        )
+        self.assertEqual(
+            wrong.count(),
+            0,
+            f"celestica-ds5000 must not have 800gbase-x-qsfpdd templates; "
+            f"found {wrong.count()} wrong-type template(s): "
+            f"{list(wrong.values_list('name', 'type'))}",
+        )
+
+    def test_canonical_ds5000_osfp_port_names(self):
+        """celestica-ds5000 OSFP templates are named E1/1 through E1/64."""
+        self._seed()
+        dt = DeviceType.objects.get(slug="celestica-ds5000")
+        osfp_names = set(
+            InterfaceTemplate.objects.filter(
+                device_type=dt, type="800gbase-x-osfp"
+            ).values_list("name", flat=True)
+        )
+        for n in range(1, 65):
+            self.assertIn(
+                f"E1/{n}",
+                osfp_names,
+                f"Expected OSFP template E1/{n} on celestica-ds5000",
+            )
+
+    def test_canonical_ds5000_is_idempotent(self):
+        """Running load_diet_reference_data twice does not duplicate templates."""
+        self._seed()
+        self._seed()
+        dt = DeviceType.objects.get(slug="celestica-ds5000")
+        osfp_count = InterfaceTemplate.objects.filter(
+            device_type=dt, type="800gbase-x-osfp"
+        ).count()
+        self.assertEqual(
+            osfp_count,
+            64,
+            f"Double-seed must not duplicate templates; expected 64, got {osfp_count}",
+        )
+
+    def test_legacy_ds5000_slug_is_not_created_by_reference_data(self):
+        """
+        The legacy 'ds5000' slug (from seed_diet_device_types) must NOT be
+        created by load_diet_reference_data.  This ensures only one canonical
+        DS5000 model exists after a clean bootstrap.
+        Purge all DeviceTypes first so the test is independent of pre-existing
+        test-DB state (e.g. from previous seed_diet_device_types runs).
+        """
+        DeviceType.objects.all().delete()
+        self._seed()
+        self.assertFalse(
+            DeviceType.objects.filter(slug="ds5000").exists(),
+            "load_diet_reference_data must not create the legacy 'ds5000' slug",
+        )
+
+
+class SwitchBayPopulationTestCase(TestCase):
+    """
+    Gate 3: populate_transceiver_bays works against the seeded DS5000 path.
+    """
+
+    def test_populate_bays_after_seed(self):
+        """
+        After load_diet_reference_data + populate_transceiver_bays,
+        celestica-ds5000 must have 66 ModuleBayTemplates — one per
+        InterfaceTemplate (64 OSFP E1/1–E1/64 + 2 SFP28 E1/65–E1/66).
+        """
+        call_command("load_diet_reference_data", stdout=StringIO())
+        call_command("populate_transceiver_bays", verbosity=0)
+
+        dt = DeviceType.objects.get(slug="celestica-ds5000")
+        bays = ModuleBayTemplate.objects.filter(device_type=dt)
+        self.assertEqual(
+            bays.count(),
+            66,
+            f"celestica-ds5000 must have 66 ModuleBayTemplates after populate "
+            f"(64 OSFP + 2 SFP28); got {bays.count()}",
+        )
+        bay_names = set(bays.values_list("name", flat=True))
+        # Verify all 64 OSFP bays are present (these are the ones used for
+        # transceiver placement in generation)
+        for n in range(1, 65):
+            self.assertIn(
+                f"E1/{n}",
+                bay_names,
+                f"Expected ModuleBayTemplate E1/{n} on celestica-ds5000",
+            )
+        # SFP28 management uplink bays also present
+        self.assertIn("E1/65", bay_names)
+        self.assertIn("E1/66", bay_names)
+
+    def test_populate_bays_is_idempotent(self):
+        """populate_transceiver_bays twice does not create duplicate bays."""
+        call_command("load_diet_reference_data", stdout=StringIO())
+        call_command("populate_transceiver_bays", verbosity=0)
+        call_command("populate_transceiver_bays", verbosity=0)
+
+        dt = DeviceType.objects.get(slug="celestica-ds5000")
+        self.assertEqual(
+            ModuleBayTemplate.objects.filter(device_type=dt).count(),
+            66,
+            "Double populate_transceiver_bays must not duplicate ModuleBayTemplates",
+        )
+
+
+class PurgeAndReseedRoundTripTestCase(TestCase):
+    """
+    Gate 4: purge → reseed recreates the canonical switch inventory.
+
+    Simulates reset_local_dev.sh --purge-inventory followed by
+    load_diet_reference_data.
+    """
+
+    def test_purge_and_reseed_recreates_canonical_ds5000(self):
+        """Purge all inventory, reseed, and verify celestica-ds5000 is correct."""
+        # Initial seed
+        call_command("load_diet_reference_data", stdout=StringIO())
+
+        # Simulate --purge-inventory: delete ModuleType first (FK protected),
+        # then ModuleTypeProfile, then DeviceType / Manufacturer
+        ModuleType.objects.all().delete()
+        ModuleTypeProfile.objects.all().delete()
+        DeviceType.objects.all().delete()
+
+        self.assertFalse(
+            DeviceType.objects.filter(slug="celestica-ds5000").exists(),
+            "Purge should remove celestica-ds5000",
+        )
+
+        # Reseed
+        call_command("load_diet_reference_data", stdout=StringIO())
+
+        dt = DeviceType.objects.filter(slug="celestica-ds5000").first()
+        self.assertIsNotNone(dt, "celestica-ds5000 must be recreated after purge + reseed")
+
+        osfp_count = InterfaceTemplate.objects.filter(
+            device_type=dt, type="800gbase-x-osfp"
+        ).count()
+        self.assertEqual(
+            osfp_count,
+            64,
+            f"Reseeded celestica-ds5000 must have 64 OSFP templates; got {osfp_count}",
+        )
+
+    def test_purge_and_reseed_then_populate_bays(self):
+        """Full round trip: purge → reseed → populate_transceiver_bays."""
+        call_command("load_diet_reference_data", stdout=StringIO())
+
+        ModuleType.objects.all().delete()
+        ModuleTypeProfile.objects.all().delete()
+        DeviceType.objects.all().delete()
+
+        call_command("load_diet_reference_data", stdout=StringIO())
+        call_command("populate_transceiver_bays", verbosity=0)
+
+        dt = DeviceType.objects.get(slug="celestica-ds5000")
+        self.assertEqual(
+            ModuleBayTemplate.objects.filter(device_type=dt).count(),
+            66,
+            "Full purge→reseed→populate round trip must produce 66 bays "
+            "(64 OSFP + 2 SFP28) on celestica-ds5000",
+        )

--- a/netbox_hedgehog/tests/test_topology_planning/test_seed_data.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_seed_data.py
@@ -14,7 +14,7 @@ from django.test import TestCase
 from django.core.management import call_command
 from io import StringIO
 
-from dcim.models import DeviceType, InterfaceTemplate, ModuleType, ModuleTypeProfile
+from dcim.models import DeviceType, InterfaceTemplate
 
 from netbox_hedgehog.models.topology_planning import BreakoutOption, DeviceTypeExtension
 
@@ -156,24 +156,51 @@ class SeedDataCommandTestCase(TestCase):
         call_command('load_diet_reference_data', stdout=StringIO())
         self.assertTrue(DeviceType.objects.filter(model='celestica-es1000').exists())
 
-    def test_command_recreates_network_transceiver_profile_after_inventory_purge(self):
-        """load_diet_reference_data should restore Network Transceiver profile after purge."""
-        # Must delete ModuleTypes before ModuleTypeProfile to avoid ProtectedError
-        # (mirrors what reset_local_dev.sh --purge-inventory does in the container)
-        ModuleType.objects.all().delete()
-        ModuleTypeProfile.objects.all().delete()
+    def test_command_seeds_generic_server_device_types(self):
+        """load_diet_reference_data should ensure all three generic server DeviceTypes exist."""
+        call_command('load_diet_reference_data', stdout=StringIO())
+        for model in ('GPU-Server-FE', 'GPU-Server-FE-BE', 'Storage-Server-200G'):
+            self.assertTrue(
+                DeviceType.objects.filter(model=model).exists(),
+                f"Expected generic server DeviceType '{model}' to be present",
+            )
+
+    def test_generic_server_device_types_have_correct_interfaces(self):
+        """Generic server DeviceTypes should have the expected interface templates."""
+        call_command('load_diet_reference_data', stdout=StringIO())
+
+        fe = DeviceType.objects.get(model='GPU-Server-FE')
+        self.assertEqual(
+            InterfaceTemplate.objects.filter(device_type=fe).count(), 2
+        )
+        self.assertTrue(
+            InterfaceTemplate.objects.filter(
+                device_type=fe, name='eth1', type='200gbase-x-qsfp56'
+            ).exists()
+        )
+
+        fe_be = DeviceType.objects.get(model='GPU-Server-FE-BE')
+        self.assertEqual(
+            InterfaceTemplate.objects.filter(device_type=fe_be).count(), 10
+        )
+        self.assertEqual(
+            InterfaceTemplate.objects.filter(
+                device_type=fe_be, type='400gbase-x-qsfpdd'
+            ).count(), 8
+        )
+
+    def test_generic_server_device_types_recreated_after_purge(self):
+        """Generic server DeviceTypes should be restored after a DeviceType purge."""
+        call_command('load_diet_reference_data', stdout=StringIO())
+        DeviceType.objects.all().delete()
 
         call_command('load_diet_reference_data', stdout=StringIO())
 
-        profile = ModuleTypeProfile.objects.filter(name='Network Transceiver').first()
-        self.assertIsNotNone(profile, "Network Transceiver profile must be recreated")
-        cage_enum = (
-            profile.schema.get('properties', {})
-            .get('cage_type', {})
-            .get('enum', [])
-        )
-        self.assertIn('OSFP', cage_enum)
-        self.assertIn('QSFP56', cage_enum)
+        for model in ('GPU-Server-FE', 'GPU-Server-FE-BE', 'Storage-Server-200G'):
+            self.assertTrue(
+                DeviceType.objects.filter(model=model).exists(),
+                f"'{model}' must be recreated after purge+reseed",
+            )
 
 
 class SeedDataRecordTestCase(TestCase):

--- a/netbox_hedgehog/tests/test_topology_planning/test_seed_data.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_seed_data.py
@@ -14,7 +14,7 @@ from django.test import TestCase
 from django.core.management import call_command
 from io import StringIO
 
-from dcim.models import DeviceType, InterfaceTemplate
+from dcim.models import DeviceType, InterfaceTemplate, ModuleType, ModuleTypeProfile
 
 from netbox_hedgehog.models.topology_planning import BreakoutOption, DeviceTypeExtension
 
@@ -155,6 +155,25 @@ class SeedDataCommandTestCase(TestCase):
 
         call_command('load_diet_reference_data', stdout=StringIO())
         self.assertTrue(DeviceType.objects.filter(model='celestica-es1000').exists())
+
+    def test_command_recreates_network_transceiver_profile_after_inventory_purge(self):
+        """load_diet_reference_data should restore Network Transceiver profile after purge."""
+        # Must delete ModuleTypes before ModuleTypeProfile to avoid ProtectedError
+        # (mirrors what reset_local_dev.sh --purge-inventory does in the container)
+        ModuleType.objects.all().delete()
+        ModuleTypeProfile.objects.all().delete()
+
+        call_command('load_diet_reference_data', stdout=StringIO())
+
+        profile = ModuleTypeProfile.objects.filter(name='Network Transceiver').first()
+        self.assertIsNotNone(profile, "Network Transceiver profile must be recreated")
+        cage_enum = (
+            profile.schema.get('properties', {})
+            .get('cage_type', {})
+            .get('enum', [])
+        )
+        self.assertIn('OSFP', cage_enum)
+        self.assertIn('QSFP56', cage_enum)
 
 
 class SeedDataRecordTestCase(TestCase):

--- a/scripts/reset_local_dev.sh
+++ b/scripts/reset_local_dev.sh
@@ -83,6 +83,5 @@ if [[ "$PURGE_INVENTORY" == "true" ]]; then
 fi
 
 docker compose exec -T netbox python manage.py load_diet_reference_data
-docker compose exec -T netbox python manage.py seed_diet_device_types
 
 echo "Done."


### PR DESCRIPTION
## Summary

Closes #448.

`load_diet_reference_data` is now the **single canonical path** for all repo-owned, locally-bundled DeviceType and reference-data seeds. `seed_diet_device_types` has been retired from bootstrap and reset flows.

### Scope

**What this PR makes canonical** (locally-bundled, no network required):

| Seed | Method in `load_diet_reference_data` |
|------|--------------------------------------|
| BreakoutOptions (14 records) | `load_breakout_options()` — unchanged |
| `celestica-ds5000` switch | `import_bundled_switch_profiles()` — reads `fabric_profiles/p_bcm_celestica_ds5000.go`, the **only** bundled profile file |
| `celestica-es1000` management switch | `seed_management_switch_device_types()` — unchanged |
| `GPU-Server-FE`, `GPU-Server-FE-BE`, `Storage-Server-200G` | `seed_generic_server_device_types()` — **new** (previously only in `seed_diet_device_types`, now won't be lost on reset) |

**What this PR does not change**: importing the full Hedgehog switch catalog (DS3000, DS4000, DS4101, etc.) still requires an explicit `manage.py import_fabric_profiles --fabric-ref <ref>` or `--source-dir` call. That is an intentional, explicit operation that needs a network connection or a local mirror. This PR does not expand the bundled profile set.

### Root cause fixed

`seed_diet_device_types` created `Celestica/DS5000` (slug `ds5000`) with `800gbase-x-qsfpdd` — a different model name and wrong interface type versus the canonical `import_fabric_profiles` output (`celestica-ds5000`, `800gbase-x-osfp`). `reset_local_dev.sh` called both paths, silently producing two divergent DS5000 models. `post_migrate` skipped the switch-profile import entirely.

### What changed

**`netbox_hedgehog/__init__.py`** — Added `_seed_reference_data()` + `ready()`: post-migrate now runs `load_diet_reference_data` without `--skip-switch-profile-import`. Fresh install and every `migrate` seed the canonical DS5000 and server inventory from local files.

**`scripts/reset_local_dev.sh`** — Removed `seed_diet_device_types` call; `load_diet_reference_data` is now sufficient.

**`load_diet_reference_data.py`** — Added `seed_generic_server_device_types()`: idempotent `get_or_create` + `_ensure_interfaces` for the three generic server DeviceTypes (same pattern as `celestica-es1000`). Updated summary output.

**`seed_diet_device_types.py`** — Updated deprecation notice: explicitly lists which seeds moved to `load_diet_reference_data`, explains the legacy `DS5000` slug/interface-type problem, marks the command as manual-use only.

**`test_seed_data.py`** — Added: `test_command_seeds_generic_server_device_types`, `test_generic_server_device_types_have_correct_interfaces`, `test_generic_server_device_types_recreated_after_purge`.

**`test_reference_data_bootstrap.py`** (new) — 10 regression tests: canonical DS5000 slug, OSFP type guard (no qsfpdd), port names, idempotency, legacy slug not created, bay population, purge→reseed round trip.

## Test command run

```bash
cd /home/ubuntu/afewell-hh/netbox-docker
docker compose exec -T netbox python manage.py test \
  netbox_hedgehog.tests.test_topology_planning.test_seed_data \
  netbox_hedgehog.tests.test_topology_planning.test_xoc64_ds5000_bays \
  netbox_hedgehog.tests.test_topology_planning.test_reference_data_bootstrap \
  --keepdb --parallel 2
```

Result: **29 tests, OK**

## Known gaps / explicit non-goals

- Full Hedgehog switch catalog (DS3000, DS4000, etc.) not bundled — explicit `import_fabric_profiles` required
- `opg64_hyperconverged_ds5000.yaml` `celestica-ds5000-leaf` template gap: out of scope per issue Non-Goals (see #446)
- Transceiver UX and rule-engine tickets deferred per issue scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)