### PR TITLE
[DIET-487] Topology Plan YAML Contract v2 — GREEN implementation

### DIFF
--- a/netbox_hedgehog/management/commands/dump_plan_status.py
+++ b/netbox_hedgehog/management/commands/dump_plan_status.py
@@ -1,0 +1,75 @@
+"""dump_plan_status: write DB-authoritative status block into a YAML case file."""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Write the current DB-authoritative status block into a YAML case file."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--case", dest="case", required=True,
+            help="yaml_case_id to look up the plan",
+        )
+        parser.add_argument(
+            "--file", dest="file", default=None,
+            help="Path to the YAML file to update (required unless --dry-run with no file)",
+        )
+        parser.add_argument(
+            "--dry-run", dest="dry_run", action="store_true", default=False,
+            help="Print the new status block without modifying the file",
+        )
+
+    def handle(self, *args, **options):
+        import yaml
+
+        from netbox_hedgehog.models.topology_planning import GenerationState, TopologyPlan
+
+        case_id = options["case"]
+        file_path = options.get("file")
+        dry_run = options.get("dry_run", False)
+
+        plan = TopologyPlan.objects.filter(
+            custom_field_data__managed_by="yaml",
+            custom_field_data__yaml_case_id=case_id,
+        ).first()
+        if plan is None:
+            raise CommandError(f"No YAML-managed plan found with yaml_case_id='{case_id}'")
+
+        # Build status block from DB
+        try:
+            gs = GenerationState.objects.get(plan=plan)
+            generation_status = {
+                "status": gs.status,
+                "device_count": gs.device_count,
+                "interface_count": gs.interface_count,
+                "cable_count": gs.cable_count,
+                "generated_at": gs.generated_at.isoformat() if gs.generated_at else None,
+            }
+        except GenerationState.DoesNotExist:
+            generation_status = None
+
+        status_block = {"generation": generation_status}
+
+        if dry_run:
+            self.stdout.write(yaml.dump({"status": status_block}, default_flow_style=False))
+            return
+
+        if not file_path:
+            self.stdout.write(yaml.dump({"status": status_block}, default_flow_style=False))
+            return
+
+        with open(file_path) as f:
+            case_data = yaml.safe_load(f)
+
+        if not isinstance(case_data, dict):
+            raise CommandError(f"File '{file_path}' does not contain a YAML mapping")
+
+        case_data["status"] = status_block
+
+        with open(file_path, "w") as f:
+            yaml.dump(case_data, f, default_flow_style=False, allow_unicode=True)
+
+        self.stdout.write(f"Written status for plan '{plan.name}' to '{file_path}'")

--- a/netbox_hedgehog/management/commands/import_fabric_profiles.py
+++ b/netbox_hedgehog/management/commands/import_fabric_profiles.py
@@ -383,12 +383,22 @@ class Command(BaseCommand):
             defaults={"slug": manufacturer_name.lower()}
         )
 
-        # Get or create device type
-        device_type, device_type_created = DeviceType.objects.get_or_create(
-            manufacturer=manufacturer,
-            model=profile_name,
-            defaults={"slug": profile_name}
-        )
+        # Get or create device type.
+        # Slug-first lookup handles pre-seeded DeviceTypes whose model field uses a
+        # human-readable name (e.g. "Celestica DS1000") rather than the profile slug
+        # ("celestica-ds1000").  Without this, get_or_create(model=profile_name) misses
+        # the existing record and the INSERT hits the unique-slug constraint.
+        device_type = DeviceType.objects.filter(
+            manufacturer=manufacturer, slug=profile_name
+        ).first()
+        if device_type:
+            device_type_created = False
+        else:
+            device_type, device_type_created = DeviceType.objects.get_or_create(
+                manufacturer=manufacturer,
+                model=profile_name,
+                defaults={"slug": profile_name}
+            )
 
         # Create or update extension (only fills empty fields)
         # Check if extension already exists to determine created vs updated

--- a/netbox_hedgehog/test_cases/assertions.py
+++ b/netbox_hedgehog/test_cases/assertions.py
@@ -2,12 +2,29 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Any
+
 from netbox_hedgehog.models.topology_planning import (
+    GenerationState,
     PlanServerClass,
     PlanServerConnection,
     PlanSwitchClass,
+    SwitchPortZone,
     TopologyPlan,
 )
+
+
+@dataclass
+class ContractResult:
+    name: str
+    result: str  # "pass", "fail", "skipped"
+    expected: Any = None
+    actual: Any = None
+    message: str = ""
+
+    def __repr__(self):
+        return f"ContractResult({self.name!r}, {self.result!r}, expected={self.expected!r}, actual={self.actual!r})"
 
 
 def planning_counts(plan: TopologyPlan) -> dict:
@@ -18,3 +35,124 @@ def planning_counts(plan: TopologyPlan) -> dict:
         "connections": PlanServerConnection.objects.filter(server_class__plan=plan).count(),
     }
 
+
+def validate_contract(plan: TopologyPlan, contract: dict) -> list[ContractResult]:
+    """
+    Validate a contract dict against live DB state for the given plan.
+
+    Supported contract keys: counts, zones, generation, topology.
+    Returns a list of ContractResult objects.
+    """
+    results: list[ContractResult] = []
+
+    # counts assertions
+    counts_spec = contract.get("counts")
+    if isinstance(counts_spec, dict):
+        actual = planning_counts(plan)
+        for key, expected_val in counts_spec.items():
+            actual_val = actual.get(key)
+            if actual_val == expected_val:
+                results.append(ContractResult(
+                    name=f"counts.{key}", result="pass",
+                    expected=expected_val, actual=actual_val,
+                ))
+            else:
+                results.append(ContractResult(
+                    name=f"counts.{key}", result="fail",
+                    expected=expected_val, actual=actual_val,
+                    message=f"Expected {expected_val}, got {actual_val}",
+                ))
+
+    # zones assertions
+    zones_spec = contract.get("zones")
+    if isinstance(zones_spec, dict):
+        required = zones_spec.get("required", []) or []
+        for entry in required:
+            sc_id = entry.get("switch_class")
+            zone_name = entry.get("zone_name")
+            exists = SwitchPortZone.objects.filter(
+                switch_class__plan=plan,
+                switch_class__switch_class_id=sc_id,
+                zone_name=zone_name,
+            ).exists()
+            name = f"zones.required[{sc_id}/{zone_name}]"
+            if exists:
+                results.append(ContractResult(name=name, result="pass"))
+            else:
+                results.append(ContractResult(
+                    name=name, result="fail",
+                    message=f"Zone '{zone_name}' not found for switch_class '{sc_id}'",
+                ))
+
+    # generation assertions
+    generation_spec = contract.get("generation")
+    if isinstance(generation_spec, dict):
+        try:
+            gs = GenerationState.objects.get(plan=plan)
+        except GenerationState.DoesNotExist:
+            for key in generation_spec:
+                results.append(ContractResult(
+                    name=f"generation.{key}", result="skipped",
+                    message="No GenerationState exists for this plan",
+                ))
+        else:
+            field_map = {
+                "device_count": gs.device_count,
+                "interface_count": gs.interface_count,
+                "cable_count": gs.cable_count,
+            }
+            for key, expected_val in generation_spec.items():
+                actual_val = field_map.get(key)
+                if actual_val == expected_val:
+                    results.append(ContractResult(
+                        name=f"generation.{key}", result="pass",
+                        expected=expected_val, actual=actual_val,
+                    ))
+                else:
+                    results.append(ContractResult(
+                        name=f"generation.{key}", result="fail",
+                        expected=expected_val, actual=actual_val,
+                        message=f"Expected {expected_val}, got {actual_val}",
+                    ))
+
+    # topology assertions
+    topology_spec = contract.get("topology")
+    if isinstance(topology_spec, dict):
+        storage_spec = topology_spec.get("storage")
+        if isinstance(storage_spec, dict):
+            results.extend(_validate_topology_storage(plan, storage_spec))
+
+    return results
+
+
+def _validate_topology_storage(plan: TopologyPlan, storage: dict) -> list[ContractResult]:
+    results: list[ContractResult] = []
+    sc_id = storage.get("switch_class_id")
+    srv_id = storage.get("server_class_id")
+    expected_qty = storage.get("server_quantity")
+
+    if srv_id is not None and expected_qty is not None:
+        try:
+            sc = PlanServerClass.objects.get(plan=plan, server_class_id=srv_id)
+            actual_qty = sc.quantity
+        except PlanServerClass.DoesNotExist:
+            actual_qty = None
+        name = f"topology.storage.server_quantity[{srv_id}]"
+        if actual_qty == expected_qty:
+            results.append(ContractResult(name=name, result="pass",
+                                          expected=expected_qty, actual=actual_qty))
+        else:
+            results.append(ContractResult(name=name, result="fail",
+                                          expected=expected_qty, actual=actual_qty,
+                                          message=f"Expected quantity {expected_qty}, got {actual_qty}"))
+
+    if sc_id is not None:
+        exists = PlanSwitchClass.objects.filter(plan=plan, switch_class_id=sc_id).exists()
+        name = f"topology.storage.switch_class_id[{sc_id}]"
+        if exists:
+            results.append(ContractResult(name=name, result="pass"))
+        else:
+            results.append(ContractResult(name=name, result="fail",
+                                          message=f"Switch class '{sc_id}' not found"))
+
+    return results

