### PR TITLE
[DIET-541] Prepare v0.2.0 release polish

### DIFF
--- a/netbox_hedgehog/__init__.py
+++ b/netbox_hedgehog/__init__.py
@@ -25,7 +25,7 @@ class HedgehogPluginConfig(PluginConfig):
     name = 'netbox_hedgehog'
     verbose_name = 'Hedgehog Fabric Manager'
     description = 'Manage Hedgehog fabric CRDs with self-service catalog'
-    version = '0.1.0'
+    version = '0.2.0'
     author = 'Hedgehog'
     author_email = 'support@hedgehog.cloud'
     base_url = 'hedgehog'

--- a/netbox_hedgehog/services/bom_export.py
+++ b/netbox_hedgehog/services/bom_export.py
@@ -214,7 +214,7 @@ def _aggregate_base_devices(plan) -> tuple:
 def render_bom_csv(bom: PlanBOM) -> str:
     """Return a CSV string for the given BOM, including the suppressed-count footer.
 
-    Field order: section, module_type_model, hedgehog_class, manufacturer, quantity,
+    Field order: section, module_type_model, module_type_description, hedgehog_class, manufacturer, quantity,
                  cage_type, medium, connector, standard, ...transceiver cols..., is_cable_assembly
     Base-device rows are prepended before module rows.
     Footer: # suppressed_switch_cable_assembly_count,N
@@ -224,7 +224,7 @@ def render_bom_csv(bom: PlanBOM) -> str:
 
     buf = io.StringIO()
     fieldnames = [
-        'section', 'module_type_model', 'hedgehog_class', 'manufacturer', 'quantity',
+        'section', 'module_type_model', 'module_type_description', 'hedgehog_class', 'manufacturer', 'quantity',
         'cage_type', 'medium', 'connector', 'standard',
         'reach_class', 'wavelength_nm', 'host_lane_count', 'host_serdes_gbps_per_lane',
         'optical_lane_pattern', 'gearbox_present', 'cable_assembly_type', 'breakout_topology',
@@ -236,6 +236,7 @@ def render_bom_csv(bom: PlanBOM) -> str:
         writer.writerow({
             'section': item.section,
             'module_type_model': item.device_type_model,
+            'module_type_description': '',
             'hedgehog_class': item.hedgehog_class,
             'manufacturer': item.manufacturer_name,
             'quantity': item.quantity,
@@ -249,6 +250,7 @@ def render_bom_csv(bom: PlanBOM) -> str:
         writer.writerow({
             'section': item.section,
             'module_type_model': item.module_type_model,
+            'module_type_description': item.module_type_description,
             'hedgehog_class': '',
             'manufacturer': item.manufacturer,
             'quantity': item.quantity,

--- a/netbox_hedgehog/templates/netbox_hedgehog/topologyplan.html
+++ b/netbox_hedgehog/templates/netbox_hedgehog/topologyplan.html
@@ -235,24 +235,6 @@
                         <i class="mdi mdi-download"></i> Download BOM (CSV)
                     </button>
                 {% endif %}
-                {% if object.generation_state and object.generation_state.status == 'generated' %}
-                    <a href="{% url 'plugins:netbox_hedgehog:topologyplan_bom_per_device_csv' pk=object.pk %}" class="btn btn-info">
-                        <i class="mdi mdi-download"></i> Download Per-Device BOM (CSV)
-                    </a>
-                {% else %}
-                    <button class="btn btn-secondary" disabled title="Device generation must be completed before downloading BOM">
-                        <i class="mdi mdi-download"></i> Download Per-Device BOM (CSV)
-                    </button>
-                {% endif %}
-                {% if object.generation_state and object.generation_state.status == 'generated' %}
-                    <a href="{% url 'plugins:netbox_hedgehog:topologyplan_bom_comparison_csv' pk=object.pk %}" class="btn btn-info">
-                        <i class="mdi mdi-download"></i> Download Comparison CSV
-                    </a>
-                {% else %}
-                    <button class="btn btn-secondary" disabled title="Device generation must be completed before downloading comparison">
-                        <i class="mdi mdi-download"></i> Download Comparison CSV
-                    </button>
-                {% endif %}
             </div>
         </div>
     </div>

--- a/netbox_hedgehog/tests/test_topology_planning/test_bom_export.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_bom_export.py
@@ -494,7 +494,7 @@ class BOMExportCommandTestCase(_BOMFixtureMixin, TestCase):
             reader = csv.DictReader(f)
             fieldnames = reader.fieldnames
         expected = [
-            'section', 'module_type_model', 'hedgehog_class', 'manufacturer', 'quantity',
+            'section', 'module_type_model', 'module_type_description', 'hedgehog_class', 'manufacturer', 'quantity',
             'cage_type', 'medium', 'connector', 'standard',
             'reach_class', 'wavelength_nm', 'host_lane_count', 'host_serdes_gbps_per_lane',
             'optical_lane_pattern', 'gearbox_present', 'cable_assembly_type', 'breakout_topology',
@@ -513,6 +513,17 @@ class BOMExportCommandTestCase(_BOMFixtureMixin, TestCase):
         nic_rows = [r for r in rows if r['section'] == 'nic']
         self.assertGreater(len(nic_rows), 0)
         self.assertEqual(nic_rows[0]['module_type_model'], self.nic_mt.model)
+        self.assertEqual(nic_rows[0]['module_type_description'], '')
+
+    def test_csv_format_includes_module_type_description_when_present(self):
+        self.nic_mt.description = 'BOM CSV description'
+        self.nic_mt.save(update_fields=['description'])
+        path = self._out_path('bom-desc.csv')
+        call_command('export_plan_bom', str(self.plan.pk), '--output', path, '--format', 'csv')
+        with open(path, newline='') as f:
+            rows = [r for r in csv.DictReader(f) if not r['section'].startswith('#')]
+        nic_rows = [r for r in rows if r['section'] == 'nic']
+        self.assertEqual(nic_rows[0]['module_type_description'], 'BOM CSV description')
 
     # T28
     def test_csv_suppressed_count_footer(self):

--- a/netbox_hedgehog/tests/test_topology_planning/test_bom_per_device_ui.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_bom_per_device_ui.py
@@ -322,35 +322,35 @@ class BOMPerDeviceRBACTestCase(_BOMPerDeviceUIFixtureMixin, TestCase):
 # ---------------------------------------------------------------------------
 
 class BOMPerDeviceButtonTestCase(_BOMPerDeviceUIFixtureMixin, TestCase):
-    """Tests that the per-device download button appears correctly on the plan detail page."""
+    """Top action bar should not expose the per-device download button."""
 
     def setUp(self):
         self.client = Client()
         self.client.login(username='bom-pd-admin', password='testpass123')
 
     # U12
-    def test_u12_per_device_button_active_when_generated(self):
-        """U12: 'Download Per-Device BOM (CSV)' button is an active <a> link when GENERATED."""
+    def test_u12_per_device_button_absent_when_generated(self):
+        """U12: 'Download Per-Device BOM (CSV)' is absent from the top action bar when GENERATED."""
         plan = self._make_generated_plan('U12-pd-btn')
         response = self.client.get(_detail_url(plan.pk))
         self.assertEqual(response.status_code, 200)
         content = response.content.decode()
-        self.assertIn(_PER_DEVICE_BUTTON_TEXT, content,
-                      f"'{_PER_DEVICE_BUTTON_TEXT}' must be present when GENERATED")
-        self.assertIn(_PER_DEVICE_CSV_FILENAME_FRAGMENT, content,
-                      f"'{_PER_DEVICE_CSV_FILENAME_FRAGMENT}' must appear in active button href")
+        self.assertNotIn(_PER_DEVICE_BUTTON_TEXT, content,
+                         f"'{_PER_DEVICE_BUTTON_TEXT}' must not be shown in the top action bar")
+        self.assertNotIn(_PER_DEVICE_CSV_FILENAME_FRAGMENT, content,
+                         f"'{_PER_DEVICE_CSV_FILENAME_FRAGMENT}' must not appear in the detail page action links")
 
     # U13
-    def test_u13_per_device_button_disabled_when_not_generated(self):
-        """U13: 'Download Per-Device BOM (CSV)' button is disabled when not GENERATED."""
+    def test_u13_per_device_button_absent_when_not_generated(self):
+        """U13: 'Download Per-Device BOM (CSV)' is absent from the top action bar when not GENERATED."""
         plan = self._make_plan_with_status('U13-pd-disabled', GenerationStatusChoices.FAILED)
         response = self.client.get(_detail_url(plan.pk))
         self.assertEqual(response.status_code, 200)
         content = response.content.decode()
-        self.assertIn(_PER_DEVICE_BUTTON_TEXT, content,
-                      f"'{_PER_DEVICE_BUTTON_TEXT}' must still appear (disabled) when not GENERATED")
-        self.assertIn('disabled', content,
-                      "Button must have disabled attribute when status is not GENERATED")
+        self.assertNotIn(_PER_DEVICE_BUTTON_TEXT, content,
+                         f"'{_PER_DEVICE_BUTTON_TEXT}' must not be shown when not GENERATED")
+        self.assertNotIn(_PER_DEVICE_CSV_FILENAME_FRAGMENT, content,
+                         f"'{_PER_DEVICE_CSV_FILENAME_FRAGMENT}' must not appear when not GENERATED")
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_hedgehog/tests/test_topology_planning/test_bom_ui.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_bom_ui.py
@@ -340,7 +340,7 @@ class BOMCSVEndpointTestCase(_BOMUIFixtureMixin, TestCase):
             line for line in content.splitlines() if line.strip()
         )
         expected_header = (
-            'section,module_type_model,hedgehog_class,manufacturer,quantity,'
+            'section,module_type_model,module_type_description,hedgehog_class,manufacturer,quantity,'
             'cage_type,medium,connector,standard,'
             'reach_class,wavelength_nm,host_lane_count,host_serdes_gbps_per_lane,'
             'optical_lane_pattern,gearbox_present,cable_assembly_type,breakout_topology,'
@@ -367,6 +367,25 @@ class BOMCSVEndpointTestCase(_BOMUIFixtureMixin, TestCase):
         nic_rows = [r for r in rows if r.get('section') == 'nic']
         self.assertGreater(len(nic_rows), 0,
                            "CSV must contain at least one row with section='nic'")
+
+    def test_t13b_csv_body_contains_module_description_when_present(self):
+        """T13b: CSV body includes module_type_description for module rows when present."""
+        self.nic_mt.description = 'Built-in/native RJ45 port placeholder - no transceiver needed'
+        self.nic_mt.save(update_fields=['description'])
+        plan = self._make_generated_plan('T13b-csv-desc')
+        self._add_nic_module(plan)
+        response = self.client.get(self._csv_url(plan.pk))
+        self.assertEqual(response.status_code, 200)
+        data_lines = [
+            line for line in response.content.decode('utf-8').splitlines()
+            if line.strip() and not line.startswith('#')
+        ]
+        rows = list(csv.DictReader(iter(data_lines)))
+        nic_rows = [r for r in rows if r.get('section') == 'nic']
+        self.assertEqual(
+            nic_rows[0].get('module_type_description'),
+            'Built-in/native RJ45 port placeholder - no transceiver needed',
+        )
 
     # T14 — 400 when no GenerationState
     def test_t14_csv_returns_400_when_no_generation_state(self):
@@ -657,7 +676,7 @@ class BOMBaseDeviceCSVTestCase(_BOMUIFixtureMixin, TestCase):
         content = response.content.decode('utf-8')
         first_line = next(line for line in content.splitlines() if line.strip())
         expected_header = (
-            'section,module_type_model,hedgehog_class,manufacturer,quantity,'
+            'section,module_type_model,module_type_description,hedgehog_class,manufacturer,quantity,'
             'cage_type,medium,connector,standard,'
             'reach_class,wavelength_nm,host_lane_count,host_serdes_gbps_per_lane,'
             'optical_lane_pattern,gearbox_present,cable_assembly_type,breakout_topology,'

--- a/netbox_hedgehog/tests/test_topology_planning/test_managed_fabric_export.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_managed_fabric_export.py
@@ -4,6 +4,8 @@ Integration and unit tests for managed-fabric export scoping (DIET-192 Phase 4 R
 All tests in this file are expected to FAIL until Phase 5 (GREEN) is implemented.
 """
 
