### PR TITLE
[DIET-325] Fix import_fabric_profiles duplicate-slug IntegrityError on pre-seeded DeviceTypes

### DIFF
--- a/netbox_hedgehog/management/commands/import_fabric_profiles.py
+++ b/netbox_hedgehog/management/commands/import_fabric_profiles.py
@@ -383,12 +383,22 @@ class Command(BaseCommand):
             defaults={"slug": manufacturer_name.lower()}
         )
 
-        # Get or create device type
-        device_type, device_type_created = DeviceType.objects.get_or_create(
-            manufacturer=manufacturer,
-            model=profile_name,
-            defaults={"slug": profile_name}
-        )
+        # Get or create device type.
+        # Slug-first lookup handles pre-seeded DeviceTypes whose model field uses a
+        # human-readable name (e.g. "Celestica DS1000") rather than the profile slug
+        # ("celestica-ds1000").  Without this, get_or_create(model=profile_name) misses
+        # the existing record and the INSERT hits the unique-slug constraint.
+        device_type = DeviceType.objects.filter(
+            manufacturer=manufacturer, slug=profile_name
+        ).first()
+        if device_type:
+            device_type_created = False
+        else:
+            device_type, device_type_created = DeviceType.objects.get_or_create(
+                manufacturer=manufacturer,
+                model=profile_name,
+                defaults={"slug": profile_name}
+            )
 
         # Create or update extension (only fills empty fields)
         # Check if extension already exists to determine created vs updated

--- a/netbox_hedgehog/tests/test_fabric_import/test_import_command.py
+++ b/netbox_hedgehog/tests/test_fabric_import/test_import_command.py
@@ -274,3 +274,138 @@ class ImportFabricProfilesCommandTestCase(TestCase):
         self.assertIn("Extensions created:", output)
         self.assertIn("Interface templates created:", output)
         self.assertIn("Import Complete", output)