--- a/netbox_hedgehog/test_cases/ingest.py
+++ b/netbox_hedgehog/test_cases/ingest.py
@@ -361,6 +361,351 @@ def _delete_plan_graph(plan: TopologyPlan) -> None:
     plan.delete()
 
 
+def _apply_test_fixtures(fixtures: dict) -> None:
+    """Bootstrap test-isolation objects from test_fixtures block (v2 only)."""
+    from dcim.models import InterfaceTemplate
+
+    for mfr_slug in {
+        item.get("manufacturer")
+        for section in (fixtures.get("device_types", []) or [])
+        for item in [section]
+        if item.get("manufacturer")
+    } | {
+        item.get("manufacturer")
+        for item in (fixtures.get("module_types", []) or [])
+        if item.get("manufacturer")
+    }:
+        from dcim.models import Manufacturer
+        Manufacturer.objects.get_or_create(
+            slug=mfr_slug,
+            defaults={"name": mfr_slug},
+        )
+
+    from dcim.models import DeviceType, Manufacturer
+    from netbox_hedgehog.models.topology_planning import DeviceTypeExtension
+
+    for item in fixtures.get("device_types", []) or []:
+        mfr_slug = item["manufacturer"]
+        mfr = Manufacturer.objects.get(slug=mfr_slug)
+        dt, _ = DeviceType.objects.get_or_create(
+            slug=item["slug"],
+            defaults={"manufacturer": mfr, "model": item["model"]},
+        )
+        for tpl in item.get("interface_templates", []) or []:
+            InterfaceTemplate.objects.get_or_create(
+                device_type=dt,
+                name=tpl["name"],
+                defaults={"type": tpl.get("type", "other")},
+            )
+        dte_data = item.get("device_type_extension")
+        if dte_data:
+            DeviceTypeExtension.objects.get_or_create(
+                device_type=dt,
+                defaults={
+                    "hedgehog_roles": dte_data.get("hedgehog_roles", []),
+                    "uplink_ports": dte_data.get("uplink_ports"),
+                    "native_speed": dte_data.get("native_speed"),
+                    "supported_breakouts": dte_data.get("supported_breakouts", []),
+                },
+            )
+
+    from dcim.models import ModuleType, Manufacturer
+    for item in fixtures.get("module_types", []) or []:
+        mfr_slug = item["manufacturer"]
+        mfr = Manufacturer.objects.get(slug=mfr_slug)
+        ModuleType.objects.get_or_create(
+            manufacturer=mfr,
+            model=item["model"],
+        )
+
+    from netbox_hedgehog.models.topology_planning import BreakoutOption
+    for item in fixtures.get("breakout_options", []) or []:
+        BreakoutOption.objects.get_or_create(
+            breakout_id=item["breakout_id"],
+            defaults={
+                "from_speed": item.get("from_speed", 0),
+                "logical_ports": item.get("logical_ports", 1),
+                "logical_speed": item.get("logical_speed", 0),
+            },
+        )
+
+
+def _resolve_v2_switch_refs(spec: dict) -> tuple[dict, dict, list[dict]]:
+    """
+    Resolve slug-based references for v2 switch classes and zones.
+    Returns (switch_type_map, breakout_map, errors).
+    switch_type_map: switch_class_id -> (DeviceTypeExtension, fabric_class)
+    breakout_map: breakout_id_str -> BreakoutOption
+    """
+    from dcim.models import DeviceType
+    from netbox_hedgehog.models.topology_planning import BreakoutOption, DeviceTypeExtension
+
+    errors: list[dict] = []
+    dte_map: dict[str, object] = {}
+
+    for item in spec.get("switch_classes", []) or []:
+        sc_id = item.get("switch_class_id", "?")
+        slug = item.get("device_type")
+        if not slug:
+            continue
+        try:
+            dt = DeviceType.objects.get(slug=slug)
+        except DeviceType.DoesNotExist:
+            errors.append({
+                "severity": "error", "code": "missing_reference",
+                "path": f"spec.switch_classes[{sc_id}].device_type",
+                "message": f"DeviceType with slug '{slug}' not found",
+            })
+            continue
+        try:
+            dte = DeviceTypeExtension.objects.get(device_type=dt)
+        except DeviceTypeExtension.DoesNotExist:
+            errors.append({
+                "severity": "error", "code": "missing_dte",
+                "path": f"spec.switch_classes[{sc_id}].device_type",
+                "message": f"No DeviceTypeExtension for DeviceType '{slug}'",
+            })
+            continue
+        dte_map[sc_id] = dte
+
+    breakout_map: dict[str, object] = {}
+    for item in spec.get("switch_port_zones", []) or []:
+        bo_id = item.get("breakout_option")
+        if not bo_id or bo_id in breakout_map:
+            continue
+        try:
+            bo = BreakoutOption.objects.get(breakout_id=bo_id)
+            breakout_map[bo_id] = bo
+        except BreakoutOption.DoesNotExist:
+            zone_name = item.get("zone_name", "?")
+            errors.append({
+                "severity": "error", "code": "missing_reference",
+                "path": f"spec.switch_port_zones[{zone_name}].breakout_option",
+                "message": f"BreakoutOption with breakout_id '{bo_id}' not found",
+            })
+
+    return dte_map, breakout_map, errors
+
+
+def _resolve_v2_server_refs(spec: dict) -> tuple[dict, dict, list[dict]]:
+    """
+    Resolve slug-based references for v2 server classes and NICs.
+    Returns (server_dt_map, module_type_map, errors).
+    """
+    from dcim.models import DeviceType, Manufacturer, ModuleType
+
+    errors: list[dict] = []
+    server_dt_map: dict[str, object] = {}
+
+    for item in spec.get("server_classes", []) or []:
+        sc_id = item.get("server_class_id", "?")
+        slug = item.get("server_device_type")
+        if not slug:
+            continue
+        try:
+            dt = DeviceType.objects.get(slug=slug)
+            server_dt_map[sc_id] = dt
+        except DeviceType.DoesNotExist:
+            errors.append({
+                "severity": "error", "code": "missing_reference",
+                "path": f"spec.server_classes[{sc_id}].server_device_type",
+                "message": f"DeviceType with slug '{slug}' not found",
+            })
+
+    module_type_map: dict[tuple, object] = {}
+    for item in spec.get("server_nics", []) or []:
+        mt_ref = item.get("module_type")
+        if not isinstance(mt_ref, dict):
+            continue
+        mfr_slug = mt_ref.get("manufacturer")
+        model = mt_ref.get("model")
+        key = (mfr_slug, model)
+        if key in module_type_map:
+            continue
+        try:
+            mfr = Manufacturer.objects.get(slug=mfr_slug)
+        except Manufacturer.DoesNotExist:
+            errors.append({
+                "severity": "error", "code": "missing_reference",
+                "path": f"spec.server_nics.module_type.manufacturer",
+                "message": f"Manufacturer with slug '{mfr_slug}' not found",
+            })
+            continue
+        try:
+            mt = ModuleType.objects.get(manufacturer=mfr, model=model)
+            module_type_map[key] = mt
+        except ModuleType.DoesNotExist:
+            errors.append({
+                "severity": "error", "code": "missing_reference",
+                "path": f"spec.server_nics.module_type",
+                "message": f"ModuleType '{model}' for manufacturer '{mfr_slug}' not found",
+            })
+
+    return server_dt_map, module_type_map, errors
+
+
+@transaction.atomic
+def _apply_v2_case(case: dict, *, clean: bool = False, prune: bool = False) -> TopologyPlan:
+    """Apply a validated v2-format case dict."""
+    from netbox_hedgehog.services._fabric_utils import _legacy_fabric_name_to_class
+
+    metadata = case["metadata"]
+    case_id = metadata["case_id"]
+    spec = case["spec"]
+    plan_cfg = spec.get("plan", {})
+    plan_name = plan_cfg["name"]
+    plan_status = plan_cfg.get("status", "draft")
+    plan_description = plan_cfg.get("description", "")
+
+    # Bootstrap test fixtures before reference resolution
+    fixtures = case.get("test_fixtures")
+    if fixtures:
+        _apply_test_fixtures(fixtures)
+
+    # Resolve all slug-based references; raise on first batch of errors
+    dte_map, breakout_map, sw_errors = _resolve_v2_switch_refs(spec)
+    server_dt_map, module_type_map, srv_errors = _resolve_v2_server_refs(spec)
+    all_errors = sw_errors + srv_errors
+    if all_errors:
+        raise TestCaseValidationError(all_errors)
+
+    owned_plans = list(_owned_case_filter(case_id).order_by("id"))
+    if clean and owned_plans:
+        for old in owned_plans:
+            _delete_plan_graph(old)
+        owned_plans = []
+
+    name_match = TopologyPlan.objects.filter(name=plan_name).first()
+    if name_match and (
+        name_match.custom_field_data.get("managed_by") != "yaml"
+        or name_match.custom_field_data.get("yaml_case_id") != case_id
+    ):
+        raise TestCaseValidationError([{
+            "severity": "error", "code": "ownership_conflict",
+            "path": "spec.plan.name",
+            "message": f"Plan name '{plan_name}' is already used by non-YAML-managed data.",
+        }])
+
+    if owned_plans:
+        plan = owned_plans[0]
+        plan.name = plan_name
+        plan.status = plan_status
+        plan.description = plan_description
+    else:
+        plan = TopologyPlan(name=plan_name, status=plan_status, description=plan_description)
+
+    cf = dict(plan.custom_field_data or {})
+    cf["managed_by"] = "yaml"
+    cf["yaml_case_id"] = case_id
+    plan.custom_field_data = cf
+    plan.save()
+
+    # Upsert switch classes
+    switch_map = {}
+    declared_switch_ids = set()
+    for item in spec.get("switch_classes", []) or []:
+        sc_id = item["switch_class_id"]
+        declared_switch_ids.add(sc_id)
+        dte = dte_map.get(sc_id)
+        fabric_name = item.get("fabric_name", "")
+        fabric_class = item.get("fabric_class") or _legacy_fabric_name_to_class(fabric_name)
+        sw, _ = PlanSwitchClass.objects.update_or_create(
+            plan=plan, switch_class_id=sc_id,
+            defaults={
+                "fabric_name": fabric_name,
+                "fabric_class": fabric_class,
+                "hedgehog_role": item.get("hedgehog_role", ""),
+                "device_type_extension": dte,
+                "uplink_ports_per_switch": item.get("uplink_ports_per_switch"),
+                "mclag_pair": item.get("mclag_pair", False),
+                "override_quantity": item.get("override_quantity"),
+                "topology_mode": item.get("topology_mode", ""),
+                "redundancy_type": item.get("redundancy_type", ""),
+                "redundancy_group": item.get("redundancy_group", ""),
+            },
+        )
+        switch_map[sc_id] = sw
+
+    # Upsert port zones
+    declared_zone_keys = set()
+    for item in spec.get("switch_port_zones", []) or []:
+        sc_id = item["switch_class"]
+        zone_name = item["zone_name"]
+        declared_zone_keys.add((sc_id, zone_name))
+        switch = switch_map.get(sc_id)
+        if not switch:
+            raise TestCaseValidationError([{
+                "severity": "error", "code": "unknown_reference",
+                "path": f"spec.switch_port_zones[{zone_name}].switch_class",
+                "message": f"Unknown switch_class ref '{sc_id}'",
+            }])
+        bo_id = item.get("breakout_option")
+        breakout = breakout_map.get(bo_id) if bo_id else None
+        SwitchPortZone.objects.update_or_create(
+            switch_class=switch, zone_name=zone_name,
+            defaults={
+                "zone_type": item["zone_type"],
+                "port_spec": item.get("port_spec", ""),
+                "breakout_option": breakout,
+                "allocation_strategy": item.get("allocation_strategy", "sequential"),
+                "priority": item.get("priority", 100),
+            },
+        )
+
+    # Build zone_map for connection resolution
+    zone_map = {
+        f"{z.switch_class.switch_class_id}/{z.zone_name}": z
+        for z in SwitchPortZone.objects.filter(
+            switch_class__in=list(switch_map.values())
+        ).select_related("switch_class")
+    }
+
+    # Upsert server classes
+    server_map = {}
+    declared_server_ids = set()
+    for item in spec.get("server_classes", []) or []:
+        sc_id = item["server_class_id"]
+        declared_server_ids.add(sc_id)
+        dt = server_dt_map.get(sc_id)
+        sc, _ = PlanServerClass.objects.update_or_create(
+            plan=plan, server_class_id=sc_id,
+            defaults={
+                "description": item.get("description", ""),
+                "category": item.get("category", ""),
+                "quantity": item.get("quantity", 0),
+                "gpus_per_server": item.get("gpus_per_server", 0),
+                "server_device_type": dt,
+            },
+        )
+        server_map[sc_id] = sc
+
+    # Upsert server NICs
+    nic_map: dict[tuple[str, str], PlanServerNIC] = {}
+    for item in spec.get("server_nics", []) or []:
+        sc_id = item["server_class"]
+        nic_id = item["nic_id"]
+        server = server_map.get(sc_id)
+        if not server:
+            raise TestCaseValidationError([{
+                "severity": "error", "code": "unknown_reference",
+                "path": f"spec.server_nics[{nic_id}].server_class",
+                "message": f"Unknown server_class ref '{sc_id}'",
+            }])
+        mt_ref = item.get("module_type")
+        mt = module_type_map.get((mt_ref.get("manufacturer"), mt_ref.get("model"))) if isinstance(mt_ref, dict) else None
+        nic_obj, _ = PlanServerNIC.objects.update_or_create(
+            server_class=server, nic_id=nic_id,
+            defaults={"module_type": mt, "description": item.get("description", "")},
+        )
+        nic_map[(sc_id, nic_id)] = nic_obj
+
+    if prune and len(owned_plans) > 1:
+        for old in owned_plans[1:]:
+            _delete_plan_graph(old)
+
+    return plan
+
+
 @transaction.atomic
 def apply_case(
     case: dict,
@@ -373,6 +718,10 @@ def apply_case(
     Apply one validated YAML case into DIET planning models.
     """
     case = validate_case_dict(case)
+
+    if case.get("apiVersion") == "diet/v2":
+        return _apply_v2_case(case, clean=clean, prune=prune)
+
     case_id = case["meta"]["case_id"]
     plan_name = case["plan"]["name"]
     plan_status = case["plan"]["status"]

--- a/netbox_hedgehog/test_cases/schema.py
+++ b/netbox_hedgehog/test_cases/schema.py
@@ -10,6 +10,9 @@ from .exceptions import TestCaseValidationError
 CASE_ID_RE = re.compile(r"^[a-z0-9_]+$")
 VALID_PLAN_STATUSES = {"draft", "review", "approved", "exported"}
 
+_V2_API_VERSION = "diet/v2"
+_V2_KIND = "TopologyPlan"
+
 
 def _err(code: str, path: str, message: str, hint: str | None = None) -> dict:
     payload = {
@@ -21,6 +24,116 @@ def _err(code: str, path: str, message: str, hint: str | None = None) -> dict:
     if hint:
         payload["hint"] = hint
     return payload
+
+
+def _validate_v2(data: dict) -> tuple[dict, list[dict]]:
+    """Validate a v2-format case dict. Returns (normalized_data, errors)."""
+    errors: list[dict] = []
+
+    if "reference_data" in data:
+        errors.append(_err("v2_forbidden_key", "reference_data",
+                           "reference_data is not allowed in v2; use test_fixtures or pre-seeded inventory"))
+
+    kind = data.get("kind")
+    if not kind:
+        errors.append(_err("missing_required", "kind", "kind is required in v2"))
+    elif kind != _V2_KIND:
+        errors.append(_err("invalid_value", "kind",
+                           f"kind must be '{_V2_KIND}', got '{kind}'"))
+
+    metadata = data.get("metadata")
+    if not isinstance(metadata, dict):
+        errors.append(_err("missing_required", "metadata", "metadata mapping is required in v2"))
+        metadata = {}
+
+    case_id = metadata.get("case_id")
+    if not isinstance(case_id, str) or not case_id:
+        errors.append(_err("missing_required", "metadata.case_id", "case_id is required"))
+    elif not CASE_ID_RE.match(case_id):
+        errors.append(_err("invalid_format", "metadata.case_id", "case_id must match [a-z0-9_]+"))
+
+    if not isinstance(metadata.get("name"), str) or not metadata.get("name"):
+        errors.append(_err("missing_required", "metadata.name", "name is required"))
+
+    if metadata.get("version") != 2:
+        errors.append(_err("invalid_value", "metadata.version",
+                           f"version must be 2 in a v2 document, got {metadata.get('version')!r}"))
+
+    if metadata.get("managed_by") != "yaml":
+        errors.append(_err("invalid_value", "metadata.managed_by",
+                           "managed_by must be literal 'yaml'"))
+
+    spec = data.get("spec")
+    if not isinstance(spec, dict):
+        errors.append(_err("missing_required", "spec", "spec mapping is required in v2"))
+        spec = {}
+
+    plan = spec.get("plan")
+    if not isinstance(plan, dict):
+        errors.append(_err("invalid_type", "spec.plan", "spec.plan must be a mapping"))
+        plan = {}
+
+    if not isinstance(plan.get("name"), str) or not plan.get("name"):
+        errors.append(_err("missing_required", "spec.plan.name", "spec.plan.name is required"))
+
+    plan_status = plan.get("status")
+    if not isinstance(plan_status, str):
+        errors.append(_err("missing_required", "spec.plan.status", "spec.plan.status is required"))
+    elif plan_status not in VALID_PLAN_STATUSES:
+        errors.append(_err("invalid_enum", "spec.plan.status",
+                           f"status must be one of {sorted(VALID_PLAN_STATUSES)}"))
+
+    for key in ("switch_classes", "server_classes", "server_connections"):
+        if key in spec and not isinstance(spec[key], list):
+            errors.append(_err("invalid_type", f"spec.{key}", f"spec.{key} must be a list"))
+
+    # Validate optional status block
+    status_block = data.get("status")
+    if isinstance(status_block, dict):
+        gen = status_block.get("generation")
+        if isinstance(gen, dict):
+            for field in ("device_count", "interface_count", "cable_count"):
+                val = gen.get(field)
+                if val is not None and not isinstance(val, int):
+                    errors.append(_err("invalid_type", f"status.generation.{field}",
+                                       f"{field} must be an integer"))
+
+    # Validate optional contract block
+    contract_block = data.get("contract")
+    if isinstance(contract_block, dict):
+        errors.extend(_validate_contract_block(contract_block))
+
+    return data, errors
+
+
+def _validate_contract_block(contract: dict) -> list[dict]:
+    errors: list[dict] = []
+
+    counts = contract.get("counts")
+    if isinstance(counts, dict):
+        for k, v in counts.items():
+            if not isinstance(v, int):
+                errors.append(_err("invalid_type", f"contract.counts.{k}",
+                                   f"{k} must be an integer"))
+
+    generation = contract.get("generation")
+    if isinstance(generation, dict):
+        for k, v in generation.items():
+            if not isinstance(v, int):
+                errors.append(_err("invalid_type", f"contract.generation.{k}",
+                                   f"{k} must be an integer"))
+
+    zones = contract.get("zones")
+    if isinstance(zones, dict):
+        required = zones.get("required")
+        if isinstance(required, list):
+            for i, entry in enumerate(required):
+                if isinstance(entry, dict) and "switch_class" not in entry:
+                    errors.append(_err("missing_required",
+                                       f"contract.zones.required[{i}].switch_class",
+                                       "switch_class is required in each zones.required entry"))
+
+    return errors
 
 
 def validate_case_dict(payload: dict) -> dict:
@@ -35,6 +148,14 @@ def validate_case_dict(payload: dict) -> dict:
     if not isinstance(data, dict):
         raise TestCaseValidationError([_err("invalid_type", "<root>", "Case must be a mapping")])
 
+    # Dispatch to v2 validator if apiVersion is set
+    if data.get("apiVersion") == _V2_API_VERSION:
+        data, errors = _validate_v2(data)
+        if errors:
+            raise TestCaseValidationError(errors)
+        return data
+
+    # v1 validation path
     required_top = ["meta", "plan", "switch_classes", "server_classes", "server_connections"]
     for key in required_top:
         if key not in data:
@@ -109,4 +230,3 @@ def validate_case_dict(payload: dict) -> dict:
     if errors:
         raise TestCaseValidationError(errors)
     return data
-

--- a/netbox_hedgehog/tests/test_fabric_import/test_import_command.py
+++ b/netbox_hedgehog/tests/test_fabric_import/test_import_command.py
@@ -274,3 +274,138 @@ class ImportFabricProfilesCommandTestCase(TestCase):
         self.assertIn("Extensions created:", output)
         self.assertIn("Interface templates created:", output)
         self.assertIn("Import Complete", output)
+
+
+class ImportFabricProfilesIdempotencyTestCase(TestCase):
+    """
+    Regression tests for DIET-325: import_fabric_profiles must be idempotent when a
+    logically equivalent DeviceType already exists with a human-readable model name.
+
+    The bug: get_or_create(model=profile_name) misses a pre-seeded DeviceType whose
+    model field is "Celestica DS5000" (human-readable) rather than "celestica-ds5000"
+    (profile slug), then tries to INSERT a duplicate slug and hits a UniqueViolation.
+
+    The fix: slug-first lookup — filter(slug=profile_name).first() before get_or_create.
+    """
+
+    def setUp(self):
+        self.fixtures_dir = Path(__file__).parent / "fixtures"
+        self.manufacturer, _ = Manufacturer.objects.get_or_create(
+            name="Celestica",
+            defaults={"slug": "celestica"},
+        )
+
+    def _pre_seed(self, slug, human_readable_model):
+        """
+        Ensure a DeviceType exists with the given slug and human-readable model,
+        simulating pre-seeded data from a different tool/fixture.
+        Uses update to force the model name even if the record already exists
+        (e.g. seeded by load_diet_reference_data with a different model string).
+        """
+        dt, _ = DeviceType.objects.get_or_create(
+            manufacturer=self.manufacturer,
+            slug=slug,
+            defaults={"model": human_readable_model},
+        )
+        if dt.model != human_readable_model:
+            dt.model = human_readable_model
+            dt.save(update_fields=["model"])
+        return dt
+
+    def test_import_reuses_pre_seeded_device_type_with_human_readable_model(self):
+        """
+        DIET-325 root case: pre-seeded DeviceType with human-readable model and matching
+        slug must be reused without IntegrityError.
+        """
+        dt = self._pre_seed("celestica-ds5000", "Celestica DS5000")
+        original_pk = dt.pk
+
+        out = StringIO()
+        # Must not raise UniqueViolation
+        call_command(
+            "import_fabric_profiles",
+            source_dir=str(self.fixtures_dir),
+            profiles="celestica-ds5000",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        self.assertIn("Import Complete", output)
+        # Original record preserved — no duplicate created
+        self.assertEqual(DeviceType.objects.filter(slug="celestica-ds5000").count(), 1)
+        dt.refresh_from_db()
+        self.assertEqual(dt.pk, original_pk, "Pre-seeded record must be reused, not replaced")
+
+    def test_import_pre_seeded_reports_updated_not_created(self):
+        """Re-using a pre-seeded DeviceType must count as 'updated', not 'created'."""
+        self._pre_seed("celestica-ds5000", "Celestica DS5000")
+
+        out = StringIO()
+        call_command(
+            "import_fabric_profiles",
+            source_dir=str(self.fixtures_dir),
+            profiles="celestica-ds5000",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        self.assertIn("Device types created: 0", output)
+        self.assertIn("Device types updated: 1", output)
+
+    def test_import_is_idempotent_on_repeated_runs(self):
+        """Running import twice must not create duplicates or raise errors."""
+        self._pre_seed("celestica-ds5000", "Celestica DS5000")
+
+        for _ in range(2):
+            out = StringIO()
+            call_command(
+                "import_fabric_profiles",
+                source_dir=str(self.fixtures_dir),
+                profiles="celestica-ds5000",
+                stdout=out,
+            )
+            self.assertIn("Import Complete", out.getvalue())
+
+        self.assertEqual(DeviceType.objects.filter(slug="celestica-ds5000").count(), 1)
+
+    def test_fresh_import_still_creates_correctly(self):
+        """Normal fresh import (no pre-seeded record) must still create the DeviceType."""
+        DeviceType.objects.filter(
+            manufacturer=self.manufacturer, slug="celestica-ds3000"
+        ).delete()
+
+        out = StringIO()
+        call_command(
+            "import_fabric_profiles",
+            source_dir=str(self.fixtures_dir),
+            profiles="celestica-ds3000",
+            stdout=out,
+        )
+
+        self.assertTrue(
+            DeviceType.objects.filter(
+                manufacturer=self.manufacturer, slug="celestica-ds3000"
+            ).exists()
+        )
+        self.assertIn("Device types created: 1", out.getvalue())
+
+    def test_pre_seeded_human_readable_model_name_preserved(self):
+        """
+        The fix must not silently rename a pre-seeded human-readable model.
+        If "Celestica DS5000" was the pre-existing model name, it stays unchanged.
+        """
+        dt = self._pre_seed("celestica-ds5000", "Celestica DS5000")
+
+        out = StringIO()
+        call_command(
+            "import_fabric_profiles",
+            source_dir=str(self.fixtures_dir),
+            profiles="celestica-ds5000",
+            stdout=out,
+        )
+
+        dt.refresh_from_db()
+        self.assertEqual(
+            dt.model, "Celestica DS5000",
+            "Human-readable model name must not be overwritten by profile slug",
+        )

--- a/netbox_hedgehog/tests/test_topology_planning/test_yaml_contract_v2.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_yaml_contract_v2.py
@@ -1,0 +1,763 @@
+"""RED tests — Topology Plan YAML Contract v2 (#486).
+
+Categories:
+  V2SchemaValidationTestCase   — schema gating (apiVersion, kind, metadata, forbidden keys)
+  V2IngestReferenceTestCase    — slug/composite reference resolution + missing-ref errors
+  V2TestFixturesTestCase       — test_fixtures object bootstrap
+  V2StatusSectionTestCase      — status block ignored on ingest, schema-allowed
+  V2ContractSectionTestCase    — contract schema validation + validate_contract assertions
+  V2DumpPlanStatusTestCase     — dump_plan_status command writes status to YAML file
+  V1CompatRegressionTestCase   — v1 YAML still processes correctly (should PASS)
+"""
+from __future__ import annotations
+
+from django.test import TestCase
+
+from netbox_hedgehog.test_cases.exceptions import TestCaseValidationError
+from netbox_hedgehog.test_cases.schema import validate_case_dict
+from netbox_hedgehog.test_cases import ingest
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _v2_base(case_id="v2_test"):
+    return {
+        "apiVersion": "diet/v2",
+        "kind": "TopologyPlan",
+        "metadata": {
+            "case_id": case_id,
+            "name": f"V2 Test {case_id}",
+            "version": 2,
+            "managed_by": "yaml",
+        },
+        "spec": {
+            "plan": {"name": f"Plan {case_id}", "status": "draft"},
+            "switch_classes": [],
+            "server_classes": [],
+            "server_connections": [],
+        },
+    }
+
+
+def _seed_inventory():
+    """Create minimal inventory objects for v2 reference-resolution tests."""
+    from dcim.models import DeviceType, Manufacturer, ModuleType
+    from netbox_hedgehog.models.topology_planning import (
+        BreakoutOption, DeviceTypeExtension,
+    )
+
+    mfr, _ = Manufacturer.objects.get_or_create(
+        slug="v2-test-mfr", defaults={"name": "V2 Test Mfr"}
+    )
+    dt, _ = DeviceType.objects.get_or_create(
+        slug="v2-test-switch",
+        defaults={"manufacturer": mfr, "model": "V2 Test Switch"},
+    )
+    DeviceTypeExtension.objects.get_or_create(
+        device_type=dt,
+        defaults={
+            "hedgehog_roles": ["server-leaf"],
+            "uplink_ports": 8,
+            "supported_breakouts": [],
+            "native_speed": 400,
+        },
+    )
+    srv_dt, _ = DeviceType.objects.get_or_create(
+        slug="v2-test-server",
+        defaults={"manufacturer": mfr, "model": "V2 Test Server"},
+    )
+    bo, _ = BreakoutOption.objects.get_or_create(
+        breakout_id="v2-1x400g",
+        defaults={"from_speed": 400, "logical_ports": 1, "logical_speed": 400},
+    )
+    mt, _ = ModuleType.objects.get_or_create(
+        manufacturer=mfr, model="V2 Test NIC",
+    )
+    return mfr, dt, srv_dt, bo, mt
+
+
+# ---------------------------------------------------------------------------
+# S1: Schema validation
+# ---------------------------------------------------------------------------
+
+class V2SchemaValidationTestCase(TestCase):
+    """T-SV-*: validate_case_dict must handle v2 document shape."""
+
+    def test_v2_valid_minimal_passes_schema(self):
+        # T-P-01 / T-SV-04: well-formed v2 YAML with empty spec lists passes
+        result = validate_case_dict(_v2_base())
+        self.assertIsNotNone(result)
+
+    def test_v2_reference_data_forbidden(self):
+        # T-N-01: reference_data at root in v2 → v2_forbidden_key
+        case = _v2_base()
+        case["reference_data"] = {"manufacturers": []}
+        with self.assertRaises(TestCaseValidationError) as ctx:
+            validate_case_dict(case)
+        codes = [e["code"] for e in ctx.exception.errors]
+        self.assertIn("v2_forbidden_key", codes, codes)
+
+    def test_v2_requires_kind(self):
+        # T-N-08: missing kind → missing_required
+        case = _v2_base()
+        del case["kind"]
+        with self.assertRaises(TestCaseValidationError) as ctx:
+            validate_case_dict(case)
+        codes = [e["code"] for e in ctx.exception.errors]
+        self.assertIn("missing_required", codes, codes)
+
+    def test_v2_kind_must_be_topology_plan(self):
+        case = _v2_base()
+        case["kind"] = "WrongKind"
+        with self.assertRaises(TestCaseValidationError) as ctx:
+            validate_case_dict(case)
+        codes = [e["code"] for e in ctx.exception.errors]
+        self.assertIn("invalid_value", codes, codes)
+
+    def test_v2_metadata_version_must_be_2(self):
+        # T-N-09
+        case = _v2_base()
+        case["metadata"]["version"] = 1
+        with self.assertRaises(TestCaseValidationError) as ctx:
+            validate_case_dict(case)
+        codes = [e["code"] for e in ctx.exception.errors]
+        self.assertIn("invalid_value", codes, codes)
+
+    def test_v2_uses_metadata_not_meta(self):
+        # v2 uses metadata:; meta: alone with apiVersion is invalid
+        case = _v2_base()
+        case["meta"] = case.pop("metadata")
+        with self.assertRaises(TestCaseValidationError) as ctx:
+            validate_case_dict(case)
+        self.assertTrue(len(ctx.exception.errors) > 0)
+
+    def test_v2_spec_required(self):
+        case = _v2_base()
+        del case["spec"]
+        with self.assertRaises(TestCaseValidationError) as ctx:
+            validate_case_dict(case)
+        codes = [e["code"] for e in ctx.exception.errors]
+        self.assertIn("missing_required", codes, codes)
+
+    def test_v2_status_section_allowed_not_required(self):
+        # T-SV-04: status present → no error
+        case = _v2_base()
+        case["status"] = {
+            "calculated_at": "2026-05-04T00:00:00Z",
+            "switch_classes": [],
+            "generation": {"status": "generated", "device_count": 0,
+                           "interface_count": 0, "cable_count": 0,
+                           "generated_at": "2026-05-04T00:01:00Z"},
+        }
+        result = validate_case_dict(case)
+        self.assertIsNotNone(result)
+
+    def test_v2_contract_section_allowed_not_required(self):
+        # T-SV-05: contract present → no error
+        case = _v2_base()
+        case["contract"] = {"counts": {"server_classes": 0, "switch_classes": 0, "connections": 0}}
+        result = validate_case_dict(case)
+        self.assertIsNotNone(result)
+
+    def test_v2_contract_counts_must_be_integers(self):
+        # T-SV-03: non-integer device_count in contract.generation → invalid_type
+        case = _v2_base()
+        case["contract"] = {"generation": {"device_count": "not-an-int"}}
+        with self.assertRaises(TestCaseValidationError) as ctx:
+            validate_case_dict(case)
+        codes = [e["code"] for e in ctx.exception.errors]
+        self.assertIn("invalid_type", codes, codes)
+
+    def test_v2_contract_zones_required_needs_switch_class(self):
+        # T-SV-02: zones.required entry missing switch_class → missing_required
+        case = _v2_base()
+        case["contract"] = {"zones": {"required": [{"zone_name": "x", "zone_type": "server"}]}}
+        with self.assertRaises(TestCaseValidationError) as ctx:
+            validate_case_dict(case)
+        codes = [e["code"] for e in ctx.exception.errors]
+        self.assertIn("missing_required", codes, codes)
+
+    def test_v2_test_fixtures_allowed(self):
+        # T-SV-05: test_fixtures block present → no schema error
+        case = _v2_base()
+        case["test_fixtures"] = {"device_types": []}
+        result = validate_case_dict(case)
+        self.assertIsNotNone(result)
+
+
+# ---------------------------------------------------------------------------
+# S2: v2 ingest — reference resolution
+# ---------------------------------------------------------------------------
+
+class V2IngestReferenceTestCase(TestCase):
+    """T-P-02 to T-P-08, T-N-02 to T-N-07: slug/composite lookup at ingest."""
+
+    def setUp(self):
+        self.mfr, self.dt, self.srv_dt, self.bo, self.mt = _seed_inventory()
+
+    def _case_with_switch(self, device_type_slug=None):
+        case = _v2_base("v2_ingest_sw")
+        case["spec"]["switch_classes"] = [{
+            "switch_class_id": "v2-leaf",
+            "fabric_name": "backend",
+            "fabric_class": "managed",
+            "hedgehog_role": "server-leaf",
+            "device_type": device_type_slug or "v2-test-switch",
+        }]
+        case["spec"]["switch_port_zones"] = [{
+            "switch_class": "v2-leaf",
+            "zone_name": "downlinks",
+            "zone_type": "server",
+            "port_spec": "1-4",
+            "breakout_option": "v2-1x400g",
+        }]
+        return case
+
+    def _case_with_server(self, server_dt_slug=None):
+        case = _v2_base("v2_ingest_srv")
+        case["spec"]["server_classes"] = [{
+            "server_class_id": "v2-gpu",
+            "category": "gpu",
+            "quantity": 2,
+            "server_device_type": server_dt_slug or "v2-test-server",
+        }]
+        return case
+
+    def test_v2_ingest_resolves_device_type_by_slug(self):
+        # T-P-02: device_type slug resolves DeviceType + DeviceTypeExtension
+        from netbox_hedgehog.models.topology_planning import PlanSwitchClass
+        case = self._case_with_switch()
+        plan = ingest.apply_case(case, reference_mode="require")
+        sw = PlanSwitchClass.objects.get(plan=plan, switch_class_id="v2-leaf")
+        self.assertEqual(sw.device_type_extension.device_type.slug, "v2-test-switch")
+
+    def test_v2_ingest_resolves_breakout_option_by_breakout_id(self):
+        # T-P-03
+        from netbox_hedgehog.models.topology_planning import SwitchPortZone
+        case = self._case_with_switch()
+        plan = ingest.apply_case(case, reference_mode="require")
+        zone = SwitchPortZone.objects.get(switch_class__plan=plan, zone_name="downlinks")
+        self.assertEqual(zone.breakout_option.breakout_id, "v2-1x400g")
+
+    def test_v2_ingest_resolves_server_device_type_by_slug(self):
+        # T-P-02 (server side)
+        from netbox_hedgehog.models.topology_planning import PlanServerClass
+        case = self._case_with_server()
+        plan = ingest.apply_case(case, reference_mode="require")
+        sc = PlanServerClass.objects.get(plan=plan, server_class_id="v2-gpu")
+        self.assertEqual(sc.server_device_type.slug, "v2-test-server")
+
+    def test_v2_ingest_resolves_nic_module_type_by_composite(self):
+        # T-P-05: module_type {manufacturer, model} resolves ModuleType
+        from netbox_hedgehog.models.topology_planning import PlanServerNIC
+        case = self._case_with_server()
+        case["spec"]["server_nics"] = [{
+            "server_class": "v2-gpu",
+            "nic_id": "fe",
+            "module_type": {"manufacturer": "v2-test-mfr", "model": "V2 Test NIC"},
+        }]
+        plan = ingest.apply_case(case, reference_mode="require")
+        nic = PlanServerNIC.objects.get(server_class__plan=plan, nic_id="fe")
+        self.assertEqual(nic.module_type.model, "V2 Test NIC")
+
+    def test_v2_ingest_missing_device_type_slug_raises(self):
+        # T-N-02
+        case = self._case_with_switch(device_type_slug="slug-does-not-exist")
+        with self.assertRaises(TestCaseValidationError) as ctx:
+            ingest.apply_case(case, reference_mode="require")
+        codes = [e["code"] for e in ctx.exception.errors]
+        self.assertIn("missing_reference", codes, codes)
+
+    def test_v2_ingest_missing_dte_raises(self):
+        # T-N-03: DeviceType exists but has no DeviceTypeExtension
+        from dcim.models import DeviceType
+        from netbox_hedgehog.models.topology_planning import DeviceTypeExtension
+        no_dte_dt, _ = DeviceType.objects.get_or_create(
+            slug="v2-no-dte-switch",
+            defaults={"manufacturer": self.mfr, "model": "V2 No DTE Switch"},
+        )
+        DeviceTypeExtension.objects.filter(device_type=no_dte_dt).delete()
+        case = self._case_with_switch(device_type_slug="v2-no-dte-switch")
+        with self.assertRaises(TestCaseValidationError) as ctx:
+            ingest.apply_case(case, reference_mode="require")
+        codes = [e["code"] for e in ctx.exception.errors]
+        self.assertIn("missing_dte", codes, codes)
+
+    def test_v2_ingest_missing_breakout_option_raises(self):
+        # T-N-04
+        case = self._case_with_switch()
+        case["spec"]["switch_port_zones"][0]["breakout_option"] = "nonexistent-breakout"
+        with self.assertRaises(TestCaseValidationError) as ctx:
+            ingest.apply_case(case, reference_mode="require")
+        codes = [e["code"] for e in ctx.exception.errors]
+        self.assertIn("missing_reference", codes, codes)
+
+    def test_v2_ingest_missing_server_device_type_raises(self):
+        # T-N-06
+        case = self._case_with_server(server_dt_slug="nonexistent-server-slug")
+        with self.assertRaises(TestCaseValidationError) as ctx:
+            ingest.apply_case(case, reference_mode="require")
+        codes = [e["code"] for e in ctx.exception.errors]
+        self.assertIn("missing_reference", codes, codes)
+
+    def test_v2_ingest_is_idempotent(self):
+        # T-P-08
+        from netbox_hedgehog.models.topology_planning import TopologyPlan
+        case = self._case_with_server()
+        ingest.apply_case(case, reference_mode="require")
+        ingest.apply_case(case, reference_mode="require")
+        self.assertEqual(TopologyPlan.objects.filter(name="Plan v2_ingest_srv").count(), 1)
+
+    def test_v2_status_section_ignored_on_ingest(self):
+        # T-P-06: status present → ignored, ingest succeeds
+        case = _v2_base("v2_status_ignored")
+        case["status"] = {"generation": {"status": "generated", "device_count": 999,
+                                         "interface_count": 0, "cable_count": 0,
+                                         "generated_at": "2026-01-01T00:00:00Z"}}
+        plan = ingest.apply_case(case, reference_mode="require")
+        self.assertIsNotNone(plan)
+
+    def test_v2_contract_section_ignored_on_ingest(self):
+        # T-P-07: contract present → ignored, ingest succeeds
+        case = _v2_base("v2_contract_ignored")
+        case["contract"] = {"counts": {"server_classes": 99}}
+        plan = ingest.apply_case(case, reference_mode="require")
+        self.assertIsNotNone(plan)
+
+
+# ---------------------------------------------------------------------------
+# S3: test_fixtures
+# ---------------------------------------------------------------------------
+
+class V2TestFixturesTestCase(TestCase):
+    """T-P-09 to T-P-11: test_fixtures bootstraps test-isolation objects."""
+
+    def _case_with_fixtures(self):
+        case = _v2_base("v2_fixtures_test")
+        case["test_fixtures"] = {
+            "device_types": [{
+                "slug": "tf-switch-unique",
+                "manufacturer": "tf-mfr",
+                "model": "TF Switch",
+                "interface_templates": [{"name": "E1/1", "type": "800gbase-x-osfp"}],
+                "device_type_extension": {
+                    "hedgehog_roles": ["server-leaf"],
+                    "uplink_ports": 4,
+                    "native_speed": 800,
+                    "supported_breakouts": [],
+                },
+            }],
+            "breakout_options": [{
+                "breakout_id": "tf-1x800g",
+                "from_speed": 800,
+                "logical_ports": 1,
+                "logical_speed": 800,
+            }],
+            "module_types": [{
+                "manufacturer": "tf-mfr",
+                "model": "TF NIC",
+            }],
+        }
+        case["spec"]["switch_classes"] = [{
+            "switch_class_id": "tf-leaf",
+            "fabric_name": "backend",
+            "fabric_class": "managed",
+            "hedgehog_role": "server-leaf",
+            "device_type": "tf-switch-unique",
+        }]
+        return case
+
+    def test_test_fixtures_creates_device_type(self):
+        # T-P-09
+        from dcim.models import DeviceType
+        ingest.apply_case(self._case_with_fixtures(), reference_mode="require")
+        self.assertTrue(DeviceType.objects.filter(slug="tf-switch-unique").exists())
+
+    def test_test_fixtures_creates_device_type_extension(self):
+        # T-P-09 (DTE side)
+        from netbox_hedgehog.models.topology_planning import DeviceTypeExtension
+        ingest.apply_case(self._case_with_fixtures(), reference_mode="require")
+        self.assertTrue(
+            DeviceTypeExtension.objects.filter(device_type__slug="tf-switch-unique").exists()
+        )
+
+    def test_test_fixtures_creates_breakout_option(self):
+        # T-P-10
+        from netbox_hedgehog.models.topology_planning import BreakoutOption
+        ingest.apply_case(self._case_with_fixtures(), reference_mode="require")
+        self.assertTrue(BreakoutOption.objects.filter(breakout_id="tf-1x800g").exists())
+
+    def test_test_fixtures_creates_module_type(self):
+        # T-P-11
+        from dcim.models import ModuleType
+        ingest.apply_case(self._case_with_fixtures(), reference_mode="require")
+        self.assertTrue(ModuleType.objects.filter(model="TF NIC").exists())
+
+    def test_test_fixtures_is_idempotent(self):
+        # T-P-09: get_or_create semantics — second apply does not error
+        ingest.apply_case(self._case_with_fixtures(), reference_mode="require")
+        ingest.apply_case(self._case_with_fixtures(), reference_mode="require")
+
+
+# ---------------------------------------------------------------------------
+# S4: status section
+# ---------------------------------------------------------------------------
+
+class V2StatusSectionTestCase(TestCase):
+    """Status block must be ignored on ingest and schema-validated if present."""
+
+    def test_status_generation_invalid_type_rejected_by_schema(self):
+        # device_count must be integer
+        case = _v2_base("v2_status_schema")
+        case["status"] = {"generation": {"device_count": "bad"}}
+        with self.assertRaises(TestCaseValidationError) as ctx:
+            validate_case_dict(case)
+        codes = [e["code"] for e in ctx.exception.errors]
+        self.assertIn("invalid_type", codes, codes)
+
+    def test_status_not_written_to_db_on_ingest(self):
+        # status.generation.device_count=999 must not affect GenerationState
+        from netbox_hedgehog.models.topology_planning import GenerationState
+        case = _v2_base("v2_status_nodb")
+        case["status"] = {
+            "generation": {"status": "generated", "device_count": 999,
+                           "interface_count": 0, "cable_count": 0,
+                           "generated_at": "2026-01-01T00:00:00Z"}
+        }
+        plan = ingest.apply_case(case, reference_mode="require")
+        self.assertFalse(GenerationState.objects.filter(plan=plan).exists())
+
+
+# ---------------------------------------------------------------------------
+# S5: contract section + validate_contract
+# ---------------------------------------------------------------------------
+
+class V2ContractSectionTestCase(TestCase):
+    """T-VC-*: validate_contract assertions against live DB."""
+
+    def _build_plan_with_counts(self, case_id, num_servers=1, num_switches=1):
+        """Helper: ingest a minimal plan and return it."""
+        from dcim.models import DeviceType, Manufacturer
+        from netbox_hedgehog.models.topology_planning import BreakoutOption, DeviceTypeExtension
+        mfr, _ = Manufacturer.objects.get_or_create(
+            slug="vc-mfr", defaults={"name": "VC Mfr"}
+        )
+        sw_dt, _ = DeviceType.objects.get_or_create(
+            slug="vc-switch", defaults={"manufacturer": mfr, "model": "VC Switch"}
+        )
+        DeviceTypeExtension.objects.get_or_create(
+            device_type=sw_dt,
+            defaults={"hedgehog_roles": ["server-leaf"], "uplink_ports": 4,
+                      "native_speed": 400, "supported_breakouts": []},
+        )
+        srv_dt, _ = DeviceType.objects.get_or_create(
+            slug="vc-server", defaults={"manufacturer": mfr, "model": "VC Server"}
+        )
+        bo, _ = BreakoutOption.objects.get_or_create(
+            breakout_id="vc-1x400g",
+            defaults={"from_speed": 400, "logical_ports": 1, "logical_speed": 400},
+        )
+        case = _v2_base(case_id)
+        case["spec"]["switch_classes"] = [
+            {"switch_class_id": f"vc-leaf-{i}", "fabric_name": "backend",
+             "fabric_class": "managed", "hedgehog_role": "server-leaf",
+             "device_type": "vc-switch"}
+            for i in range(num_switches)
+        ]
+        case["spec"]["server_classes"] = [
+            {"server_class_id": f"vc-gpu-{i}", "category": "gpu",
+             "quantity": 2, "server_device_type": "vc-server"}
+            for i in range(num_servers)
+        ]
+        return ingest.apply_case(case, reference_mode="require")
+
+    def _validate_contract(self, plan, contract_dict):
+        from netbox_hedgehog.test_cases.assertions import validate_contract
+        return validate_contract(plan, contract_dict)
+
+    def test_validate_contract_counts_pass(self):
+        # T-VC-01
+        plan = self._build_plan_with_counts("vc_counts_pass", num_servers=2, num_switches=2)
+        results = self._validate_contract(plan, {"counts": {"server_classes": 2, "switch_classes": 2, "connections": 0}})
+        self.assertTrue(all(r.result == "pass" for r in results), results)
+
+    def test_validate_contract_counts_fail_mismatch(self):
+        # T-VC-N01
+        plan = self._build_plan_with_counts("vc_counts_fail", num_servers=1, num_switches=1)
+        results = self._validate_contract(plan, {"counts": {"server_classes": 99}})
+        failed = [r for r in results if r.result == "fail"]
+        self.assertTrue(len(failed) > 0, "Expected a failure but all passed")
+
+    def test_validate_contract_zones_pass(self):
+        # T-VC-02
+        from netbox_hedgehog.models.topology_planning import BreakoutOption, SwitchPortZone
+        plan = self._build_plan_with_counts("vc_zones_pass", num_switches=1)
+        sw_class = plan.switch_classes.first()
+        bo = BreakoutOption.objects.get(breakout_id="vc-1x400g")
+        SwitchPortZone.objects.get_or_create(
+            switch_class=sw_class, zone_name="downlinks",
+            defaults={"zone_type": "server", "port_spec": "1-4", "breakout_option": bo},
+        )
+        results = self._validate_contract(plan, {
+            "zones": {"required": [{"switch_class": "vc-leaf-0", "zone_name": "downlinks"}]}
+        })
+        self.assertTrue(all(r.result == "pass" for r in results), results)
+
+    def test_validate_contract_zones_fail_missing(self):
+        # T-VC-N02: required zone doesn't exist
+        plan = self._build_plan_with_counts("vc_zones_fail", num_switches=1)
+        results = self._validate_contract(plan, {
+            "zones": {"required": [{"switch_class": "vc-leaf-0", "zone_name": "no-such-zone"}]}
+        })
+        failed = [r for r in results if r.result == "fail"]
+        self.assertTrue(len(failed) > 0, "Expected a failure")
+
+    def test_validate_contract_generation_skipped_when_no_generation_state(self):
+        # T-VC-07: no GenerationState → generation assertions are skipped
+        plan = self._build_plan_with_counts("vc_gen_skip", num_switches=1)
+        results = self._validate_contract(plan, {"generation": {"device_count": 10}})
+        skipped = [r for r in results if r.result == "skipped"]
+        self.assertTrue(len(skipped) > 0, "Expected skipped assertions when no GenerationState")
+
+    def test_validate_contract_generation_fail_mismatch(self):
+        # T-VC-N05: device_count in contract doesn't match GenerationState
+        from netbox_hedgehog.models.topology_planning import GenerationState
+        from netbox_hedgehog.choices import GenerationStatusChoices
+        plan = self._build_plan_with_counts("vc_gen_fail", num_switches=1)
+        GenerationState.objects.create(
+            plan=plan, device_count=5, interface_count=10, cable_count=3,
+            snapshot={}, status=GenerationStatusChoices.GENERATED,
+        )
+        results = self._validate_contract(plan, {"generation": {"device_count": 999}})
+        failed = [r for r in results if r.result == "fail"]
+        self.assertTrue(len(failed) > 0, "Expected failure for device_count mismatch")
+
+    def test_validate_contract_topology_storage_pass(self):
+        # T-VC-04
+        plan = self._build_plan_with_counts("vc_storage_pass", num_servers=1, num_switches=1)
+        results = self._validate_contract(plan, {
+            "topology": {"storage": {
+                "consolidated": True,
+                "switch_class_id": "vc-leaf-0",
+                "server_class_id": "vc-gpu-0",
+                "server_quantity": 2,
+            }}
+        })
+        self.assertTrue(all(r.result == "pass" for r in results), results)
+
+    def test_validate_contract_topology_storage_wrong_quantity(self):
+        # T-VC-N04
+        plan = self._build_plan_with_counts("vc_storage_fail", num_servers=1)
+        results = self._validate_contract(plan, {
+            "topology": {"storage": {
+                "consolidated": True,
+                "switch_class_id": "vc-leaf-0",
+                "server_class_id": "vc-gpu-0",
+                "server_quantity": 999,
+            }}
+        })
+        failed = [r for r in results if r.result == "fail"]
+        self.assertTrue(len(failed) > 0)
+
+
+# ---------------------------------------------------------------------------
+# S6: dump_plan_status command
+# ---------------------------------------------------------------------------
+
+class V2DumpPlanStatusTestCase(TestCase):
+    """T-DS-*: dump_plan_status writes status block to YAML file."""
+
+    def _make_plan_with_state(self, case_id):
+        from dcim.models import DeviceType, Manufacturer
+        from netbox_hedgehog.models.topology_planning import (
+            BreakoutOption, DeviceTypeExtension, GenerationState, TopologyPlan,
+        )
+        from netbox_hedgehog.choices import GenerationStatusChoices
+        mfr, _ = Manufacturer.objects.get_or_create(
+            slug="ds-mfr", defaults={"name": "DS Mfr"}
+        )
+        sw_dt, _ = DeviceType.objects.get_or_create(
+            slug="ds-switch", defaults={"manufacturer": mfr, "model": "DS Switch"}
+        )
+        DeviceTypeExtension.objects.get_or_create(
+            device_type=sw_dt,
+            defaults={"hedgehog_roles": ["server-leaf"], "uplink_ports": 4,
+                      "native_speed": 400, "supported_breakouts": []},
+        )
+        plan = TopologyPlan.objects.create(name=f"DS Plan {case_id}", status="draft")
+        plan.custom_field_data = {"managed_by": "yaml", "yaml_case_id": case_id}
+        plan.save()
+        GenerationState.objects.create(
+            plan=plan, device_count=42, interface_count=100, cable_count=50,
+            snapshot={}, status=GenerationStatusChoices.GENERATED,
+        )
+        return plan
+
+    def _run_command(self, case_id, extra_args=None):
+        from django.core.management import call_command
+        from io import StringIO
+        out = StringIO()
+        args = {"case": case_id, "stdout": out}
+        if extra_args:
+            args.update(extra_args)
+        call_command("dump_plan_status", **args)
+        return out.getvalue()
+
+    def test_dump_plan_status_writes_device_count(self):
+        # T-DS-02
+        import yaml
+        import tempfile, os
+        plan = self._make_plan_with_state("ds_write_test")
+        # Write a minimal v2 YAML to a temp file and point the command at it
+        case_data = _v2_base("ds_write_test")
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            import yaml as _yaml
+            _yaml.dump(case_data, f)
+            tmppath = f.name
+        try:
+            self._run_command("ds_write_test", {"file": tmppath})
+            with open(tmppath) as f:
+                result = yaml.safe_load(f)
+            self.assertEqual(result["status"]["generation"]["device_count"], 42)
+        finally:
+            os.unlink(tmppath)
+
+    def test_dump_plan_status_is_idempotent(self):
+        # T-DS-03: run twice → same result
+        import yaml, tempfile, os
+        plan = self._make_plan_with_state("ds_idem_test")
+        case_data = _v2_base("ds_idem_test")
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            import yaml as _yaml; _yaml.dump(case_data, f)
+            tmppath = f.name
+        try:
+            self._run_command("ds_idem_test", {"file": tmppath})
+            with open(tmppath) as f:
+                first = f.read()
+            self._run_command("ds_idem_test", {"file": tmppath})
+            with open(tmppath) as f:
+                second = f.read()
+            self.assertEqual(first, second)
+        finally:
+            os.unlink(tmppath)
+
+    def test_dump_plan_status_dry_run_does_not_modify_file(self):
+        # T-DS-04
+        import yaml, tempfile, os
+        plan = self._make_plan_with_state("ds_dry_test")
+        case_data = _v2_base("ds_dry_test")
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            import yaml as _yaml; _yaml.dump(case_data, f)
+            tmppath = f.name
+        try:
+            original = open(tmppath).read()
+            self._run_command("ds_dry_test", {"file": tmppath, "dry_run": True})
+            self.assertEqual(original, open(tmppath).read())
+        finally:
+            os.unlink(tmppath)
+
+    def test_dump_plan_status_fails_when_plan_not_found(self):
+        # T-DS-05
+        from django.core.management.base import CommandError
+        with self.assertRaises(CommandError):
+            self._run_command("case_id_does_not_exist")
+
+    def test_dump_plan_status_succeeds_without_generation_state(self):
+        # T-DS-06: no GenerationState → status.generation: null, exit 0
+        import yaml, tempfile, os
+        from netbox_hedgehog.models.topology_planning import TopologyPlan
+        plan = TopologyPlan.objects.create(name="DS NoState Plan", status="draft")
+        plan.custom_field_data = {"managed_by": "yaml", "yaml_case_id": "ds_nostate"}
+        plan.save()
+        case_data = _v2_base("ds_nostate")
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            import yaml as _yaml; _yaml.dump(case_data, f)
+            tmppath = f.name
+        try:
+            self._run_command("ds_nostate", {"file": tmppath})
+            with open(tmppath) as f:
+                result = yaml.safe_load(f)
+            self.assertIsNone(result.get("status", {}).get("generation"))
+        finally:
+            os.unlink(tmppath)
+
+
+# ---------------------------------------------------------------------------
+# S7: v1 compat regression (these should PASS)
+# ---------------------------------------------------------------------------
+
+class V1CompatRegressionTestCase(TestCase):
+    """T-C-*: v1 YAML continues to work unchanged."""
+
+    def _minimal_v1(self, case_id="v1_compat_min"):
+        from dcim.models import DeviceType, Manufacturer
+        from netbox_hedgehog.models.topology_planning import BreakoutOption, DeviceTypeExtension
+        mfr, _ = Manufacturer.objects.get_or_create(
+            slug="v1c-mfr", defaults={"name": "V1C Mfr"}
+        )
+        dt, _ = DeviceType.objects.get_or_create(
+            slug="v1c-switch",
+            defaults={"manufacturer": mfr, "model": "V1C Switch"},
+        )
+        DeviceTypeExtension.objects.get_or_create(
+            device_type=dt,
+            defaults={"hedgehog_roles": ["server-leaf"], "uplink_ports": 4,
+                      "native_speed": 400, "supported_breakouts": []},
+        )
+        BreakoutOption.objects.get_or_create(
+            breakout_id="v1c-1x400g",
+            defaults={"from_speed": 400, "logical_ports": 1, "logical_speed": 400},
+        )
+        return {
+            "meta": {"case_id": case_id, "name": "V1 Compat", "version": 1, "managed_by": "yaml"},
+            "reference_data": {
+                "manufacturers": [{"id": "m1", "name": "V1C Mfr", "slug": "v1c-mfr"}],
+                "device_types": [{"id": "sw1", "manufacturer": "m1", "model": "V1C Switch",
+                                   "slug": "v1c-switch"}],
+                "device_type_extensions": [{"id": "dte1", "device_type": "sw1",
+                                             "uplink_ports": 4, "native_speed": 400,
+                                             "hedgehog_roles": ["server-leaf"],
+                                             "supported_breakouts": []}],
+                "breakout_options": [{"id": "bo1", "breakout_id": "v1c-1x400g",
+                                       "from_speed": 400, "logical_ports": 1, "logical_speed": 400}],
+                "module_types": [],
+            },
+            "plan": {"name": "V1 Compat Plan", "status": "draft"},
+            "switch_classes": [],
+            "server_classes": [],
+            "server_connections": [],
+        }
+
+    def test_v1_yaml_with_reference_data_ingests(self):
+        # T-C-01
+        case = self._minimal_v1()
+        plan = ingest.apply_case(case, reference_mode="ensure")
+        self.assertIsNotNone(plan)
+
+    def test_v1_apply_all_discovers_files(self):
+        # T-C-02: runner.list_case_ids() returns known cases
+        from netbox_hedgehog.test_cases.runner import list_case_ids
+        ids = list_case_ids()
+        self.assertIn("ux_case_128gpu_odd_ports", ids)
+
+    def test_v1_expected_counts_helper_still_works(self):
+        # T-C-03
+        from netbox_hedgehog.tests.test_topology_planning.case_128gpu_helpers import (
+            expected_128gpu_counts,
+        )
+        counts = expected_128gpu_counts()
+        self.assertIn("server_classes", counts)
+        self.assertIsInstance(counts["server_classes"], int)
+
+    def test_v1_contract_helpers_still_work(self):
+        # T-C-04
+        from netbox_hedgehog.tests.test_topology_planning.case_128gpu_helpers import (
+            contract_storage, contract_zones,
+        )
+        storage = contract_storage()
+        self.assertIn("switch_class_id", storage)
+        zones = contract_zones()
+        self.assertIsInstance(zones, list)
+        self.assertGreater(len(zones), 0)


### PR DESCRIPTION
## Problem statement

Topology plan YAML files had no formal separation between four distinct concerns:

- **Intent** (`spec`): what the plan declares
- **Inventory references** (`reference_data` in v1): what objects must exist
- **Derived status** (`status`): machine-generated generation state
- **Regression contract** (`contract`): invariants asserted against live DB

Without this separation, v1 YAML conflated intent and inventory-creation (via `reference_data`), and there was no structured way to assert post-generation counts or topology shape. DIET-482/483/484/485 designed the v2 contract. This PR is the GREEN implementation of the RED suite from #486.

## Scope implemented

Four implementation clusters, each targeted to pass the corresponding RED test group:

### 1. `schema.py` — v2 validation branch
- Dispatches on `apiVersion: diet/v2` before the v1 path; v1 behavior unchanged
- v2 requires `metadata`, `kind: TopologyPlan`, `spec`
- Forbids `reference_data` → error code `v2_forbidden_key`
- `status` and `contract` are optional but type-validated when present:
  - `contract.counts.*` and `contract.generation.*` must be integers → `invalid_type`
  - `contract.zones.required[*]` must have `switch_class` → `missing_required`
  - `status.generation.*` integer fields type-checked

### 2. `ingest.py` — v2 strict path + `test_fixtures`
- `_apply_test_fixtures()`: bootstraps `DeviceType`, `DeviceTypeExtension`, `BreakoutOption`, `ModuleType` from the `test_fixtures` block before reference resolution (idempotent via `get_or_create`)
- `_resolve_v2_switch_refs()`: slug-based `DeviceType` lookup; `DeviceTypeExtension` is **lookup-only** — raises `missing_dte` if absent, never `update_or_create`
- `_resolve_v2_server_refs()`: slug-based server `DeviceType`; composite `{manufacturer, model}` `ModuleType` lookup
- `_apply_v2_case()`: full v2 ingest path — `status` and `contract` sections silently ignored on read, v2 objects resolved by canonical slug/composite identifiers
- v1 path unchanged

### 3. `assertions.validate_contract()`
- `ContractResult` dataclass with `.result` in `{"pass", "fail", "skipped"}`
- Supported contract keys:
  - `counts`: `server_classes`, `switch_classes`, `connections`
  - `zones.required`: each entry asserted to exist in DB
  - `generation`: skipped (not fail) when no `GenerationState` exists; fails on count mismatch
  - `topology.storage`: asserts `switch_class_id` exists and `server_quantity` matches

### 4. `dump_plan_status` management command
- Args: `--case` (required), `--file`, `--dry-run`
- Derives `status.generation` from DB-authoritative `GenerationState`
- Re-serializes full YAML file deterministically (`yaml.dump()`); **does not preserve inline comments** (approved behavior per #485)
- Idempotent: second run produces identical file

## Invariants preserved

| Invariant | Status |
|---|---|
| v1 compat (`meta`, `reference_data`, flat sections) | ✅ unchanged |
| v2 forbids `reference_data` | ✅ `v2_forbidden_key` error |
| `DeviceTypeExtension` lookup-only in v2 | ✅ raises `missing_dte`, never creates |
| `status` ignored on ingest | ✅ silently skipped |
| `contract` distinct from `status` | ✅ separate keys, separate semantics |
| `dump_plan_status` re-serializes full file | ✅ canonical key order |
| No comment preservation in YAML mutation | ✅ uses `yaml.dump()` |
| No free-form `contract.topology` | ✅ only `topology.storage` supported |

## Test results

```
# RED suite (#486)
Ran 47 tests — OK (0 failures, 0 errors)

# Combined regression (RED + seeded catalog + reference data bootstrap + managed fabric export)
Ran 119 tests — OK (0 failures, 0 errors)
```

## Files changed

| File | Change |
|---|---|
| `netbox_hedgehog/test_cases/schema.py` | v2 validation branch |
| `netbox_hedgehog/test_cases/ingest.py` | v2 ingest path + `test_fixtures` |
| `netbox_hedgehog/test_cases/assertions.py` | `validate_contract()` + `ContractResult` |
| `netbox_hedgehog/management/commands/dump_plan_status.py` | new command |

## Related issues

Closes #487 (GREEN implementation)
Closes #486 (RED tests — greened here)
Closes #485 (technical spec — approved design gate)
Closes #484 (architecture — approved design gate)
Closes #483 (research — approved design gate)
Closes #482 (epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)