+import io
+import zipfile
 import yaml
 from django.test import TestCase, Client
 from django.urls import reverse
@@ -126,14 +128,7 @@ class ManagedFabricTestBase(TestCase):
             },
         )
 
-        cls.breakout_1x800, _ = BreakoutOption.objects.get_or_create(
-            breakout_id='mf-1x800g',
-            defaults={
-                'from_speed': 800,
-                'logical_ports': 1,
-                'logical_speed': 800,
-            },
-        )
+        cls.breakout_1x800 = BreakoutOption.objects.get(breakout_id='1x800g')
 
         # Use slug='server' so _generate_servers() (which filters role__slug='server') finds them.
         cls.server_role, _ = DeviceRole.objects.get_or_create(
@@ -242,12 +237,80 @@ class ManagedFabricTestBase(TestCase):
         self.assertEqual(response.status_code, 200)
         return [d for d in yaml.safe_load_all(response.content.decode()) if d]
 
+    @staticmethod
+    def _yaml_docs(content_bytes):
+        return [d for d in yaml.safe_load_all(content_bytes.decode()) if d]
+
     def _anchor_cable(self, plan, switch, suffix='anc'):
         """Add a minimal server+cable so the export view passes the cables-exist check."""
         server = self._make_server_device(plan, f'{switch.name}-{suffix}-srv')
         sw_iface = self._make_interface(switch, f'E1/1/{suffix}')
         srv_iface = self._make_interface(server, f'eth-{suffix}')
         return self._make_cable(plan, srv_iface, sw_iface)
+
+
+class TestManagedFabricExportDownloads(ManagedFabricTestBase):
+    """Export view must return dedicated artifacts per managed fabric."""
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def test_multi_fabric_export_downloads_zip_with_one_yaml_per_fabric(self):
+        plan = self._make_plan_with_generation_state('MF Zip Export Plan')
+        fe = self._make_switch_device(plan, 'fe-leaf-zip-01', 'frontend', 'server-leaf')
+        be = self._make_switch_device(plan, 'be-leaf-zip-01', 'backend', 'server-leaf')
+        self._anchor_cable(plan, fe, suffix='fe')
+        self._anchor_cable(plan, be, suffix='be')
+
+        response = self.client.get(self._export_url(plan))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/zip')
+        self.assertIn('mf-zip-export-plan-by-fabric.zip', response['Content-Disposition'])
+
+        archive = zipfile.ZipFile(io.BytesIO(response.content))
+        names = sorted(archive.namelist())
+        self.assertEqual(
+            names,
+            ['mf-zip-export-plan-backend.yaml', 'mf-zip-export-plan-frontend.yaml'],
+        )
+
+        fe_docs = self._yaml_docs(archive.read('mf-zip-export-plan-frontend.yaml'))
+        be_docs = self._yaml_docs(archive.read('mf-zip-export-plan-backend.yaml'))
+
+        fe_switches = {
+            doc['metadata']['name']
+            for doc in fe_docs
+            if doc.get('kind') == 'Switch'
+        }
+        be_switches = {
+            doc['metadata']['name']
+            for doc in be_docs
+            if doc.get('kind') == 'Switch'
+        }
+
+        self.assertIn('fe-leaf-zip-01', fe_switches)
+        self.assertNotIn('be-leaf-zip-01', fe_switches)
+        self.assertIn('be-leaf-zip-01', be_switches)
+        self.assertNotIn('fe-leaf-zip-01', be_switches)
+
+    def test_single_managed_fabric_export_downloads_dedicated_yaml(self):
+        plan = self._make_plan_with_generation_state('Single Fabric Export Plan')
+        fe = self._make_switch_device(plan, 'fe-leaf-yaml-01', 'frontend', 'server-leaf')
+        self._anchor_cable(plan, fe, suffix='only')
+
+        response = self.client.get(self._export_url(plan))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'text/yaml; charset=utf-8')
+        self.assertIn('single-fabric-export-plan-frontend.yaml', response['Content-Disposition'])
+
+        docs = self._yaml_docs(response.content)
+        switches = {
+            doc['metadata']['name']
+            for doc in docs
+            if doc.get('kind') == 'Switch'
+        }
+        self.assertEqual(switches, {'fe-leaf-yaml-01'})
 
 
 # =============================================================================

