### PR TITLE
[DIET-546] GREEN: full-capacity parallel links for explicit mesh fabrics

### DIFF
--- a/netbox_hedgehog/services/device_generator.py
+++ b/netbox_hedgehog/services/device_generator.py
@@ -1606,6 +1606,56 @@ class DeviceGenerator:
             role=switch_class.hedgehog_role or "",
         )
 
+    def _compute_cables_per_pair(self, fabric_name: str, total_switches: int, mesh_classes: list) -> int:
+        """
+        Return how many parallel cables to create per switch pair in a mesh fabric.
+
+        2-switch mesh: cables_per_pair = total mesh ports per switch (all ports connect
+        to the single peer).
+
+        3-switch mesh: cables_per_pair = total mesh ports // 2 (ports split evenly across
+        the two peer connections each switch participates in).
+
+        Raises ValidationError if:
+        - mesh zone port counts differ across switch classes (asymmetric capacity)
+        - 3-switch capacity is not divisible by 2
+        """
+        from netbox_hedgehog.choices import PortZoneTypeChoices
+        from netbox_hedgehog.services.port_specification import PortSpecification
+
+        port_counts = []
+        for sc in mesh_classes:
+            mesh_zones = list(sc.port_zones.filter(
+                zone_type=PortZoneTypeChoices.MESH
+            ).order_by('priority', 'zone_name'))
+            total = sum(
+                len(PortSpecification(z.port_spec).parse())
+                * ((z.breakout_option.logical_ports or 1) if z.breakout_option else 1)
+                for z in mesh_zones
+            )
+            port_counts.append(total)
+
+        if len(set(port_counts)) > 1:
+            raise ValidationError(
+                f"Mesh fabric '{fabric_name}' has asymmetric mesh zone capacity across "
+                f"switch classes: {port_counts}. All switch classes must contribute the "
+                f"same number of mesh ports."
+            )
+
+        port_count = port_counts[0] if port_counts else 0
+
+        if total_switches == 2:
+            return port_count
+
+        # 3-switch: ports must split evenly across 2 peer connections
+        if port_count % 2 != 0:
+            raise ValidationError(
+                f"Mesh fabric '{fabric_name}' has {port_count} mesh port(s) per switch, "
+                f"which is not divisible by 2. A 3-switch mesh requires an even number "
+                f"of mesh ports so they can be split evenly across both peer connections."
+            )
+        return port_count // 2
+
     def _create_mesh_connections(self, plan, switch_devices: dict[str, Device]):
         """
         Allocate mesh links for all explicit mesh fabrics and create NetBox cables.
@@ -1675,6 +1725,10 @@ class DeviceGenerator:
                         f"{ports_needed_per_switch} (for a {total_switches}-switch mesh)."
                     )
 
+            cables_per_pair = self._compute_cables_per_pair(
+                fabric_name, total_switches, mesh_classes
+            )
+
             mesh_links = allocate_mesh_links(
                 plan,
                 fabric_name,
@@ -1693,8 +1747,8 @@ class DeviceGenerator:
                 switch_class_a = mesh_link.switch_class_a
                 switch_class_b = mesh_link.switch_class_b
 
-                def _pick_mesh_interface(device, switch_class):
-                    """Allocate one port from a MESH zone; raises if none available."""
+                def _pick_mesh_interfaces(device, switch_class, count):
+                    """Allocate count ports from MESH zones; returns list of Interface."""
                     mesh_zones = list(switch_class.port_zones.filter(
                         zone_type=PortZoneTypeChoices.MESH
                     ).order_by('priority', 'zone_name')) if switch_class else []
@@ -1705,7 +1759,7 @@ class DeviceGenerator:
                             f"has no MESH-type port zones."
                         )
 
-                    ports = self._allocate_ports_for_zones(device.name, mesh_zones, count=1)
+                    ports = self._allocate_ports_for_zones(device.name, mesh_zones, count=count)
                     if not ports:
                         raise ValidationError(
                             f"Device '{device.name}': no available ports in MESH zones of "
@@ -1713,44 +1767,53 @@ class DeviceGenerator:
                             f"Add more ports to the MESH zone for this fabric size."
                         )
 
-                    zone, port = ports[0]
-                    iface = self._get_or_create_interface(
-                        device=device,
-                        name=port.name,
-                        interfaces=mesh_interfaces,
-                        custom_fields={
-                            'hedgehog_plan_id': str(plan.pk),
-                            'hedgehog_zone': zone.zone_name,
-                            'hedgehog_physical_port': port.physical_port,
-                            'hedgehog_breakout_index': port.breakout_index,
-                        },
-                        interface_type=self._interface_type_for_zone(zone),
+                    ifaces = []
+                    for zone, port in ports:
+                        iface = self._get_or_create_interface(
+                            device=device,
+                            name=port.name,
+                            interfaces=mesh_interfaces,
+                            custom_fields={
+                                'hedgehog_plan_id': str(plan.pk),
+                                'hedgehog_zone': zone.zone_name,
+                                'hedgehog_physical_port': port.physical_port,
+                                'hedgehog_breakout_index': port.breakout_index,
+                            },
+                            interface_type=self._interface_type_for_zone(zone),
+                        )
+                        self._create_switch_transceiver_module(device, port.name, zone)
+                        ifaces.append(iface)
+                    return ifaces
+
+                ifaces_a = _pick_mesh_interfaces(device_a, switch_class_a, cables_per_pair)
+                ifaces_b = _pick_mesh_interfaces(device_b, switch_class_b, cables_per_pair)
+
+                first_iface_a = None
+                first_iface_b = None
+                for iface_a, iface_b in zip(ifaces_a, ifaces_b):
+                    cable = Cable(
+                        a_terminations=[iface_a],
+                        b_terminations=[iface_b],
                     )
-                    self._create_switch_transceiver_module(device, port.name, zone)
-                    return iface
+                    cable.custom_field_data = {
+                        'hedgehog_plan_id': str(plan.pk),
+                    }
+                    cable.save()
+                    mesh_cables.append(cable)
+                    if first_iface_a is None:
+                        first_iface_a = iface_a
+                        first_iface_b = iface_b
 
-                iface_a = _pick_mesh_interface(device_a, switch_class_a)
-                iface_b = _pick_mesh_interface(device_b, switch_class_b)
-
-                cable = Cable(
-                    a_terminations=[iface_a],
-                    b_terminations=[iface_b],
-                )
-                cable.custom_field_data = {
-                    'hedgehog_plan_id': str(plan.pk),
-                }
-                cable.save()
-                mesh_cables.append(cable)
-
-                # Store chosen port names back on PlanMeshLink
-                mesh_link.leaf1_port = iface_a.name
-                mesh_link.leaf2_port = iface_b.name
+                # Store first allocated port names back on PlanMeshLink
+                mesh_link.leaf1_port = first_iface_a.name
+                mesh_link.leaf2_port = first_iface_b.name
                 mesh_link.save(update_fields=['leaf1_port', 'leaf2_port'])
 
                 if self.logger:
                     self.logger.info(
-                        f"Mesh cable created: {mesh_link.leaf1_name}/{iface_a.name} ↔ "
-                        f"{mesh_link.leaf2_name}/{iface_b.name}"
+                        f"Mesh cables created ({cables_per_pair}): "
+                        f"{mesh_link.leaf1_name}/{first_iface_a.name} ↔ "
+                        f"{mesh_link.leaf2_name}/{first_iface_b.name} (first port)"
                     )
 
         return mesh_interfaces, mesh_cables

--- a/netbox_hedgehog/tests/test_topology_planning/test_mesh_topology.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_mesh_topology.py
@@ -622,3 +622,248 @@ class Mesh317ViewsPermissionsTests(TestCase):
         r = self.client.get(reverse(
             'plugins:netbox_hedgehog:planswitchclass_add'))
         self.assertIn(r.status_code, (403, 302))
+
+
+# ---------------------------------------------------------------------------
+# 10. Full-capacity multi-link mesh generation (#548 RED)
+#
+# Fails until GREEN (#546): _compute_cables_per_pair doesn't exist and
+# current _create_mesh_connections() allocates count=1 per PlanMeshLink.
+# ---------------------------------------------------------------------------
+
+class Mesh544FullCapacityTests(TestCase):
+    """
+    RED tests for #548: full-capacity parallel link generation for explicit mesh fabrics.
+
+    Current bottleneck: _create_mesh_connections() calls
+    _allocate_ports_for_zones(..., count=1) per PlanMeshLink, producing
+    exactly one cable per switch pair regardless of mesh zone port count.
+
+    These tests will all be RED until GREEN (#546) implements:
+    - _compute_cables_per_pair() helper
+    - batch allocation (count=cables_per_pair)
+    - zip-loop cable creation
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        _, _, cls.ext = _mfr_dt_ext()
+        cls.site = _site()
+
+    def _gen(self, plan):
+        from netbox_hedgehog.services.device_generator import DeviceGenerator
+        return DeviceGenerator(plan, site=self.site).generate_all()
+
+    def _make_gen(self, plan):
+        """Return a DeviceGenerator instance without running generate_all()."""
+        from netbox_hedgehog.services.device_generator import DeviceGenerator
+        return DeviceGenerator(plan, site=self.site)
+
+    def _cable_count(self, plan):
+        from dcim.models import Cable
+        return Cable.objects.filter(
+            custom_field_data__hedgehog_plan_id=str(plan.pk)
+        ).count()
+
+    # -------------------------------------------------------------------
+    # Section 1: _compute_cables_per_pair helper unit tests
+    # All RED via AttributeError — method does not exist yet.
+    # -------------------------------------------------------------------
+
+    def test_helper_2switch_full_capacity_returns_N(self):
+        """_compute_cables_per_pair: 2-switch, 4-port zone → 4."""
+        plan = _plan('M544 Helper 2sw')
+        sc = _mesh_sc(plan, self.ext, sc_id='h2sw-leaf', qty=2)
+        _mesh_zone(sc, port_spec='1-4')
+        gen = self._make_gen(plan)
+        mesh_classes = list(plan.switch_classes.filter(fabric_name='backend'))
+        result = gen._compute_cables_per_pair('backend', 2, mesh_classes)
+        self.assertEqual(result, 4)
+
+    def test_helper_3switch_divisible_capacity_returns_half(self):
+        """_compute_cables_per_pair: 3-switch, 4-port zone → 4 // 2 = 2."""
+        plan = _plan('M544 Helper 3sw')
+        sc = _mesh_sc(plan, self.ext, sc_id='h3sw-leaf', qty=3)
+        _mesh_zone(sc, port_spec='1-4')
+        gen = self._make_gen(plan)
+        mesh_classes = list(plan.switch_classes.filter(fabric_name='backend'))
+        result = gen._compute_cables_per_pair('backend', 3, mesh_classes)
+        self.assertEqual(result, 2)
+
+    def test_helper_asymmetric_capacity_raises_validation_error(self):
+        """_compute_cables_per_pair: class A (2 ports) vs class B (4 ports) → ValidationError."""
+        plan = _plan('M544 Helper Asym')
+        sc_a = _mesh_sc(plan, self.ext, sc_id='hasym-leaf-a', qty=1, fabric='hasym-fab')
+        sc_b = _mesh_sc(plan, self.ext, sc_id='hasym-leaf-b', qty=1, fabric='hasym-fab')
+        _mesh_zone(sc_a, zone_name='mesh-a', port_spec='1-2')
+        _mesh_zone(sc_b, zone_name='mesh-b', port_spec='1-4')
+        gen = self._make_gen(plan)
+        mesh_classes = list(plan.switch_classes.filter(fabric_name='hasym-fab'))
+        with self.assertRaises(ValidationError) as ctx:
+            gen._compute_cables_per_pair('hasym-fab', 2, mesh_classes)
+        self.assertIn('asymmetric', str(ctx.exception).lower())
+
+    def test_helper_3switch_non_divisible_capacity_raises_validation_error(self):
+        """_compute_cables_per_pair: 3-switch, 3-port zone (odd) → ValidationError."""
+        plan = _plan('M544 Helper Odd')
+        sc = _mesh_sc(plan, self.ext, sc_id='hodd-leaf', qty=3)
+        _mesh_zone(sc, port_spec='1-3')
+        gen = self._make_gen(plan)
+        mesh_classes = list(plan.switch_classes.filter(fabric_name='backend'))
+        with self.assertRaises(ValidationError) as ctx:
+            gen._compute_cables_per_pair('backend', 3, mesh_classes)
+        self.assertIn('divisible', str(ctx.exception).lower())
+
+    # -------------------------------------------------------------------
+    # Section 2: Generation behavior
+    # T1, T2 fail RED (cable count wrong). T5/T6/T7 pass RED and GREEN.
+    # -------------------------------------------------------------------
+
+    def test_2switch_N_port_zone_creates_N_cables(self):
+        """2-switch, port_spec='1-4' → 4 cables. RED: current code creates 1."""
+        plan = _plan('M544 Gen 2sw 4port')
+        sc = _mesh_sc(plan, self.ext, sc_id='g2n-leaf', qty=2)
+        _mesh_zone(sc, port_spec='1-4')
+        self._gen(plan)
+        self.assertEqual(self._cable_count(plan), 4)
+
+    def test_3switch_even_capacity_splits_evenly(self):
+        """3-switch, port_spec='1-4' (4 ports) → 2 cables/pair, 6 total. RED: current code creates 3."""
+        plan = _plan('M544 Gen 3sw 4port')
+        sc = _mesh_sc(plan, self.ext, sc_id='g3ev-leaf', qty=3)
+        _mesh_zone(sc, port_spec='1-4')
+        self._gen(plan)
+        self.assertEqual(self._cable_count(plan), 6)
+
+    def test_2switch_single_port_still_creates_one_cable(self):
+        """Regression: 2-switch, port_spec='1-1' → 1 cable. Passes RED and GREEN."""
+        plan = _plan('M544 Reg 2sw 1port')
+        sc = _mesh_sc(plan, self.ext, sc_id='g1reg-leaf', qty=2)
+        _mesh_zone(sc, port_spec='1-1')
+        self._gen(plan)
+        self.assertEqual(self._cable_count(plan), 1)
+
+    def test_3switch_2port_creates_1_cable_per_pair(self):
+        """Regression: 3-switch, port_spec='1-2' → 1 cable/pair, 3 total. Passes RED and GREEN."""
+        plan = _plan('M544 Reg 3sw 2port')
+        sc = _mesh_sc(plan, self.ext, sc_id='g3reg-leaf', qty=3)
+        _mesh_zone(sc, port_spec='1-2')
+        self._gen(plan)
+        self.assertEqual(self._cable_count(plan), 3)
+
+    def test_planmeshlink_leaf1_port_is_first_allocated_port(self):
+        """PlanMeshLink.leaf1_port stores the first port from the batch (E1/1 for port_spec='1-4')."""
+        plan = _plan('M544 MeshLink FirstPort')
+        sc = _mesh_sc(plan, self.ext, sc_id='fp4-leaf', qty=2)
+        _mesh_zone(sc, port_spec='1-4')
+        self._gen(plan)
+        link = PlanMeshLink.objects.get(plan=plan)
+        self.assertEqual(link.leaf1_port, 'E1/1')
+        self.assertEqual(link.leaf2_port, 'E1/1')
+
+    # -------------------------------------------------------------------
+    # Section 3: Validation failures (new error substrings)
+    # Both fail RED — current code raises no error for these cases.
+    # -------------------------------------------------------------------
+
+    def test_asymmetric_capacity_raises_before_allocation(self):
+        """
+        Two switch classes with mismatched mesh port counts → ValidationError with 'asymmetric'.
+        RED: current code performs no symmetry check; 1 cable is created silently.
+        Confirmed clean fail: no cables and no devices must exist after the exception.
+        """
+        from dcim.models import Cable, Device
+        plan = _plan('M544 Val Asym')
+        sc_a = _mesh_sc(plan, self.ext, sc_id='va-leaf-a', qty=1, fabric='va-fab')
+        sc_b = _mesh_sc(plan, self.ext, sc_id='va-leaf-b', qty=1, fabric='va-fab')
+        _mesh_zone(sc_a, zone_name='mesh-a', port_spec='1-2')
+        _mesh_zone(sc_b, zone_name='mesh-b', port_spec='1-4')
+        with self.assertRaises(ValidationError) as ctx:
+            self._gen(plan)
+        self.assertIn('asymmetric', str(ctx.exception).lower())
+        self.assertEqual(
+            Cable.objects.filter(
+                custom_field_data__hedgehog_plan_id=str(plan.pk)
+            ).count(), 0,
+            "No cables should be created when asymmetric validation fires",
+        )
+
+    def test_3switch_non_divisible_capacity_raises_before_allocation(self):
+        """
+        3-switch, port_spec='1-3' (odd) → ValidationError mentioning divisibility.
+        RED: current code raises no error; it creates 3 cables (1 per pair).
+        """
+        from dcim.models import Cable
+        plan = _plan('M544 Val Odd3')
+        sc = _mesh_sc(plan, self.ext, sc_id='vodd3-leaf', qty=3)
+        _mesh_zone(sc, port_spec='1-3')
+        with self.assertRaises(ValidationError) as ctx:
+            self._gen(plan)
+        err = str(ctx.exception).lower()
+        self.assertTrue(
+            'divisible' in err,
+            f"Expected 'divisible' in ValidationError message, got: {ctx.exception}",
+        )
+        self.assertEqual(
+            Cable.objects.filter(
+                custom_field_data__hedgehog_plan_id=str(plan.pk)
+            ).count(), 0,
+            "No cables should be created when divisibility validation fires",
+        )
+
+    # -------------------------------------------------------------------
+    # Section 4: Canonical motivating case (XOC-64 style)
+    # -------------------------------------------------------------------
+
+    def test_xoc64_style_32port_2switch_mesh_creates_32_cables(self):
+        """
+        XOC-64 motivating case: 2-switch, 32 odd-numbered mesh ports per switch → 32 cables.
+        port_spec='1-63:2' → [1,3,5,...,63] = 32 ports.
+        RED: current code creates exactly 1 cable.
+        """
+        plan = _plan('M544 XOC64 32port')
+        sc = _mesh_sc(plan, self.ext, sc_id='xoc64-leaf', qty=2, fabric='scale-out')
+        _mesh_zone(sc, zone_name='mesh-800', port_spec='1-63:2')
+        self._gen(plan)
+        self.assertEqual(self._cable_count(plan), 32)
+
+    # -------------------------------------------------------------------
+    # Section 5: Export regression guard
+    # -------------------------------------------------------------------
+
+    def test_mesh_export_crd_aggregates_all_cables_per_pair(self):
+        """
+        Export regression guard: after generating a 2-switch 4-port mesh,
+        _generate_connection_crds() produces exactly 1 mesh CRD with 4 links.
+
+        Verifies that yaml_generator.py already aggregates mesh cables by pair
+        (mesh_links_by_pair dict) and passes the full list to _create_mesh_crd().
+
+        RED: current generation creates 1 cable → CRD has 1 link, not 4.
+        GREEN: 4 cables → 1 CRD with 4 links.
+
+        Stop condition check: if this test fails for a reason other than link count
+        (e.g., 0 mesh CRDs returned), the exporter aggregation is broken and
+        GREEN scope must be reassessed before proceeding.
+        """
+        from netbox_hedgehog.services.yaml_generator import YAMLGenerator
+        plan = _plan('M544 Export 4link')
+        sc = _mesh_sc(plan, self.ext, sc_id='exp4l-leaf', qty=2, fabric='exp4-fab')
+        _mesh_zone(sc, zone_name='mesh-exp', port_spec='1-4')
+        self._gen(plan)
+
+        gen = YAMLGenerator(plan=plan)
+        conn_crds = gen._generate_connection_crds()
+        mesh_crds = [c for c in conn_crds if 'mesh' in c.get('spec', {})]
+
+        self.assertEqual(
+            len(mesh_crds), 1,
+            f"Expected exactly 1 mesh CRD; got {len(mesh_crds)}. "
+            "If 0: exporter aggregation is broken — stop and report before GREEN.",
+        )
+        links = mesh_crds[0]['spec']['mesh']['links']
+        self.assertEqual(
+            len(links), 4,
+            f"Expected 4 links in mesh CRD (one per cable), got {len(links)}. "
+            "With current code this is 1 (RED). After GREEN it should be 4.",
+        )


### PR DESCRIPTION
## Problem

Explicit `topology_mode=mesh` fabrics generated exactly one inter-switch cable per peer edge regardless of how many ports the mesh zone contained. In `_create_mesh_connections()`, the inner allocation loop called `_allocate_ports_for_zones(..., count=1)` for every `PlanMeshLink`. This made full-capacity mesh designs impossible to represent — the motivating case is the XOC-64 DS5000 pair, where each leaf contributes 32 × 800G odd-numbered ports to the mesh interconnect, but only one cable was created.

## Fix

**Single production file changed: `netbox_hedgehog/services/device_generator.py`**

### `_compute_cables_per_pair(fabric_name, total_switches, mesh_classes) → int`

New helper that derives cable multiplicity from mesh zone capacity:

- **2-switch mesh:** `cables_per_pair = total_mesh_ports_per_switch` (the single peer gets all of them)
- **3-switch mesh:** `cables_per_pair = total_mesh_ports // 2` (ports split evenly across the 2 peer edges each switch participates in)

Raises `ValidationError` with `'asymmetric'` if switch classes have unequal mesh port counts. Raises with `'divisible'` if a 3-switch fabric has an odd port count.

### Updated `_create_mesh_connections`

- Calls `_compute_cables_per_pair` after the existing minimum-ports check (new validation order: zone exists → min ports → asymmetric → non-divisible → allocate)
- Replaces `_pick_mesh_interface` (returns one Interface) with `_pick_mesh_interfaces(count)` (returns a list)
- Zip-loops the two Interface lists to create `cables_per_pair` cables per graph edge
- `PlanMeshLink` stays one row per graph edge; `leaf1_port`/`leaf2_port` record the first port in the batch

## Non-goals

- No export changes — `yaml_generator.py` already aggregates mesh cables by pair (`mesh_links_by_pair`), so multi-link CRDs work automatically
- No schema or model changes
- No migration
- No allocator redesign

## Test results

```
docker compose exec -T netbox python manage.py test \
  netbox_hedgehog.tests.test_topology_planning.test_mesh_topology \
  --keepdb
Ran 51 tests in 24.452s
OK

docker compose exec -T netbox python manage.py test \
  netbox_hedgehog.tests.test_topology_planning.test_seed_data \
  --keepdb
Ran 19 tests in 73.696s
OK
```

RED suite (`#548`): 10 failures → green. 3 regression guards (single-port meshes) unchanged.

## Issue chain

Closes #544
Closes #545
Closes #546
Closes #547
Closes #548
Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)