+
+
+class ImportFabricProfilesIdempotencyTestCase(TestCase):
+    """
+    Regression tests for DIET-325: import_fabric_profiles must be idempotent when a
+    logically equivalent DeviceType already exists with a human-readable model name.
+
+    The bug: get_or_create(model=profile_name) misses a pre-seeded DeviceType whose
+    model field is "Celestica DS5000" (human-readable) rather than "celestica-ds5000"
+    (profile slug), then tries to INSERT a duplicate slug and hits a UniqueViolation.
+
+    The fix: slug-first lookup — filter(slug=profile_name).first() before get_or_create.
+    """
+
+    def setUp(self):
+        self.fixtures_dir = Path(__file__).parent / "fixtures"
+        self.manufacturer, _ = Manufacturer.objects.get_or_create(
+            name="Celestica",
+            defaults={"slug": "celestica"},
+        )
+
+    def _pre_seed(self, slug, human_readable_model):
+        """
+        Ensure a DeviceType exists with the given slug and human-readable model,
+        simulating pre-seeded data from a different tool/fixture.
+        Uses update to force the model name even if the record already exists
+        (e.g. seeded by load_diet_reference_data with a different model string).
+        """
+        dt, _ = DeviceType.objects.get_or_create(
+            manufacturer=self.manufacturer,
+            slug=slug,
+            defaults={"model": human_readable_model},
+        )
+        if dt.model != human_readable_model:
+            dt.model = human_readable_model
+            dt.save(update_fields=["model"])
+        return dt
+
+    def test_import_reuses_pre_seeded_device_type_with_human_readable_model(self):
+        """
+        DIET-325 root case: pre-seeded DeviceType with human-readable model and matching
+        slug must be reused without IntegrityError.
+        """
+        dt = self._pre_seed("celestica-ds5000", "Celestica DS5000")
+        original_pk = dt.pk
+
+        out = StringIO()
+        # Must not raise UniqueViolation
+        call_command(
+            "import_fabric_profiles",
+            source_dir=str(self.fixtures_dir),
+            profiles="celestica-ds5000",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        self.assertIn("Import Complete", output)
+        # Original record preserved — no duplicate created
+        self.assertEqual(DeviceType.objects.filter(slug="celestica-ds5000").count(), 1)
+        dt.refresh_from_db()
+        self.assertEqual(dt.pk, original_pk, "Pre-seeded record must be reused, not replaced")
+
+    def test_import_pre_seeded_reports_updated_not_created(self):
+        """Re-using a pre-seeded DeviceType must count as 'updated', not 'created'."""
+        self._pre_seed("celestica-ds5000", "Celestica DS5000")
+
+        out = StringIO()
+        call_command(
+            "import_fabric_profiles",
+            source_dir=str(self.fixtures_dir),
+            profiles="celestica-ds5000",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        self.assertIn("Device types created: 0", output)
+        self.assertIn("Device types updated: 1", output)
+
+    def test_import_is_idempotent_on_repeated_runs(self):
+        """Running import twice must not create duplicates or raise errors."""
+        self._pre_seed("celestica-ds5000", "Celestica DS5000")
+
+        for _ in range(2):
+            out = StringIO()
+            call_command(
+                "import_fabric_profiles",
+                source_dir=str(self.fixtures_dir),
+                profiles="celestica-ds5000",
+                stdout=out,
+            )
+            self.assertIn("Import Complete", out.getvalue())
+
+        self.assertEqual(DeviceType.objects.filter(slug="celestica-ds5000").count(), 1)
+
+    def test_fresh_import_still_creates_correctly(self):
+        """Normal fresh import (no pre-seeded record) must still create the DeviceType."""
+        DeviceType.objects.filter(
+            manufacturer=self.manufacturer, slug="celestica-ds3000"
+        ).delete()
+
+        out = StringIO()
+        call_command(
+            "import_fabric_profiles",
+            source_dir=str(self.fixtures_dir),
+            profiles="celestica-ds3000",
+            stdout=out,
+        )
+
+        self.assertTrue(
+            DeviceType.objects.filter(
+                manufacturer=self.manufacturer, slug="celestica-ds3000"
+            ).exists()
+        )
+        self.assertIn("Device types created: 1", out.getvalue())
+
+    def test_pre_seeded_human_readable_model_name_preserved(self):
+        """
+        The fix must not silently rename a pre-seeded human-readable model.
+        If "Celestica DS5000" was the pre-existing model name, it stays unchanged.
+        """
+        dt = self._pre_seed("celestica-ds5000", "Celestica DS5000")
+
+        out = StringIO()
+        call_command(
+            "import_fabric_profiles",
+            source_dir=str(self.fixtures_dir),
+            profiles="celestica-ds5000",
+            stdout=out,
+        )
+
+        dt.refresh_from_db()
+        self.assertEqual(
+            dt.model, "Celestica DS5000",
+            "Human-readable model name must not be overwritten by profile slug",
+        )


### PR DESCRIPTION
## Summary

Fixes `import_fabric_profiles` failing with a `UniqueViolation` on duplicate slug when a logically equivalent `DeviceType` already exists in inventory with a human-readable model name.

**Root cause:** `_import_profile()` used `get_or_create(model=profile_name)` where `profile_name` is the Hedgehog profile slug (e.g. `celestica-ds1000`). If a `DeviceType` was already seeded with `slug=celestica-ds1000` but `model="Celestica DS1000"`, the lookup missed it, and the subsequent INSERT hit the unique constraint on `(manufacturer, slug)`.

**Fix:** Slug-first lookup — `filter(manufacturer=manufacturer, slug=profile_name).first()` before `get_or_create`. If a match is found by slug, it is reused as-is (no model rename). If not found, original `get_or_create` behavior is preserved for fresh imports.

## Code change

`netbox_hedgehog/management/commands/import_fabric_profiles.py`, `_import_profile()`:

```python
# Before (broken for pre-seeded records):
device_type, device_type_created = DeviceType.objects.get_or_create(
    manufacturer=manufacturer,
    model=profile_name,
    defaults={"slug": profile_name}
)

# After (slug-first, idempotent):
device_type = DeviceType.objects.filter(
    manufacturer=manufacturer, slug=profile_name
).first()
if device_type:
    device_type_created = False
else:
    device_type, device_type_created = DeviceType.objects.get_or_create(
        manufacturer=manufacturer,
        model=profile_name,
        defaults={"slug": profile_name}
    )
```

## Tests

New class `ImportFabricProfilesIdempotencyTestCase` (5 tests):

| Test | Verifies |
|---|---|
| `test_import_reuses_pre_seeded_device_type_with_human_readable_model` | No IntegrityError; same PK reused |
| `test_import_pre_seeded_reports_updated_not_created` | Counted as "updated: 1", not "created: 1" |
| `test_import_is_idempotent_on_repeated_runs` | Two runs, still exactly 1 record |
| `test_fresh_import_still_creates_correctly` | Normal import path unchanged |
| `test_pre_seeded_human_readable_model_name_preserved` | Model field not overwritten by profile slug |

## Test commands run

```bash
# New idempotency tests (5 tests)
docker compose exec -T netbox python manage.py test \
  netbox_hedgehog.tests.test_fabric_import.test_import_command.ImportFabricProfilesIdempotencyTestCase \
  --keepdb
# Ran 5 tests — OK

# Full import command module (15 tests)
docker compose exec -T netbox python manage.py test \
  netbox_hedgehog.tests.test_fabric_import.test_import_command \
  --keepdb
# Ran 15 tests — 3 failures, 1 error (all pre-existing, unrelated to this change)
```

## Pre-existing failures (waiver)

3 failures + 1 error in `ImportFabricProfilesCommandTestCase` are pre-existing DB isolation issues caused by `load_diet_reference_data` seeding device types at test DB setup time. Those tests assert a clean-slate that no longer holds with `--keepdb`. They are not regressions from this PR and are unchanged by this fix.

Closes #325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)