--- a/netbox_hedgehog/views/topology_planning.py
+++ b/netbox_hedgehog/views/topology_planning.py
@@ -3,8 +3,10 @@ Topology Planning Views (DIET Module)
 CRUD views for BreakoutOption, DeviceTypeExtension, and Topology Plan models.
 """
 
+import io
 import logging
 import re
+import zipfile
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
@@ -20,7 +22,7 @@ from netbox.views import generic
 from .. import models, tables, forms, choices
 from ..services.device_generator import DeviceGenerator
 from ..utils.topology_calculations import update_plan_calculations
-from ..services.yaml_generator import generate_yaml_for_plan
+from ..services.yaml_generator import YAMLGenerator, generate_yaml_for_plan
 from ..jobs.device_generation import DeviceGenerationJob
 from ..services.preflight import check_transceiver_bay_readiness, user_message
 
@@ -625,6 +627,12 @@ class TopologyPlanExportView(PermissionRequiredMixin, View):
     permission_required = 'netbox_hedgehog.change_topologyplan'
     raise_exception = True
 
+    @staticmethod
+    def _export_filename_base(plan):
+        filename = re.sub(r'[^a-z0-9-]', '-', plan.name.lower())
+        filename = re.sub(r'-+', '-', filename)
+        return filename.strip('-') or f'plan-{plan.pk}'
+
     def get(self, request, pk):
         """Handle export GET request with precondition validation (DIET-139)"""
         _require_topologyplan_change_permission(request)
@@ -670,26 +678,46 @@ class TopologyPlanExportView(PermissionRequiredMixin, View):
             )
 
         # ===== GENERATE YAML FROM INVENTORY (DIET-139) =====
-        # Do NOT call update_plan_calculations - export is read-only
-
-        # Generate YAML from NetBox inventory (not from plan allocation)
+        # Do NOT call update_plan_calculations - export is read-only.
+        # Multi-fabric managed plans should download one artifact per fabric.
         try:
-            yaml_content = generate_yaml_for_plan(plan)
+            generator = YAMLGenerator(plan)
+            managed_fabrics = (
+                generator._managed_fabric_names_from_inventory()
+                or generator._managed_fabric_names_from_plan()
+            )
+            filename_base = self._export_filename_base(plan)
+
+            if len(managed_fabrics) > 1:
+                archive_buffer = io.BytesIO()
+                with zipfile.ZipFile(archive_buffer, mode='w', compression=zipfile.ZIP_DEFLATED) as archive:
+                    for fabric in managed_fabrics:
+                        yaml_content = generate_yaml_for_plan(plan, fabric=fabric)
+                        archive.writestr(f"{filename_base}-{fabric}.yaml", yaml_content)
+
+                response = HttpResponse(
+                    archive_buffer.getvalue(),
+                    content_type='application/zip',
+                )
+                response['Content-Disposition'] = (
+                    f'attachment; filename="{filename_base}-by-fabric.zip"'
+                )
+                return response
+
+            if len(managed_fabrics) == 1:
+                fabric = managed_fabrics[0]
+                yaml_content = generate_yaml_for_plan(plan, fabric=fabric)
+                filename = f"{filename_base}-{fabric}.yaml"
+            else:
+                yaml_content = generate_yaml_for_plan(plan)
+                filename = f"{filename_base}.yaml"
         except Exception as e:
             return HttpResponseBadRequest(
                 f"YAML generation failed: {str(e)}"
             )
 
-        # Create filename from plan name (sanitize for filesystem)
-        filename = re.sub(r'[^a-z0-9-]', '-', plan.name.lower())
-        filename = re.sub(r'-+', '-', filename)  # Collapse multiple dashes
-        filename = filename.strip('-')  # Remove leading/trailing dashes
-        filename = f"{filename}.yaml"
-
-        # Create HTTP response with YAML content
         response = HttpResponse(yaml_content, content_type='text/yaml; charset=utf-8')
         response['Content-Disposition'] = f'attachment; filename="{filename}"'
-
         return response
 
 


### PR DESCRIPTION
Summary
- switch topology-plan YAML export UI to deliver dedicated managed-fabric artifacts (zip for multi-fabric, direct yaml for single-fabric)
- include module descriptions in aggregate BOM CSV downloads
- remove top action-bar links for per-device BOM and comparison CSV
- bump plugin version to 0.2.0

Tests
- docker compose exec -T netbox python manage.py test netbox_hedgehog.tests.test_topology_planning.test_managed_fabric_export.TestManagedFabricExportDownloads --keepdb --parallel 1
- docker compose exec -T netbox python manage.py test netbox_hedgehog.tests.test_topology_planning.test_yaml_export_inventory_based.YAMLExportUITestCase --keepdb --parallel 1
- docker compose exec -T netbox python manage.py test netbox_hedgehog.tests.test_topology_planning.test_bom_export.BOMExportCommandTestCase netbox_hedgehog.tests.test_topology_planning.test_bom_ui.BOMCSVEndpointTestCase --keepdb --parallel 1
- docker compose exec -T netbox python manage.py test netbox_hedgehog.tests.test_topology_planning.test_bom_per_device_ui netbox_hedgehog.tests.test_topology_planning.test_bom_comparison --keepdb --parallel 1

Release note
- prepare tag target for v0.2.0 after merge