### PR TITLE
[DIET-570] GREEN: complete supported-switch library bootstrap (all 21 slugs)

### DIFF
--- a/netbox_hedgehog/fabric_profiles/p_bcm_celestica_ds2000.go
+++ b/netbox_hedgehog/fabric_profiles/p_bcm_celestica_ds2000.go
@@ -1,0 +1,129 @@
+// Copyright 2023 Hedgehog
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var CelesticaDS2000 = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "celestica-ds2000",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Celestica DS2000",
+		OtherNames:    []string{"Celestica Questone 2a"},
+		SwitchSilicon: SiliconBroadcomTD3_X5,
+		Features: wiringapi.SwitchProfileFeatures{
+			Subinterfaces: true,
+			ACLs:          true,
+			L2VNI:         true,
+			L3VNI:         true,
+			RoCE:          false,
+			MCLAG:         true,
+			ESLAG:         true,
+			ECMPRoCEQPN:   false,
+		},
+		NOSType:  meta.NOSTypeSONiCBCMBase,
+		Platform: "x86_64-cel_ds2000-r0",
+		Config:   wiringapi.SwitchProfileConfig{},
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},
+			"E1/1":  {NOSName: "Ethernet0", Label: "1", Profile: "SFP28-25G"},
+			"E1/2":  {NOSName: "Ethernet1", Label: "2", Profile: "SFP28-25G"},
+			"E1/3":  {NOSName: "Ethernet2", Label: "3", Profile: "SFP28-25G"},
+			"E1/4":  {NOSName: "Ethernet3", Label: "4", Profile: "SFP28-25G"},
+			"E1/5":  {NOSName: "Ethernet4", Label: "5", Profile: "SFP28-25G"},
+			"E1/6":  {NOSName: "Ethernet5", Label: "6", Profile: "SFP28-25G"},
+			"E1/7":  {NOSName: "Ethernet6", Label: "7", Profile: "SFP28-25G"},
+			"E1/8":  {NOSName: "Ethernet7", Label: "8", Profile: "SFP28-25G"},
+			"E1/9":  {NOSName: "Ethernet8", Label: "9", Profile: "SFP28-25G"},
+			"E1/10": {NOSName: "Ethernet9", Label: "10", Profile: "SFP28-25G"},
+			"E1/11": {NOSName: "Ethernet10", Label: "11", Profile: "SFP28-25G"},
+			"E1/12": {NOSName: "Ethernet11", Label: "12", Profile: "SFP28-25G"},
+			"E1/13": {NOSName: "Ethernet12", Label: "13", Profile: "SFP28-25G"},
+			"E1/14": {NOSName: "Ethernet13", Label: "14", Profile: "SFP28-25G"},
+			"E1/15": {NOSName: "Ethernet14", Label: "15", Profile: "SFP28-25G"},
+			"E1/16": {NOSName: "Ethernet15", Label: "16", Profile: "SFP28-25G"},
+			"E1/17": {NOSName: "Ethernet16", Label: "17", Profile: "SFP28-25G"},
+			"E1/18": {NOSName: "Ethernet17", Label: "18", Profile: "SFP28-25G"},
+			"E1/19": {NOSName: "Ethernet18", Label: "19", Profile: "SFP28-25G"},
+			"E1/20": {NOSName: "Ethernet19", Label: "20", Profile: "SFP28-25G"},
+			"E1/21": {NOSName: "Ethernet20", Label: "21", Profile: "SFP28-25G"},
+			"E1/22": {NOSName: "Ethernet21", Label: "22", Profile: "SFP28-25G"},
+			"E1/23": {NOSName: "Ethernet22", Label: "23", Profile: "SFP28-25G"},
+			"E1/24": {NOSName: "Ethernet23", Label: "24", Profile: "SFP28-25G"},
+			"E1/25": {NOSName: "Ethernet24", Label: "25", Profile: "SFP28-25G"},
+			"E1/26": {NOSName: "Ethernet25", Label: "26", Profile: "SFP28-25G"},
+			"E1/27": {NOSName: "Ethernet26", Label: "27", Profile: "SFP28-25G"},
+			"E1/28": {NOSName: "Ethernet27", Label: "28", Profile: "SFP28-25G"},
+			"E1/29": {NOSName: "Ethernet28", Label: "29", Profile: "SFP28-25G"},
+			"E1/30": {NOSName: "Ethernet29", Label: "30", Profile: "SFP28-25G"},
+			"E1/31": {NOSName: "Ethernet30", Label: "31", Profile: "SFP28-25G"},
+			"E1/32": {NOSName: "Ethernet31", Label: "32", Profile: "SFP28-25G"},
+			"E1/33": {NOSName: "Ethernet32", Label: "33", Profile: "SFP28-25G"},
+			"E1/34": {NOSName: "Ethernet33", Label: "34", Profile: "SFP28-25G"},
+			"E1/35": {NOSName: "Ethernet34", Label: "35", Profile: "SFP28-25G"},
+			"E1/36": {NOSName: "Ethernet35", Label: "36", Profile: "SFP28-25G"},
+			"E1/37": {NOSName: "Ethernet36", Label: "37", Profile: "SFP28-25G"},
+			"E1/38": {NOSName: "Ethernet37", Label: "38", Profile: "SFP28-25G"},
+			"E1/39": {NOSName: "Ethernet38", Label: "39", Profile: "SFP28-25G"},
+			"E1/40": {NOSName: "Ethernet39", Label: "40", Profile: "SFP28-25G"},
+			"E1/41": {NOSName: "Ethernet40", Label: "41", Profile: "SFP28-25G"},
+			"E1/42": {NOSName: "Ethernet41", Label: "42", Profile: "SFP28-25G"},
+			"E1/43": {NOSName: "Ethernet42", Label: "43", Profile: "SFP28-25G"},
+			"E1/44": {NOSName: "Ethernet43", Label: "44", Profile: "SFP28-25G"},
+			"E1/45": {NOSName: "Ethernet44", Label: "45", Profile: "SFP28-25G"},
+			"E1/46": {NOSName: "Ethernet45", Label: "46", Profile: "SFP28-25G"},
+			"E1/47": {NOSName: "Ethernet46", Label: "47", Profile: "SFP28-25G"},
+			"E1/48": {NOSName: "Ethernet47", Label: "48", Profile: "SFP28-25G"},
+			"E1/49": {NOSName: "1/49", BaseNOSName: "Ethernet48", Label: "49", Profile: "QSFP28-100G"},
+			"E1/50": {NOSName: "Ethernet52", Label: "50", Profile: "QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix},
+			"E1/51": {NOSName: "Ethernet56", Label: "51", Profile: "QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix},
+			"E1/52": {NOSName: "Ethernet60", Label: "52", Profile: "QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix},
+			"E1/53": {NOSName: "Ethernet64", Label: "53", Profile: "QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix},
+			"E1/54": {NOSName: "Ethernet68", Label: "54", Profile: "QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix},
+			"E1/55": {NOSName: "Ethernet72", Label: "55", Profile: "QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix},
+			"E1/56": {NOSName: "1/56", BaseNOSName: "Ethernet76", Label: "56", Profile: "QSFP28-100G"},
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"SFP28-25G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "25G",
+					Supported: []string{"10G", "25G"},
+				},
+			},
+			"QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix: {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "100G",
+					Supported: []string{"40G", "100G"},
+				},
+			},
+			"QSFP28-100G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "1x100G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x40G":  {Offsets: []string{"0"}},
+						"1x100G": {Offsets: []string{"0"}},
+						"4x25G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"4x10G":  {Offsets: []string{"0", "1", "2", "3"}},
+					},
+				},
+			},
+		},
+	},
+}

--- a/netbox_hedgehog/fabric_profiles/p_bcm_celestica_ds3000.go
+++ b/netbox_hedgehog/fabric_profiles/p_bcm_celestica_ds3000.go
@@ -1,0 +1,91 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var CelesticaDS3000 = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "celestica-ds3000",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Celestica DS3000",
+		OtherNames:    []string{"Celestica Seastone2"},
+		SwitchSilicon: SiliconBroadcomTD3_X7_3_2T,
+		Features: wiringapi.SwitchProfileFeatures{
+			Subinterfaces: true,
+			ACLs:          true,
+			L2VNI:         true,
+			L3VNI:         true,
+			RoCE:          true,
+			MCLAG:         true,
+			ESLAG:         true,
+			ECMPRoCEQPN:   false,
+		},
+		NOSType:  meta.NOSTypeSONiCBCMBase,
+		Platform: "x86_64-cel_seastone_2-r0",
+		Config:   wiringapi.SwitchProfileConfig{},
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},
+			"E1/1":  {NOSName: "1/1", BaseNOSName: "Ethernet0", Label: "1", Profile: "QSFP28-100G"},
+			"E1/2":  {NOSName: "1/2", BaseNOSName: "Ethernet4", Label: "2", Profile: "QSFP28-100G"},
+			"E1/3":  {NOSName: "1/3", BaseNOSName: "Ethernet8", Label: "3", Profile: "QSFP28-100G"},
+			"E1/4":  {NOSName: "1/4", BaseNOSName: "Ethernet12", Label: "4", Profile: "QSFP28-100G"},
+			"E1/5":  {NOSName: "1/5", BaseNOSName: "Ethernet16", Label: "5", Profile: "QSFP28-100G"},
+			"E1/6":  {NOSName: "1/6", BaseNOSName: "Ethernet20", Label: "6", Profile: "QSFP28-100G"},
+			"E1/7":  {NOSName: "1/7", BaseNOSName: "Ethernet24", Label: "7", Profile: "QSFP28-100G"},
+			"E1/8":  {NOSName: "1/8", BaseNOSName: "Ethernet28", Label: "8", Profile: "QSFP28-100G"},
+			"E1/9":  {NOSName: "1/9", BaseNOSName: "Ethernet32", Label: "9", Profile: "QSFP28-100G"},
+			"E1/10": {NOSName: "1/10", BaseNOSName: "Ethernet36", Label: "10", Profile: "QSFP28-100G"},
+			"E1/11": {NOSName: "1/11", BaseNOSName: "Ethernet40", Label: "11", Profile: "QSFP28-100G"},
+			"E1/12": {NOSName: "1/12", BaseNOSName: "Ethernet44", Label: "12", Profile: "QSFP28-100G"},
+			"E1/13": {NOSName: "1/13", BaseNOSName: "Ethernet48", Label: "13", Profile: "QSFP28-100G"},
+			"E1/14": {NOSName: "1/14", BaseNOSName: "Ethernet52", Label: "14", Profile: "QSFP28-100G"},
+			"E1/15": {NOSName: "1/15", BaseNOSName: "Ethernet56", Label: "15", Profile: "QSFP28-100G"},
+			"E1/16": {NOSName: "1/16", BaseNOSName: "Ethernet60", Label: "16", Profile: "QSFP28-100G"},
+			"E1/17": {NOSName: "1/17", BaseNOSName: "Ethernet64", Label: "17", Profile: "QSFP28-100G"},
+			"E1/18": {NOSName: "1/18", BaseNOSName: "Ethernet68", Label: "18", Profile: "QSFP28-100G"},
+			"E1/19": {NOSName: "1/19", BaseNOSName: "Ethernet72", Label: "19", Profile: "QSFP28-100G"},
+			"E1/20": {NOSName: "1/20", BaseNOSName: "Ethernet76", Label: "20", Profile: "QSFP28-100G"},
+			"E1/21": {NOSName: "1/21", BaseNOSName: "Ethernet80", Label: "21", Profile: "QSFP28-100G"},
+			"E1/22": {NOSName: "1/22", BaseNOSName: "Ethernet84", Label: "22", Profile: "QSFP28-100G"},
+			"E1/23": {NOSName: "1/23", BaseNOSName: "Ethernet88", Label: "23", Profile: "QSFP28-100G"},
+			"E1/24": {NOSName: "1/24", BaseNOSName: "Ethernet92", Label: "24", Profile: "QSFP28-100G"},
+			"E1/25": {NOSName: "1/25", BaseNOSName: "Ethernet96", Label: "25", Profile: "QSFP28-100G"},
+			"E1/26": {NOSName: "1/26", BaseNOSName: "Ethernet100", Label: "26", Profile: "QSFP28-100G"},
+			"E1/27": {NOSName: "1/27", BaseNOSName: "Ethernet104", Label: "27", Profile: "QSFP28-100G"},
+			"E1/28": {NOSName: "1/28", BaseNOSName: "Ethernet108", Label: "28", Profile: "QSFP28-100G"},
+			"E1/29": {NOSName: "1/29", BaseNOSName: "Ethernet112", Label: "29", Profile: "QSFP28-100G"},
+			"E1/30": {NOSName: "1/30", BaseNOSName: "Ethernet116", Label: "30", Profile: "QSFP28-100G"},
+			"E1/31": {NOSName: "1/31", BaseNOSName: "Ethernet120", Label: "31", Profile: "QSFP28-100G"},
+			"E1/32": {NOSName: "1/32", BaseNOSName: "Ethernet124", Label: "32", Profile: "QSFP28-100G"}, // 32x QSFP28-100G
+			"E1/33": {NOSName: "Ethernet128", Label: "33", Profile: "SFP28-10G"},                        // 1x SFP28-10G
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"SFP28-10G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "10G",
+					Supported: []string{"1G", "10G"},
+				},
+			},
+			"QSFP28-100G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "1x100G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x100G": {Offsets: []string{"0"}},
+						"1x40G":  {Offsets: []string{"0"}},
+						"1x50G":  {Offsets: []string{"0"}},
+						"2x50G":  {Offsets: []string{"0", "2"}},
+						"4x25G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"4x10G":  {Offsets: []string{"0", "1", "2", "3"}},
+					},
+				},
+			},
+		},
+	},
+}

--- a/netbox_hedgehog/fabric_profiles/p_bcm_celestica_ds4000.go
+++ b/netbox_hedgehog/fabric_profiles/p_bcm_celestica_ds4000.go
@@ -1,0 +1,110 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var CelesticaDS4000 = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "celestica-ds4000",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Celestica DS4000",
+		OtherNames:    []string{"Celestica Silverstone2"},
+		SwitchSilicon: SiliconBroadcomTH3,
+		Features: wiringapi.SwitchProfileFeatures{
+			Subinterfaces: false,
+			ACLs:          true,
+			L2VNI:         false,
+			L3VNI:         false,
+			RoCE:          true,
+			MCLAG:         false,
+			ESLAG:         false,
+			ECMPRoCEQPN:   false,
+		},
+		NOSType:  meta.NOSTypeSONiCBCMBase,
+		Platform: "x86_64-cel_silverstone-r0",
+		Config:   wiringapi.SwitchProfileConfig{},
+		MaxPorts: 144,
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},
+			"E1/1":  {NOSName: "1/1", BaseNOSName: "Ethernet0", Label: "1", Profile: "QSFPDD-400G", Pipeline: "1"},
+			"E1/2":  {NOSName: "1/2", BaseNOSName: "Ethernet8", Label: "2", Profile: "QSFPDD-400G", Pipeline: "1"},
+			"E1/3":  {NOSName: "1/3", BaseNOSName: "Ethernet16", Label: "3", Profile: "QSFPDD-400G", Pipeline: "1"},
+			"E1/4":  {NOSName: "1/4", BaseNOSName: "Ethernet24", Label: "4", Profile: "QSFPDD-400G", Pipeline: "1"},
+			"E1/5":  {NOSName: "1/5", BaseNOSName: "Ethernet32", Label: "5", Profile: "QSFPDD-400G", Pipeline: "2"},
+			"E1/6":  {NOSName: "1/6", BaseNOSName: "Ethernet40", Label: "6", Profile: "QSFPDD-400G", Pipeline: "2"},
+			"E1/7":  {NOSName: "1/7", BaseNOSName: "Ethernet48", Label: "7", Profile: "QSFPDD-400G", Pipeline: "2"},
+			"E1/8":  {NOSName: "1/8", BaseNOSName: "Ethernet56", Label: "8", Profile: "QSFPDD-400G", Pipeline: "2"},
+			"E1/9":  {NOSName: "1/9", BaseNOSName: "Ethernet64", Label: "9", Profile: "QSFPDD-400G", Pipeline: "3"},
+			"E1/10": {NOSName: "1/10", BaseNOSName: "Ethernet72", Label: "10", Profile: "QSFPDD-400G", Pipeline: "3"},
+			"E1/11": {NOSName: "1/11", BaseNOSName: "Ethernet80", Label: "11", Profile: "QSFPDD-400G", Pipeline: "3"},
+			"E1/12": {NOSName: "1/12", BaseNOSName: "Ethernet88", Label: "12", Profile: "QSFPDD-400G", Pipeline: "3"},
+			"E1/13": {NOSName: "1/13", BaseNOSName: "Ethernet96", Label: "13", Profile: "QSFPDD-400G", Pipeline: "4"},
+			"E1/14": {NOSName: "1/14", BaseNOSName: "Ethernet104", Label: "14", Profile: "QSFPDD-400G", Pipeline: "4"},
+			"E1/15": {NOSName: "1/15", BaseNOSName: "Ethernet112", Label: "15", Profile: "QSFPDD-400G", Pipeline: "4"},
+			"E1/16": {NOSName: "1/16", BaseNOSName: "Ethernet120", Label: "16", Profile: "QSFPDD-400G", Pipeline: "4"},
+			"E1/17": {NOSName: "1/17", BaseNOSName: "Ethernet128", Label: "17", Profile: "QSFPDD-400G", Pipeline: "5"},
+			"E1/18": {NOSName: "1/18", BaseNOSName: "Ethernet136", Label: "18", Profile: "QSFPDD-400G", Pipeline: "5"},
+			"E1/19": {NOSName: "1/19", BaseNOSName: "Ethernet144", Label: "19", Profile: "QSFPDD-400G", Pipeline: "5"},
+			"E1/20": {NOSName: "1/20", BaseNOSName: "Ethernet152", Label: "20", Profile: "QSFPDD-400G", Pipeline: "5"},
+			"E1/21": {NOSName: "1/21", BaseNOSName: "Ethernet160", Label: "21", Profile: "QSFPDD-400G", Pipeline: "6"},
+			"E1/22": {NOSName: "1/22", BaseNOSName: "Ethernet168", Label: "22", Profile: "QSFPDD-400G", Pipeline: "6"},
+			"E1/23": {NOSName: "1/23", BaseNOSName: "Ethernet176", Label: "23", Profile: "QSFPDD-400G", Pipeline: "6"},
+			"E1/24": {NOSName: "1/24", BaseNOSName: "Ethernet184", Label: "24", Profile: "QSFPDD-400G", Pipeline: "6"},
+			"E1/25": {NOSName: "1/25", BaseNOSName: "Ethernet192", Label: "25", Profile: "QSFPDD-400G", Pipeline: "7"},
+			"E1/26": {NOSName: "1/26", BaseNOSName: "Ethernet200", Label: "26", Profile: "QSFPDD-400G", Pipeline: "7"},
+			"E1/27": {NOSName: "1/27", BaseNOSName: "Ethernet208", Label: "27", Profile: "QSFPDD-400G", Pipeline: "7"},
+			"E1/28": {NOSName: "1/28", BaseNOSName: "Ethernet216", Label: "28", Profile: "QSFPDD-400G", Pipeline: "7"},
+			"E1/29": {NOSName: "1/29", BaseNOSName: "Ethernet224", Label: "29", Profile: "QSFPDD-400G", Pipeline: "8"},
+			"E1/30": {NOSName: "1/30", BaseNOSName: "Ethernet232", Label: "30", Profile: "QSFPDD-400G", Pipeline: "8"},
+			"E1/31": {NOSName: "1/31", BaseNOSName: "Ethernet240", Label: "31", Profile: "QSFPDD-400G", Pipeline: "8"},
+			"E1/32": {NOSName: "1/32", BaseNOSName: "Ethernet248", Label: "32", Profile: "QSFPDD-400G", Pipeline: "8"}, // 32x QSFPDD-400G
+			"E1/33": {NOSName: "Ethernet256", Label: "33", Profile: "SFP28-10G"},                                       // 1x SFP28-10G
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"SFP28-10G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "10G",
+					Supported: []string{"1G", "10G"},
+				},
+			},
+			"QSFPDD-400G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "1x400G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x400G": {Offsets: []string{"0"}},
+						"1x100G": {Offsets: []string{"0"}},
+						"1x40G":  {Offsets: []string{"0"}},
+						"1x25G":  {Offsets: []string{"0"}},
+						"1x10G":  {Offsets: []string{"0"}},
+						"2x200G": {Offsets: []string{"0", "4"}},
+						"2x100G": {Offsets: []string{"0", "4"}},
+						"2x40G":  {Offsets: []string{"0", "4"}},
+						"4x100G": {Offsets: []string{"0", "2", "4", "6"}},
+						"4x25G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"4x10G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"8x50G":  {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+						"8x25G":  {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+						"8x10G":  {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+					},
+				},
+			},
+		},
+		Pipelines: map[string]wiringapi.SwitchProfilePipeline{
+			"1": {MaxPorts: 18},
+			"2": {MaxPorts: 18},
+			"3": {MaxPorts: 18},
+			"4": {MaxPorts: 18},
+			"5": {MaxPorts: 18},
+			"6": {MaxPorts: 18},
+			"7": {MaxPorts: 18},
+			"8": {MaxPorts: 18},
+		},
+	},
+}

--- a/netbox_hedgehog/fabric_profiles/p_bcm_celestica_ds4101.go
+++ b/netbox_hedgehog/fabric_profiles/p_bcm_celestica_ds4101.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var CelesticaDS4101 = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "celestica-ds4101",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Celestica DS4101",
+		OtherNames:    []string{"Celestica Greystone"},
+		SwitchSilicon: SiliconBroadcomTH4G,
+		Features: wiringapi.SwitchProfileFeatures{
+			Subinterfaces: false,
+			ACLs:          true,
+			L2VNI:         false,
+			L3VNI:         false,
+			RoCE:          true,
+			MCLAG:         false,
+			ESLAG:         false,
+			ECMPRoCEQPN:   true,
+		},
+		NOSType:  meta.NOSTypeSONiCBCMBase,
+		Platform: "x86_64-cel_ds4101-r0",
+		Config:   wiringapi.SwitchProfileConfig{},
+		MaxPorts: 272,
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},
+			"E1/1":  {NOSName: "1/1", BaseNOSName: "Ethernet0", Label: "1", Profile: "OSFP-2x400G", Pipeline: "1"},
+			"E1/2":  {NOSName: "1/2", BaseNOSName: "Ethernet8", Label: "2", Profile: "OSFP-2x400G", Pipeline: "1"},
+			"E1/3":  {NOSName: "1/3", BaseNOSName: "Ethernet16", Label: "3", Profile: "OSFP-2x400G", Pipeline: "2"},
+			"E1/4":  {NOSName: "1/4", BaseNOSName: "Ethernet24", Label: "4", Profile: "OSFP-2x400G", Pipeline: "2"},
+			"E1/5":  {NOSName: "1/5", BaseNOSName: "Ethernet32", Label: "5", Profile: "OSFP-2x400G", Pipeline: "3"},
+			"E1/6":  {NOSName: "1/6", BaseNOSName: "Ethernet40", Label: "6", Profile: "OSFP-2x400G", Pipeline: "3"},
+			"E1/7":  {NOSName: "1/7", BaseNOSName: "Ethernet48", Label: "7", Profile: "OSFP-2x400G", Pipeline: "4"},
+			"E1/8":  {NOSName: "1/8", BaseNOSName: "Ethernet56", Label: "8", Profile: "OSFP-2x400G", Pipeline: "4"},
+			"E1/9":  {NOSName: "1/9", BaseNOSName: "Ethernet64", Label: "9", Profile: "OSFP-2x400G", Pipeline: "5"},
+			"E1/10": {NOSName: "1/10", BaseNOSName: "Ethernet72", Label: "10", Profile: "OSFP-2x400G", Pipeline: "5"},
+			"E1/11": {NOSName: "1/11", BaseNOSName: "Ethernet80", Label: "11", Profile: "OSFP-2x400G", Pipeline: "6"},
+			"E1/12": {NOSName: "1/12", BaseNOSName: "Ethernet88", Label: "12", Profile: "OSFP-2x400G", Pipeline: "6"},
+			"E1/13": {NOSName: "1/13", BaseNOSName: "Ethernet96", Label: "13", Profile: "OSFP-2x400G", Pipeline: "7"},
+			"E1/14": {NOSName: "1/14", BaseNOSName: "Ethernet104", Label: "14", Profile: "OSFP-2x400G", Pipeline: "7"},
+			"E1/15": {NOSName: "1/15", BaseNOSName: "Ethernet112", Label: "15", Profile: "OSFP-2x400G", Pipeline: "8"},
+			"E1/16": {NOSName: "1/16", BaseNOSName: "Ethernet120", Label: "16", Profile: "OSFP-2x400G", Pipeline: "8"},
+			"E1/17": {NOSName: "1/17", BaseNOSName: "Ethernet128", Label: "17", Profile: "OSFP-2x400G", Pipeline: "9"},
+			"E1/18": {NOSName: "1/18", BaseNOSName: "Ethernet136", Label: "18", Profile: "OSFP-2x400G", Pipeline: "9"},
+			"E1/19": {NOSName: "1/19", BaseNOSName: "Ethernet144", Label: "19", Profile: "OSFP-2x400G", Pipeline: "10"},
+			"E1/20": {NOSName: "1/20", BaseNOSName: "Ethernet152", Label: "20", Profile: "OSFP-2x400G", Pipeline: "10"},
+			"E1/21": {NOSName: "1/21", BaseNOSName: "Ethernet160", Label: "21", Profile: "OSFP-2x400G", Pipeline: "11"},
+			"E1/22": {NOSName: "1/22", BaseNOSName: "Ethernet168", Label: "22", Profile: "OSFP-2x400G", Pipeline: "11"},
+			"E1/23": {NOSName: "1/23", BaseNOSName: "Ethernet176", Label: "23", Profile: "OSFP-2x400G", Pipeline: "12"},
+			"E1/24": {NOSName: "1/24", BaseNOSName: "Ethernet184", Label: "24", Profile: "OSFP-2x400G", Pipeline: "12"},
+			"E1/25": {NOSName: "1/25", BaseNOSName: "Ethernet192", Label: "25", Profile: "OSFP-2x400G", Pipeline: "13"},
+			"E1/26": {NOSName: "1/26", BaseNOSName: "Ethernet200", Label: "26", Profile: "OSFP-2x400G", Pipeline: "13"},
+			"E1/27": {NOSName: "1/27", BaseNOSName: "Ethernet208", Label: "27", Profile: "OSFP-2x400G", Pipeline: "14"},
+			"E1/28": {NOSName: "1/28", BaseNOSName: "Ethernet216", Label: "28", Profile: "OSFP-2x400G", Pipeline: "14"},
+			"E1/29": {NOSName: "1/29", BaseNOSName: "Ethernet224", Label: "29", Profile: "OSFP-2x400G", Pipeline: "15"},
+			"E1/30": {NOSName: "1/30", BaseNOSName: "Ethernet232", Label: "30", Profile: "OSFP-2x400G", Pipeline: "15"},
+			"E1/31": {NOSName: "1/31", BaseNOSName: "Ethernet240", Label: "31", Profile: "OSFP-2x400G", Pipeline: "16"},
+			"E1/32": {NOSName: "1/32", BaseNOSName: "Ethernet248", Label: "32", Profile: "OSFP-2x400G", Pipeline: "16"}, // 32x OSFP-2x400G
+			"E1/33": {NOSName: "Ethernet256", Label: "M1", Profile: "SFP28-10G"},                                        // 1x SFP28-10G
+			"E1/34": {NOSName: "Ethernet257", Label: "M2", Profile: "SFP28-10G"},                                        // 1x SFP28-10G
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"SFP28-10G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "10G",
+					Supported: []string{"1G", "10G"},
+				},
+			},
+			"OSFP-2x400G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "2x400G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x100G": {Offsets: []string{"0"}},
+						"1x200G": {Offsets: []string{"0"}},
+						"1x400G": {Offsets: []string{"0"}},
+						"2x40G":  {Offsets: []string{"0", "4"}},
+						"2x100G": {Offsets: []string{"0", "4"}},
+						"2x200G": {Offsets: []string{"0", "4"}},
+						"2x400G": {Offsets: []string{"0", "4"}},
+						"4x50G":  {Offsets: []string{"0", "2", "4", "6"}},
+						"4x100G": {Offsets: []string{"0", "2", "4", "6"}},
+						"4x200G": {Offsets: []string{"0", "2", "4", "6"}},
+						"8x10G":  {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+						"8x25G":  {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+						"8x50G":  {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+						"8x100G": {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+					},
+				},
+				AutoNegAllowed: true,
+				AutoNegDefault: false,
+			},
+		},
+		Pipelines: map[string]wiringapi.SwitchProfilePipeline{
+			"1":  {MaxPorts: 16},
+			"2":  {MaxPorts: 16},
+			"3":  {MaxPorts: 16},
+			"4":  {MaxPorts: 16},
+			"5":  {MaxPorts: 16},
+			"6":  {MaxPorts: 16},
+			"7":  {MaxPorts: 16},
+			"8":  {MaxPorts: 16},
+			"9":  {MaxPorts: 16},
+			"10": {MaxPorts: 16},
+			"11": {MaxPorts: 16},
+			"12": {MaxPorts: 16},
+			"13": {MaxPorts: 16},
+			"14": {MaxPorts: 16},
+			"15": {MaxPorts: 16},
+			"16": {MaxPorts: 16},
+		},
+	},
+}

--- a/netbox_hedgehog/fabric_profiles/p_bcm_dell_s5232f_on.go
+++ b/netbox_hedgehog/fabric_profiles/p_bcm_dell_s5232f_on.go
@@ -1,0 +1,99 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var DellS5232FON = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "dell-s5232f-on",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Dell S5232F-ON",
+		SwitchSilicon: SiliconBroadcomTD3_X7_3_2T,
+		Features: wiringapi.SwitchProfileFeatures{
+			Subinterfaces: true,
+			ACLs:          true,
+			L2VNI:         true,
+			L3VNI:         true,
+			RoCE:          true,
+			MCLAG:         true,
+			ESLAG:         true,
+			ECMPRoCEQPN:   false,
+		},
+		NOSType:  meta.NOSTypeSONiCBCMBase,
+		Platform: "x86_64-dellemc_s5232f_c3538-r0",
+		Config:   wiringapi.SwitchProfileConfig{},
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},
+			"E1/1":  {NOSName: "1/1", BaseNOSName: "Ethernet0", Label: "1", Profile: "QSFP28-100G"},
+			"E1/2":  {NOSName: "1/2", BaseNOSName: "Ethernet4", Label: "2", Profile: "QSFP28-100G"},
+			"E1/3":  {NOSName: "1/3", BaseNOSName: "Ethernet8", Label: "3", Profile: "QSFP28-100G"},
+			"E1/4":  {NOSName: "1/4", BaseNOSName: "Ethernet12", Label: "4", Profile: "QSFP28-100G"},
+			"E1/5":  {NOSName: "1/5", BaseNOSName: "Ethernet16", Label: "5", Profile: "QSFP28-100G"},
+			"E1/6":  {NOSName: "1/6", BaseNOSName: "Ethernet20", Label: "6", Profile: "QSFP28-100G"},
+			"E1/7":  {NOSName: "1/7", BaseNOSName: "Ethernet24", Label: "7", Profile: "QSFP28-100G"},
+			"E1/8":  {NOSName: "1/8", BaseNOSName: "Ethernet28", Label: "8", Profile: "QSFP28-100G"},
+			"E1/9":  {NOSName: "1/9", BaseNOSName: "Ethernet32", Label: "9", Profile: "QSFP28-100G"},
+			"E1/10": {NOSName: "1/10", BaseNOSName: "Ethernet36", Label: "10", Profile: "QSFP28-100G"},
+			"E1/11": {NOSName: "1/11", BaseNOSName: "Ethernet40", Label: "11", Profile: "QSFP28-100G"},
+			"E1/12": {NOSName: "1/12", BaseNOSName: "Ethernet44", Label: "12", Profile: "QSFP28-100G"},
+			"E1/13": {NOSName: "1/13", BaseNOSName: "Ethernet48", Label: "13", Profile: "QSFP28-100G"},
+			"E1/14": {NOSName: "1/14", BaseNOSName: "Ethernet52", Label: "14", Profile: "QSFP28-100G"},
+			"E1/15": {NOSName: "1/15", BaseNOSName: "Ethernet56", Label: "15", Profile: "QSFP28-100G"},
+			"E1/16": {NOSName: "1/16", BaseNOSName: "Ethernet60", Label: "16", Profile: "QSFP28-100G"},
+			"E1/17": {NOSName: "1/17", BaseNOSName: "Ethernet64", Label: "17", Profile: "QSFP28-100G"},
+			"E1/18": {NOSName: "1/18", BaseNOSName: "Ethernet68", Label: "18", Profile: "QSFP28-100G"},
+			"E1/19": {NOSName: "1/19", BaseNOSName: "Ethernet72", Label: "19", Profile: "QSFP28-100G"},
+			"E1/20": {NOSName: "1/20", BaseNOSName: "Ethernet76", Label: "20", Profile: "QSFP28-100G"},
+			"E1/21": {NOSName: "1/21", BaseNOSName: "Ethernet80", Label: "21", Profile: "QSFP28-100G"},
+			"E1/22": {NOSName: "1/22", BaseNOSName: "Ethernet84", Label: "22", Profile: "QSFP28-100G"},
+			"E1/23": {NOSName: "1/23", BaseNOSName: "Ethernet88", Label: "23", Profile: "QSFP28-100G"},
+			"E1/24": {NOSName: "1/24", BaseNOSName: "Ethernet92", Label: "24", Profile: "QSFP28-100G"},
+			"E1/25": {NOSName: "1/25", BaseNOSName: "Ethernet96", Label: "25", Profile: "QSFP28-100G"},
+			"E1/26": {NOSName: "1/26", BaseNOSName: "Ethernet100", Label: "26", Profile: "QSFP28-100G"},
+			"E1/27": {NOSName: "1/27", BaseNOSName: "Ethernet104", Label: "27", Profile: "QSFP28-100G"},
+			"E1/28": {NOSName: "1/28", BaseNOSName: "Ethernet108", Label: "28", Profile: "QSFP28-100G"},
+			"E1/29": {NOSName: "1/29", BaseNOSName: "Ethernet112", Label: "29", Profile: "QSFP28-100G"},
+			"E1/30": {NOSName: "1/30", BaseNOSName: "Ethernet116", Label: "30", Profile: "QSFP28-100G"},
+			"E1/31": {NOSName: "1/31", BaseNOSName: "Ethernet120", Label: "31", Profile: "QSFP28-100G"},
+			"E1/32": {NOSName: "Ethernet124", Label: "32", Profile: "QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix}, // 32x QSFP28-100G, single port w/o breakout
+			"E1/33": {NOSName: "Ethernet128", Label: "33", Profile: "SFP28-10G"},
+			"E1/34": {NOSName: "Ethernet129", Label: "34", Profile: "SFP28-10G"},
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"SFP28-10G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "10G",
+					Supported: []string{"1G", "10G"},
+				},
+			},
+			"QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix: {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "100G",
+					Supported: []string{"40G", "100G"},
+				},
+			},
+			"QSFP28-100G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "1x100G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x100G": {Offsets: []string{"0"}},
+						"1x40G":  {Offsets: []string{"0"}},
+						"2x50G":  {Offsets: []string{"0", "2"}},
+						"1x50G":  {Offsets: []string{"0"}},
+						"4x25G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"4x10G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"1x25G":  {Offsets: []string{"0"}},
+						"1x10G":  {Offsets: []string{"0"}},
+					},
+				},
+			},
+		},
+	},
+}

--- a/netbox_hedgehog/fabric_profiles/p_bcm_dell_s5248f_on.go
+++ b/netbox_hedgehog/fabric_profiles/p_bcm_dell_s5248f_on.go
@@ -1,0 +1,165 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var DellS5248FON = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "dell-s5248f-on",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Dell S5248F-ON",
+		SwitchSilicon: SiliconBroadcomTD3_X7_3_2T,
+		Features: wiringapi.SwitchProfileFeatures{
+			Subinterfaces: true,
+			ACLs:          true,
+			L2VNI:         true,
+			L3VNI:         true,
+			RoCE:          true,
+			MCLAG:         true,
+			ESLAG:         true,
+			ECMPRoCEQPN:   false,
+		},
+		NOSType:  meta.NOSTypeSONiCBCMBase,
+		Platform: "x86_64-dellemc_s5248f_c3538-r0",
+		Config:   wiringapi.SwitchProfileConfig{},
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},
+			"E1/1":  {NOSName: "Ethernet0", Label: "1", Group: "1"},
+			"E1/2":  {NOSName: "Ethernet1", Label: "2", Group: "1"},
+			"E1/3":  {NOSName: "Ethernet2", Label: "3", Group: "1"},
+			"E1/4":  {NOSName: "Ethernet3", Label: "4", Group: "1"},
+			"E1/5":  {NOSName: "Ethernet4", Label: "5", Group: "2"},
+			"E1/6":  {NOSName: "Ethernet5", Label: "6", Group: "2"},
+			"E1/7":  {NOSName: "Ethernet6", Label: "7", Group: "2"},
+			"E1/8":  {NOSName: "Ethernet7", Label: "8", Group: "2"},
+			"E1/9":  {NOSName: "Ethernet8", Label: "9", Group: "3"},
+			"E1/10": {NOSName: "Ethernet9", Label: "10", Group: "3"},
+			"E1/11": {NOSName: "Ethernet10", Label: "11", Group: "3"},
+			"E1/12": {NOSName: "Ethernet11", Label: "12", Group: "3"},
+			"E1/13": {NOSName: "Ethernet12", Label: "13", Group: "4"},
+			"E1/14": {NOSName: "Ethernet13", Label: "14", Group: "4"},
+			"E1/15": {NOSName: "Ethernet14", Label: "15", Group: "4"},
+			"E1/16": {NOSName: "Ethernet15", Label: "16", Group: "4"},
+			"E1/17": {NOSName: "Ethernet16", Label: "17", Group: "5"},
+			"E1/18": {NOSName: "Ethernet17", Label: "18", Group: "5"},
+			"E1/19": {NOSName: "Ethernet18", Label: "19", Group: "5"},
+			"E1/20": {NOSName: "Ethernet19", Label: "20", Group: "5"},
+			"E1/21": {NOSName: "Ethernet20", Label: "21", Group: "6"},
+			"E1/22": {NOSName: "Ethernet21", Label: "22", Group: "6"},
+			"E1/23": {NOSName: "Ethernet22", Label: "23", Group: "6"},
+			"E1/24": {NOSName: "Ethernet23", Label: "24", Group: "6"},
+			"E1/25": {NOSName: "Ethernet24", Label: "25", Group: "7"},
+			"E1/26": {NOSName: "Ethernet25", Label: "26", Group: "7"},
+			"E1/27": {NOSName: "Ethernet26", Label: "27", Group: "7"},
+			"E1/28": {NOSName: "Ethernet27", Label: "28", Group: "7"},
+			"E1/29": {NOSName: "Ethernet28", Label: "29", Group: "8"},
+			"E1/30": {NOSName: "Ethernet29", Label: "30", Group: "8"},
+			"E1/31": {NOSName: "Ethernet30", Label: "31", Group: "8"},
+			"E1/32": {NOSName: "Ethernet31", Label: "32", Group: "8"},
+			"E1/33": {NOSName: "Ethernet32", Label: "33", Group: "9"},
+			"E1/34": {NOSName: "Ethernet33", Label: "34", Group: "9"},
+			"E1/35": {NOSName: "Ethernet34", Label: "35", Group: "9"},
+			"E1/36": {NOSName: "Ethernet35", Label: "36", Group: "9"},
+			"E1/37": {NOSName: "Ethernet36", Label: "37", Group: "10"},
+			"E1/38": {NOSName: "Ethernet37", Label: "38", Group: "10"},
+			"E1/39": {NOSName: "Ethernet38", Label: "39", Group: "10"},
+			"E1/40": {NOSName: "Ethernet39", Label: "40", Group: "10"},
+			"E1/41": {NOSName: "Ethernet40", Label: "41", Group: "11"},
+			"E1/42": {NOSName: "Ethernet41", Label: "42", Group: "11"},
+			"E1/43": {NOSName: "Ethernet42", Label: "43", Group: "11"},
+			"E1/44": {NOSName: "Ethernet43", Label: "44", Group: "11"},
+			"E1/45": {NOSName: "Ethernet44", Label: "45", Group: "12"},
+			"E1/46": {NOSName: "Ethernet45", Label: "46", Group: "12"},
+			"E1/47": {NOSName: "Ethernet46", Label: "47", Group: "12"},
+			"E1/48": {NOSName: "Ethernet47", Label: "48", Group: "12"},
+			"E1/49": {NOSName: "1/49", BaseNOSName: "Ethernet48", Label: "49", Profile: "QSFP28-100G"},
+			"E1/50": {NOSName: "1/50", BaseNOSName: "Ethernet52", Label: "50", Profile: "QSFP28-100G"},
+			"E1/51": {NOSName: "1/51", BaseNOSName: "Ethernet56", Label: "51", Profile: "QSFP28-100G"},
+			"E1/52": {NOSName: "1/52", BaseNOSName: "Ethernet60", Label: "52", Profile: "QSFP28-100G"},
+			"E1/53": {NOSName: "1/53", BaseNOSName: "Ethernet64", Label: "53", Profile: "QSFP28-100G"},
+			"E1/54": {NOSName: "1/54", BaseNOSName: "Ethernet68", Label: "54", Profile: "QSFP28-100G"},
+			"E1/55": {NOSName: "1/55", BaseNOSName: "Ethernet72", Label: "55", Profile: "QSFP28-100G"},
+			"E1/56": {NOSName: "1/56", BaseNOSName: "Ethernet76", Label: "56", Profile: "QSFP28-100G"},
+		},
+		PortGroups: map[string]wiringapi.SwitchProfilePortGroup{
+			"1": {
+				NOSName: "1",
+				Profile: "SFP28-25G",
+			},
+			"2": {
+				NOSName: "2",
+				Profile: "SFP28-25G",
+			},
+			"3": {
+				NOSName: "3",
+				Profile: "SFP28-25G",
+			},
+			"4": {
+				NOSName: "4",
+				Profile: "SFP28-25G",
+			},
+			"5": {
+				NOSName: "5",
+				Profile: "SFP28-25G",
+			},
+			"6": {
+				NOSName: "6",
+				Profile: "SFP28-25G",
+			},
+			"7": {
+				NOSName: "7",
+				Profile: "SFP28-25G",
+			},
+			"8": {
+				NOSName: "8",
+				Profile: "SFP28-25G",
+			},
+			"9": {
+				NOSName: "9",
+				Profile: "SFP28-25G",
+			},
+			"10": {
+				NOSName: "10",
+				Profile: "SFP28-25G",
+			},
+			"11": {
+				NOSName: "11",
+				Profile: "SFP28-25G",
+			},
+			"12": {
+				NOSName: "12",
+				Profile: "SFP28-25G",
+			},
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"SFP28-25G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "25G",
+					Supported: []string{"10G", "25G"},
+				},
+			},
+			"QSFP28-100G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "1x100G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x100G": {Offsets: []string{"0"}},
+						"1x40G":  {Offsets: []string{"0"}},
+						"2x50G":  {Offsets: []string{"0", "2"}},
+						"1x50G":  {Offsets: []string{"0"}},
+						"4x25G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"4x10G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"1x25G":  {Offsets: []string{"0"}},
+						"1x10G":  {Offsets: []string{"0"}},
+					},
+				},
+			},
+		},
+	},
+}

--- a/netbox_hedgehog/fabric_profiles/p_bcm_dell_z9332f_on.go
+++ b/netbox_hedgehog/fabric_profiles/p_bcm_dell_z9332f_on.go
@@ -1,0 +1,112 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var DellZ9332FON = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "dell-z9332f-on",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Dell Z9332F-ON",
+		SwitchSilicon: SiliconBroadcomTH3,
+		Features: wiringapi.SwitchProfileFeatures{
+			Subinterfaces: false,
+			ACLs:          true,
+			L2VNI:         false,
+			L3VNI:         false,
+			RoCE:          true,
+			MCLAG:         false,
+			ESLAG:         false,
+			ECMPRoCEQPN:   false,
+		},
+		NOSType:  meta.NOSTypeSONiCBCMBase,
+		Platform: "x86_64-dellemc_z9332f_d1508-r0",
+		Config:   wiringapi.SwitchProfileConfig{},
+		MaxPorts: 144,
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},
+			"E1/1":  {NOSName: "1/1", BaseNOSName: "Ethernet0", Label: "1", Profile: "QSFPDD-400G", Pipeline: "1"},
+			"E1/2":  {NOSName: "1/2", BaseNOSName: "Ethernet8", Label: "2", Profile: "QSFPDD-400G", Pipeline: "1"},
+			"E1/3":  {NOSName: "1/3", BaseNOSName: "Ethernet16", Label: "3", Profile: "QSFPDD-400G", Pipeline: "1"},
+			"E1/4":  {NOSName: "1/4", BaseNOSName: "Ethernet24", Label: "4", Profile: "QSFPDD-400G", Pipeline: "1"},
+			"E1/5":  {NOSName: "1/5", BaseNOSName: "Ethernet32", Label: "5", Profile: "QSFPDD-400G", Pipeline: "2"},
+			"E1/6":  {NOSName: "1/6", BaseNOSName: "Ethernet40", Label: "6", Profile: "QSFPDD-400G", Pipeline: "2"},
+			"E1/7":  {NOSName: "1/7", BaseNOSName: "Ethernet48", Label: "7", Profile: "QSFPDD-400G", Pipeline: "2"},
+			"E1/8":  {NOSName: "1/8", BaseNOSName: "Ethernet56", Label: "8", Profile: "QSFPDD-400G", Pipeline: "2"},
+			"E1/9":  {NOSName: "1/9", BaseNOSName: "Ethernet64", Label: "9", Profile: "QSFPDD-400G", Pipeline: "3"},
+			"E1/10": {NOSName: "1/10", BaseNOSName: "Ethernet72", Label: "10", Profile: "QSFPDD-400G", Pipeline: "3"},
+			"E1/11": {NOSName: "1/11", BaseNOSName: "Ethernet80", Label: "11", Profile: "QSFPDD-400G", Pipeline: "3"},
+			"E1/12": {NOSName: "1/12", BaseNOSName: "Ethernet88", Label: "12", Profile: "QSFPDD-400G", Pipeline: "3"},
+			"E1/13": {NOSName: "1/13", BaseNOSName: "Ethernet96", Label: "13", Profile: "QSFPDD-400G", Pipeline: "4"},
+			"E1/14": {NOSName: "1/14", BaseNOSName: "Ethernet104", Label: "14", Profile: "QSFPDD-400G", Pipeline: "4"},
+			"E1/15": {NOSName: "1/15", BaseNOSName: "Ethernet112", Label: "15", Profile: "QSFPDD-400G", Pipeline: "4"},
+			"E1/16": {NOSName: "1/16", BaseNOSName: "Ethernet120", Label: "16", Profile: "QSFPDD-400G", Pipeline: "4"},
+			"E1/17": {NOSName: "1/17", BaseNOSName: "Ethernet128", Label: "17", Profile: "QSFPDD-400G", Pipeline: "5"},
+			"E1/18": {NOSName: "1/18", BaseNOSName: "Ethernet136", Label: "18", Profile: "QSFPDD-400G", Pipeline: "5"},
+			"E1/19": {NOSName: "1/19", BaseNOSName: "Ethernet144", Label: "19", Profile: "QSFPDD-400G", Pipeline: "5"},
+			"E1/20": {NOSName: "1/20", BaseNOSName: "Ethernet152", Label: "20", Profile: "QSFPDD-400G", Pipeline: "5"},
+			"E1/21": {NOSName: "1/21", BaseNOSName: "Ethernet160", Label: "21", Profile: "QSFPDD-400G", Pipeline: "6"},
+			"E1/22": {NOSName: "1/22", BaseNOSName: "Ethernet168", Label: "22", Profile: "QSFPDD-400G", Pipeline: "6"},
+			"E1/23": {NOSName: "1/23", BaseNOSName: "Ethernet176", Label: "23", Profile: "QSFPDD-400G", Pipeline: "6"},
+			"E1/24": {NOSName: "1/24", BaseNOSName: "Ethernet184", Label: "24", Profile: "QSFPDD-400G", Pipeline: "6"},
+			"E1/25": {NOSName: "1/25", BaseNOSName: "Ethernet192", Label: "25", Profile: "QSFPDD-400G", Pipeline: "7"},
+			"E1/26": {NOSName: "1/26", BaseNOSName: "Ethernet200", Label: "26", Profile: "QSFPDD-400G", Pipeline: "7"},
+			"E1/27": {NOSName: "1/27", BaseNOSName: "Ethernet208", Label: "27", Profile: "QSFPDD-400G", Pipeline: "7"},
+			"E1/28": {NOSName: "1/28", BaseNOSName: "Ethernet216", Label: "28", Profile: "QSFPDD-400G", Pipeline: "7"},
+			"E1/29": {NOSName: "1/29", BaseNOSName: "Ethernet224", Label: "29", Profile: "QSFPDD-400G", Pipeline: "8"},
+			"E1/30": {NOSName: "1/30", BaseNOSName: "Ethernet232", Label: "30", Profile: "QSFPDD-400G", Pipeline: "8"},
+			"E1/31": {NOSName: "1/31", BaseNOSName: "Ethernet240", Label: "31", Profile: "QSFPDD-400G", Pipeline: "8"},
+			"E1/32": {NOSName: "1/32", BaseNOSName: "Ethernet248", Label: "32", Profile: "QSFPDD-400G", Pipeline: "8"}, // 32x QSFPDD-400G
+			"E1/33": {NOSName: "Ethernet256", Label: "M1", Profile: "SFP28-10G"},                                       // 1x SFP28-10G
+			"E1/34": {NOSName: "Ethernet257", Label: "M2", Profile: "SFP28-10G"},                                       // 1x SFP28-10G
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"SFP28-10G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "10G",
+					Supported: []string{"1G", "10G"},
+				},
+			},
+			"QSFPDD-400G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "1x400G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x400G": {Offsets: []string{"0"}},
+						"1x200G": {Offsets: []string{"0"}},
+						"1x100G": {Offsets: []string{"0"}},
+						"1x40G":  {Offsets: []string{"0"}},
+						"1x50G":  {Offsets: []string{"0"}},
+						"1x25G":  {Offsets: []string{"0"}},
+						"1x10G":  {Offsets: []string{"0"}},
+						"2x200G": {Offsets: []string{"0", "4"}},
+						"2x100G": {Offsets: []string{"0", "4"}},
+						"2x40G":  {Offsets: []string{"0", "4"}},
+						"4x100G": {Offsets: []string{"0", "2", "4", "6"}},
+						"4x25G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"4x10G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"8x50G":  {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+						"8x25G":  {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+						"8x10G":  {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+					},
+				},
+			},
+		},
+		Pipelines: map[string]wiringapi.SwitchProfilePipeline{
+			"1": {MaxPorts: 18},
+			"2": {MaxPorts: 18},
+			"3": {MaxPorts: 18},
+			"4": {MaxPorts: 18},
+			"5": {MaxPorts: 18},
+			"6": {MaxPorts: 18},
+			"7": {MaxPorts: 18},
+			"8": {MaxPorts: 18},
+		},
+	},
+}

--- a/netbox_hedgehog/fabric_profiles/p_bcm_edgecore_dcs203.go
+++ b/netbox_hedgehog/fabric_profiles/p_bcm_edgecore_dcs203.go
@@ -1,0 +1,144 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var EdgecoreDCS203 = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "edgecore-dcs203",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Edgecore DCS203",
+		OtherNames:    []string{"Edgecore AS7326-56X"},
+		SwitchSilicon: SiliconBroadcomTD3_X7_2_0T,
+		Features: wiringapi.SwitchProfileFeatures{
+			Subinterfaces: true,
+			ACLs:          true,
+			L2VNI:         true,
+			L3VNI:         true,
+			RoCE:          true,
+			MCLAG:         true,
+			ESLAG:         true,
+			ECMPRoCEQPN:   false,
+		},
+		NOSType:  meta.NOSTypeSONiCBCMBase,
+		Platform: "x86_64-accton_as7326_56x-r0",
+		Config:   wiringapi.SwitchProfileConfig{},
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},
+			"E1/1":  {NOSName: "Ethernet0", Label: "1", Group: "1"},
+			"E1/2":  {NOSName: "Ethernet1", Label: "2", Group: "1"},
+			"E1/3":  {NOSName: "Ethernet2", Label: "3", Group: "1"},
+			"E1/4":  {NOSName: "Ethernet3", Label: "4", Group: "1"},
+			"E1/5":  {NOSName: "Ethernet4", Label: "5", Group: "1"},
+			"E1/6":  {NOSName: "Ethernet5", Label: "6", Group: "1"},
+			"E1/7":  {NOSName: "Ethernet6", Label: "7", Group: "1"},
+			"E1/8":  {NOSName: "Ethernet7", Label: "8", Group: "1"},
+			"E1/9":  {NOSName: "Ethernet8", Label: "9", Group: "1"},
+			"E1/10": {NOSName: "Ethernet9", Label: "10", Group: "1"},
+			"E1/11": {NOSName: "Ethernet10", Label: "11", Group: "1"},
+			"E1/12": {NOSName: "Ethernet11", Label: "12", Group: "1"},
+			"E1/13": {NOSName: "Ethernet12", Label: "13", Group: "2"},
+			"E1/14": {NOSName: "Ethernet13", Label: "14", Group: "2"},
+			"E1/15": {NOSName: "Ethernet14", Label: "15", Group: "2"},
+			"E1/16": {NOSName: "Ethernet15", Label: "16", Group: "2"},
+			"E1/17": {NOSName: "Ethernet16", Label: "17", Group: "2"},
+			"E1/18": {NOSName: "Ethernet17", Label: "18", Group: "2"},
+			"E1/19": {NOSName: "Ethernet18", Label: "19", Group: "2"},
+			"E1/20": {NOSName: "Ethernet19", Label: "20", Group: "2"},
+			"E1/21": {NOSName: "Ethernet20", Label: "21", Group: "2"},
+			"E1/22": {NOSName: "Ethernet21", Label: "22", Group: "2"},
+			"E1/23": {NOSName: "Ethernet22", Label: "23", Group: "2"},
+			"E1/24": {NOSName: "Ethernet23", Label: "24", Group: "2"},
+			"E1/25": {NOSName: "Ethernet24", Label: "25", Group: "3"},
+			"E1/26": {NOSName: "Ethernet25", Label: "26", Group: "3"},
+			"E1/27": {NOSName: "Ethernet26", Label: "27", Group: "3"},
+			"E1/28": {NOSName: "Ethernet27", Label: "28", Group: "3"},
+			"E1/29": {NOSName: "Ethernet28", Label: "29", Group: "3"},
+			"E1/30": {NOSName: "Ethernet29", Label: "30", Group: "3"},
+			"E1/31": {NOSName: "Ethernet30", Label: "31", Group: "3"},
+			"E1/32": {NOSName: "Ethernet31", Label: "32", Group: "3"},
+			"E1/33": {NOSName: "Ethernet32", Label: "33", Group: "3"},
+			"E1/34": {NOSName: "Ethernet33", Label: "34", Group: "3"},
+			"E1/35": {NOSName: "Ethernet34", Label: "35", Group: "3"},
+			"E1/36": {NOSName: "Ethernet35", Label: "36", Group: "3"},
+			"E1/37": {NOSName: "Ethernet36", Label: "37", Group: "4"},
+			"E1/38": {NOSName: "Ethernet37", Label: "38", Group: "4"},
+			"E1/39": {NOSName: "Ethernet38", Label: "39", Group: "4"},
+			"E1/40": {NOSName: "Ethernet39", Label: "40", Group: "4"},
+			"E1/41": {NOSName: "Ethernet40", Label: "41", Group: "4"},
+			"E1/42": {NOSName: "Ethernet41", Label: "42", Group: "4"},
+			"E1/43": {NOSName: "Ethernet42", Label: "43", Group: "4"},
+			"E1/44": {NOSName: "Ethernet43", Label: "44", Group: "4"},
+			"E1/45": {NOSName: "Ethernet44", Label: "45", Group: "4"},
+			"E1/46": {NOSName: "Ethernet45", Label: "46", Group: "4"},
+			"E1/47": {NOSName: "Ethernet46", Label: "47", Group: "4"},
+			"E1/48": {NOSName: "Ethernet47", Label: "48", Group: "4"}, // 48 x SFP28-25G, 4 Groups of 12 ports
+			"E1/49": {NOSName: "1/49", BaseNOSName: "Ethernet48", Label: "49", Profile: "QSFP28-100G"},
+			"E1/50": {NOSName: "1/53", BaseNOSName: "Ethernet52", Label: "50", Profile: "QSFP28-100G"},
+			"E1/51": {NOSName: "1/57", BaseNOSName: "Ethernet56", Label: "51", Profile: "QSFP28-100G"},
+			"E1/52": {NOSName: "1/61", BaseNOSName: "Ethernet60", Label: "52", Profile: "QSFP28-100G"},
+			"E1/53": {NOSName: "1/65", BaseNOSName: "Ethernet64", Label: "53", Profile: "QSFP28-100G"},
+			"E1/54": {NOSName: "1/69", BaseNOSName: "Ethernet68", Label: "54", Profile: "QSFP28-100G"},
+			"E1/55": {NOSName: "1/73", BaseNOSName: "Ethernet72", Label: "55", Profile: "QSFP28-100G"},
+			"E1/56": {NOSName: "Ethernet76", Label: "56", Profile: "QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix}, // 8x QSFP28-100G, with last one not breakable
+			"E1/57": {NOSName: "Ethernet80", Label: "57", Profile: "SFP28-10G"},
+			"E1/58": {NOSName: "Ethernet81", Label: "58", Profile: "SFP28-10G"}, // 2x SFP28-10G
+		},
+		PortGroups: map[string]wiringapi.SwitchProfilePortGroup{
+			"1": {
+				NOSName: "1",
+				Profile: "SFP28-25G",
+			},
+			"2": {
+				NOSName: "2",
+				Profile: "SFP28-25G",
+			},
+			"3": {
+				NOSName: "3",
+				Profile: "SFP28-25G",
+			},
+			"4": {
+				NOSName: "4",
+				Profile: "SFP28-25G",
+			},
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"SFP28-25G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "25G",
+					Supported: []string{"10G", "25G"},
+				},
+			},
+			"SFP28-10G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "10G",
+					Supported: []string{"1G", "10G"},
+				},
+			},
+			"QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix: {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "100G",
+					Supported: []string{"40G", "100G"},
+				},
+			},
+			"QSFP28-100G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "1x100G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x100G": {Offsets: []string{"0"}},
+						"1x40G":  {Offsets: []string{"0"}},
+						"4x25G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"4x10G":  {Offsets: []string{"0", "1", "2", "3"}},
+					},
+				},
+			},
+		},
+	},
+}

--- a/netbox_hedgehog/fabric_profiles/p_bcm_edgecore_dcs204.go
+++ b/netbox_hedgehog/fabric_profiles/p_bcm_edgecore_dcs204.go
@@ -1,0 +1,100 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var EdgecoreDCS204 = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "edgecore-dcs204",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Edgecore DCS204",
+		OtherNames:    []string{"Edgecore AS7726-32X"},
+		SwitchSilicon: SiliconBroadcomTD3_X7_3_2T,
+		Features: wiringapi.SwitchProfileFeatures{
+			Subinterfaces: true,
+			ACLs:          true,
+			L2VNI:         true,
+			L3VNI:         true,
+			RoCE:          true,
+			MCLAG:         true,
+			ESLAG:         true,
+			ECMPRoCEQPN:   false,
+		},
+		NOSType:  meta.NOSTypeSONiCBCMBase,
+		Platform: "x86_64-accton_as7726_32x-r0",
+		Config:   wiringapi.SwitchProfileConfig{},
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},
+			"E1/1":  {NOSName: "1/1", BaseNOSName: "Ethernet0", Label: "1", Profile: "QSFP28-100G"},
+			"E1/2":  {NOSName: "1/2", BaseNOSName: "Ethernet4", Label: "2", Profile: "QSFP28-100G"},
+			"E1/3":  {NOSName: "1/3", BaseNOSName: "Ethernet8", Label: "3", Profile: "QSFP28-100G"},
+			"E1/4":  {NOSName: "1/4", BaseNOSName: "Ethernet12", Label: "4", Profile: "QSFP28-100G"},
+			"E1/5":  {NOSName: "1/5", BaseNOSName: "Ethernet16", Label: "5", Profile: "QSFP28-100G"},
+			"E1/6":  {NOSName: "1/6", BaseNOSName: "Ethernet20", Label: "6", Profile: "QSFP28-100G"},
+			"E1/7":  {NOSName: "1/7", BaseNOSName: "Ethernet24", Label: "7", Profile: "QSFP28-100G"},
+			"E1/8":  {NOSName: "1/8", BaseNOSName: "Ethernet28", Label: "8", Profile: "QSFP28-100G"},
+			"E1/9":  {NOSName: "1/9", BaseNOSName: "Ethernet32", Label: "9", Profile: "QSFP28-100G"},
+			"E1/10": {NOSName: "1/10", BaseNOSName: "Ethernet36", Label: "10", Profile: "QSFP28-100G"},
+			"E1/11": {NOSName: "1/11", BaseNOSName: "Ethernet40", Label: "11", Profile: "QSFP28-100G"},
+			"E1/12": {NOSName: "1/12", BaseNOSName: "Ethernet44", Label: "12", Profile: "QSFP28-100G"},
+			"E1/13": {NOSName: "1/13", BaseNOSName: "Ethernet48", Label: "13", Profile: "QSFP28-100G"},
+			"E1/14": {NOSName: "1/14", BaseNOSName: "Ethernet52", Label: "14", Profile: "QSFP28-100G"},
+			"E1/15": {NOSName: "1/15", BaseNOSName: "Ethernet56", Label: "15", Profile: "QSFP28-100G"},
+			"E1/16": {NOSName: "1/16", BaseNOSName: "Ethernet60", Label: "16", Profile: "QSFP28-100G"},
+			"E1/17": {NOSName: "1/17", BaseNOSName: "Ethernet64", Label: "17", Profile: "QSFP28-100G"},
+			"E1/18": {NOSName: "1/18", BaseNOSName: "Ethernet68", Label: "18", Profile: "QSFP28-100G"},
+			"E1/19": {NOSName: "1/19", BaseNOSName: "Ethernet72", Label: "19", Profile: "QSFP28-100G"},
+			"E1/20": {NOSName: "1/20", BaseNOSName: "Ethernet76", Label: "20", Profile: "QSFP28-100G"},
+			"E1/21": {NOSName: "1/21", BaseNOSName: "Ethernet80", Label: "21", Profile: "QSFP28-100G"},
+			"E1/22": {NOSName: "1/22", BaseNOSName: "Ethernet84", Label: "22", Profile: "QSFP28-100G"},
+			"E1/23": {NOSName: "1/23", BaseNOSName: "Ethernet88", Label: "23", Profile: "QSFP28-100G"},
+			"E1/24": {NOSName: "1/24", BaseNOSName: "Ethernet92", Label: "24", Profile: "QSFP28-100G"},
+			"E1/25": {NOSName: "1/25", BaseNOSName: "Ethernet96", Label: "25", Profile: "QSFP28-100G"},
+			"E1/26": {NOSName: "1/26", BaseNOSName: "Ethernet100", Label: "26", Profile: "QSFP28-100G"},
+			"E1/27": {NOSName: "1/27", BaseNOSName: "Ethernet104", Label: "27", Profile: "QSFP28-100G"},
+			"E1/28": {NOSName: "1/28", BaseNOSName: "Ethernet108", Label: "28", Profile: "QSFP28-100G"},
+			"E1/29": {NOSName: "1/29", BaseNOSName: "Ethernet112", Label: "29", Profile: "QSFP28-100G"},
+			"E1/30": {NOSName: "1/30", BaseNOSName: "Ethernet116", Label: "30", Profile: "QSFP28-100G"},
+			"E1/31": {NOSName: "1/31", BaseNOSName: "Ethernet120", Label: "31", Profile: "QSFP28-100G"},
+			"E1/32": {NOSName: "Ethernet124", Label: "32", Profile: "QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix}, // 32x QSFP28-100G, single port w/o breakout
+			"E1/33": {NOSName: "Ethernet128", Label: "33", Profile: "SFP28-10G"},
+			"E1/34": {NOSName: "Ethernet129", Label: "34", Profile: "SFP28-10G"},
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"SFP28-10G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "10G",
+					Supported: []string{"1G", "10G"},
+				},
+			},
+			"QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix: {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "100G",
+					Supported: []string{"40G", "100G"},
+				},
+			},
+			"QSFP28-100G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "1x100G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x100G": {Offsets: []string{"0"}},
+						"1x40G":  {Offsets: []string{"0"}},
+						"2x50G":  {Offsets: []string{"0", "2"}},
+						"1x50G":  {Offsets: []string{"0"}},
+						"4x25G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"4x10G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"1x25G":  {Offsets: []string{"0"}},
+						"1x10G":  {Offsets: []string{"0"}},
+					},
+				},
+			},
+		},
+	},
+}

--- a/netbox_hedgehog/fabric_profiles/p_bcm_edgecore_dcs501.go
+++ b/netbox_hedgehog/fabric_profiles/p_bcm_edgecore_dcs501.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var EdgecoreDCS501 = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "edgecore-dcs501",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Edgecore DCS501",
+		OtherNames:    []string{"Edgecore AS7712-32X"},
+		SwitchSilicon: SiliconBroadcomTH,
+		Features: wiringapi.SwitchProfileFeatures{
+			Subinterfaces: false,
+			ACLs:          true,
+			L2VNI:         false,
+			L3VNI:         false,
+			RoCE:          false,
+			MCLAG:         false,
+			ESLAG:         false,
+			ECMPRoCEQPN:   false,
+		},
+		NOSType:  meta.NOSTypeSONiCBCMBase,
+		Platform: "x86_64-accton_as7712_32x-r0",
+		Config:   wiringapi.SwitchProfileConfig{},
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},
+			"E1/1":  {NOSName: "1/1", BaseNOSName: "Ethernet0", Label: "1", Profile: "QSFP28-100G"},
+			"E1/2":  {NOSName: "1/2", BaseNOSName: "Ethernet4", Label: "2", Profile: "QSFP28-100G"},
+			"E1/3":  {NOSName: "1/3", BaseNOSName: "Ethernet8", Label: "3", Profile: "QSFP28-100G"},
+			"E1/4":  {NOSName: "1/4", BaseNOSName: "Ethernet12", Label: "4", Profile: "QSFP28-100G"},
+			"E1/5":  {NOSName: "1/5", BaseNOSName: "Ethernet16", Label: "5", Profile: "QSFP28-100G"},
+			"E1/6":  {NOSName: "1/6", BaseNOSName: "Ethernet20", Label: "6", Profile: "QSFP28-100G"},
+			"E1/7":  {NOSName: "1/7", BaseNOSName: "Ethernet24", Label: "7", Profile: "QSFP28-100G"},
+			"E1/8":  {NOSName: "1/8", BaseNOSName: "Ethernet28", Label: "8", Profile: "QSFP28-100G"},
+			"E1/9":  {NOSName: "1/9", BaseNOSName: "Ethernet32", Label: "9", Profile: "QSFP28-100G"},
+			"E1/10": {NOSName: "1/10", BaseNOSName: "Ethernet36", Label: "10", Profile: "QSFP28-100G"},
+			"E1/11": {NOSName: "1/11", BaseNOSName: "Ethernet40", Label: "11", Profile: "QSFP28-100G"},
+			"E1/12": {NOSName: "1/12", BaseNOSName: "Ethernet44", Label: "12", Profile: "QSFP28-100G"},
+			"E1/13": {NOSName: "1/13", BaseNOSName: "Ethernet48", Label: "13", Profile: "QSFP28-100G"},
+			"E1/14": {NOSName: "1/14", BaseNOSName: "Ethernet52", Label: "14", Profile: "QSFP28-100G"},
+			"E1/15": {NOSName: "1/15", BaseNOSName: "Ethernet56", Label: "15", Profile: "QSFP28-100G"},
+			"E1/16": {NOSName: "1/16", BaseNOSName: "Ethernet60", Label: "16", Profile: "QSFP28-100G"},
+			"E1/17": {NOSName: "1/17", BaseNOSName: "Ethernet64", Label: "17", Profile: "QSFP28-100G"},
+			"E1/18": {NOSName: "1/18", BaseNOSName: "Ethernet68", Label: "18", Profile: "QSFP28-100G"},
+			"E1/19": {NOSName: "1/19", BaseNOSName: "Ethernet72", Label: "19", Profile: "QSFP28-100G"},
+			"E1/20": {NOSName: "1/20", BaseNOSName: "Ethernet76", Label: "20", Profile: "QSFP28-100G"},
+			"E1/21": {NOSName: "1/21", BaseNOSName: "Ethernet80", Label: "21", Profile: "QSFP28-100G"},
+			"E1/22": {NOSName: "1/22", BaseNOSName: "Ethernet84", Label: "22", Profile: "QSFP28-100G"},
+			"E1/23": {NOSName: "1/23", BaseNOSName: "Ethernet88", Label: "23", Profile: "QSFP28-100G"},
+			"E1/24": {NOSName: "1/24", BaseNOSName: "Ethernet92", Label: "24", Profile: "QSFP28-100G"},
+			"E1/25": {NOSName: "1/25", BaseNOSName: "Ethernet96", Label: "25", Profile: "QSFP28-100G"},
+			"E1/26": {NOSName: "1/26", BaseNOSName: "Ethernet100", Label: "26", Profile: "QSFP28-100G"},
+			"E1/27": {NOSName: "1/27", BaseNOSName: "Ethernet104", Label: "27", Profile: "QSFP28-100G"},
+			"E1/28": {NOSName: "1/28", BaseNOSName: "Ethernet108", Label: "28", Profile: "QSFP28-100G"},
+			"E1/29": {NOSName: "1/29", BaseNOSName: "Ethernet112", Label: "29", Profile: "QSFP28-100G"},
+			"E1/30": {NOSName: "1/30", BaseNOSName: "Ethernet116", Label: "30", Profile: "QSFP28-100G"},
+			"E1/31": {NOSName: "1/31", BaseNOSName: "Ethernet120", Label: "31", Profile: "QSFP28-100G"},
+			"E1/32": {NOSName: "1/32", BaseNOSName: "Ethernet124", Label: "32", Profile: "QSFP28-100G"}, // 32x QSFP28-100G
+		},
+
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"QSFP28-100G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "1x100G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x100G": {Offsets: []string{"0"}},
+						"1x40G":  {Offsets: []string{"0"}},
+						"4x25G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"4x10G":  {Offsets: []string{"0", "1", "2", "3"}},
+					},
+				},
+			},
+		},
+	},
+}

--- a/netbox_hedgehog/fabric_profiles/p_bcm_edgecore_eps203.go
+++ b/netbox_hedgehog/fabric_profiles/p_bcm_edgecore_eps203.go
@@ -1,0 +1,124 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var EdgecoreEPS203 = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "edgecore-eps203",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Edgecore EPS203",
+		OtherNames:    []string{"Edgecore AS4630-54NPE"},
+		SwitchSilicon: SiliconBroadcomTD3_X3,
+		Features: wiringapi.SwitchProfileFeatures{
+			Subinterfaces: false,
+			ACLs:          true,
+			L2VNI:         true,
+			L3VNI:         true,
+			RoCE:          false,
+			MCLAG:         true,
+			ESLAG:         true,
+			ECMPRoCEQPN:   false,
+		},
+		Notes:    "Doesn't support StaticExternals and ExternalAttachments with VLANs due to the lack of subinterfaces support.",
+		NOSType:  meta.NOSTypeSONiCBCMCampus,
+		Platform: "x86_64-accton_as4630_54npe-r0",
+		Config: wiringapi.SwitchProfileConfig{
+			MaxPathsEBGP: 16,
+		},
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},
+			"E1/1":  {NOSName: "Ethernet0", Label: "1", Profile: "RJ45-2.5G"},
+			"E1/2":  {NOSName: "Ethernet1", Label: "2", Profile: "RJ45-2.5G"},
+			"E1/3":  {NOSName: "Ethernet2", Label: "3", Profile: "RJ45-2.5G"},
+			"E1/4":  {NOSName: "Ethernet3", Label: "4", Profile: "RJ45-2.5G"},
+			"E1/5":  {NOSName: "Ethernet4", Label: "5", Profile: "RJ45-2.5G"},
+			"E1/6":  {NOSName: "Ethernet5", Label: "6", Profile: "RJ45-2.5G"},
+			"E1/7":  {NOSName: "Ethernet6", Label: "7", Profile: "RJ45-2.5G"},
+			"E1/8":  {NOSName: "Ethernet7", Label: "8", Profile: "RJ45-2.5G"},
+			"E1/9":  {NOSName: "Ethernet8", Label: "9", Profile: "RJ45-2.5G"},
+			"E1/10": {NOSName: "Ethernet9", Label: "10", Profile: "RJ45-2.5G"},
+			"E1/11": {NOSName: "Ethernet10", Label: "11", Profile: "RJ45-2.5G"},
+			"E1/12": {NOSName: "Ethernet11", Label: "12", Profile: "RJ45-2.5G"},
+			"E1/13": {NOSName: "Ethernet12", Label: "13", Profile: "RJ45-2.5G"},
+			"E1/14": {NOSName: "Ethernet13", Label: "14", Profile: "RJ45-2.5G"},
+			"E1/15": {NOSName: "Ethernet14", Label: "15", Profile: "RJ45-2.5G"},
+			"E1/16": {NOSName: "Ethernet15", Label: "16", Profile: "RJ45-2.5G"},
+			"E1/17": {NOSName: "Ethernet16", Label: "17", Profile: "RJ45-2.5G"},
+			"E1/18": {NOSName: "Ethernet17", Label: "18", Profile: "RJ45-2.5G"},
+			"E1/19": {NOSName: "Ethernet18", Label: "19", Profile: "RJ45-2.5G"},
+			"E1/20": {NOSName: "Ethernet19", Label: "20", Profile: "RJ45-2.5G"},
+			"E1/21": {NOSName: "Ethernet20", Label: "21", Profile: "RJ45-2.5G"},
+			"E1/22": {NOSName: "Ethernet21", Label: "22", Profile: "RJ45-2.5G"},
+			"E1/23": {NOSName: "Ethernet22", Label: "23", Profile: "RJ45-2.5G"},
+			"E1/24": {NOSName: "Ethernet23", Label: "24", Profile: "RJ45-2.5G"},
+			"E1/25": {NOSName: "Ethernet24", Label: "25", Profile: "RJ45-2.5G"},
+			"E1/26": {NOSName: "Ethernet25", Label: "26", Profile: "RJ45-2.5G"},
+			"E1/27": {NOSName: "Ethernet26", Label: "27", Profile: "RJ45-2.5G"},
+			"E1/28": {NOSName: "Ethernet27", Label: "28", Profile: "RJ45-2.5G"},
+			"E1/29": {NOSName: "Ethernet28", Label: "29", Profile: "RJ45-2.5G"},
+			"E1/30": {NOSName: "Ethernet29", Label: "30", Profile: "RJ45-2.5G"},
+			"E1/31": {NOSName: "Ethernet30", Label: "31", Profile: "RJ45-2.5G"},
+			"E1/32": {NOSName: "Ethernet31", Label: "32", Profile: "RJ45-2.5G"},
+			"E1/33": {NOSName: "Ethernet32", Label: "33", Profile: "RJ45-2.5G"},
+			"E1/34": {NOSName: "Ethernet33", Label: "34", Profile: "RJ45-2.5G"},
+			"E1/35": {NOSName: "Ethernet34", Label: "35", Profile: "RJ45-2.5G"},
+			"E1/36": {NOSName: "Ethernet35", Label: "36", Profile: "RJ45-2.5G"}, // 36x RJ45 2.5G
+			"E1/37": {NOSName: "Ethernet36", Label: "37", Profile: "RJ45-10G"},
+			"E1/38": {NOSName: "Ethernet37", Label: "38", Profile: "RJ45-10G"},
+			"E1/39": {NOSName: "Ethernet38", Label: "39", Profile: "RJ45-10G"},
+			"E1/40": {NOSName: "Ethernet39", Label: "40", Profile: "RJ45-10G"},
+			"E1/41": {NOSName: "Ethernet40", Label: "41", Profile: "RJ45-10G"},
+			"E1/42": {NOSName: "Ethernet41", Label: "42", Profile: "RJ45-10G"},
+			"E1/43": {NOSName: "Ethernet42", Label: "43", Profile: "RJ45-10G"},
+			"E1/44": {NOSName: "Ethernet43", Label: "44", Profile: "RJ45-10G"},
+			"E1/45": {NOSName: "Ethernet44", Label: "45", Profile: "RJ45-10G"},
+			"E1/46": {NOSName: "Ethernet45", Label: "46", Profile: "RJ45-10G"},
+			"E1/47": {NOSName: "Ethernet46", Label: "47", Profile: "RJ45-10G"},
+			"E1/48": {NOSName: "Ethernet47", Label: "48", Profile: "RJ45-10G"}, // 12x RJ45 10G
+			"E1/49": {NOSName: "Ethernet48", Label: "49", Profile: "SFP28-25G"},
+			"E1/50": {NOSName: "Ethernet49", Label: "50", Profile: "SFP28-25G"},
+			"E1/51": {NOSName: "Ethernet50", Label: "51", Profile: "SFP28-25G"},
+			"E1/52": {NOSName: "Ethernet51", Label: "52", Profile: "SFP28-25G"}, // 4x SFP28 25G
+			"E1/53": {NOSName: "Ethernet52", Label: "53", Profile: "QSFP28-100G"},
+			"E1/54": {NOSName: "Ethernet56", Label: "54", Profile: "QSFP28-100G"}, // No breakouts but name is still adjusted by 4. 2x QSFP28 100G
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"RJ45-2.5G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "2.5G",
+					Supported: []string{"1G", "2.5G"}, // TODO: 100M is also supported
+				},
+				AutoNegAllowed: true,
+				AutoNegDefault: true,
+			},
+			"RJ45-10G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "10G",
+					Supported: []string{"1G", "10G"},
+				},
+				AutoNegAllowed: true,
+				AutoNegDefault: true,
+			},
+			"SFP28-25G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "25G",
+					Supported: []string{"1G", "10G", "25G"},
+				},
+			},
+			"QSFP28-100G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "100G",
+					Supported: []string{"40G", "100G"},
+				},
+			},
+		},
+	},
+}

--- a/netbox_hedgehog/fabric_profiles/p_bcm_supermicro_sse_c4632.go
+++ b/netbox_hedgehog/fabric_profiles/p_bcm_supermicro_sse_c4632.go
@@ -1,0 +1,26 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package switchprofile
+
+import (
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var SupermicroSSEC4632SB = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "supermicro-sse-c4632sb",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Supermicro SSE-C4632SB",
+		SwitchSilicon: CelesticaDS3000.Spec.SwitchSilicon,
+		Features:      CelesticaDS3000.Spec.Features,
+		NOSType:       CelesticaDS3000.Spec.NOSType,
+		Platform:      CelesticaDS3000.Spec.Platform,
+		Config:        CelesticaDS3000.Spec.Config,
+		Ports:         CelesticaDS3000.Spec.Ports,
+		PortGroups:    CelesticaDS3000.Spec.PortGroups,
+		PortProfiles:  CelesticaDS3000.Spec.PortProfiles,
+	},
+}

--- a/netbox_hedgehog/fabric_profiles/p_clsp_celestica_ds2000.go
+++ b/netbox_hedgehog/fabric_profiles/p_clsp_celestica_ds2000.go
@@ -1,0 +1,129 @@
+// Copyright 2025 Hedgehog
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var CLSPCelesticaDS2000 = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "celestica-ds2000-clsp",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Celestica DS2000",
+		OtherNames:    []string{"Celestica Questone 2a"},
+		SwitchSilicon: SiliconBroadcomTD3_X5,
+		Features: wiringapi.SwitchProfileFeatures{ // TODO update
+			Subinterfaces: true,
+			ACLs:          true,
+			L2VNI:         true,
+			L3VNI:         true,
+			RoCE:          false,
+			MCLAG:         true,
+			ESLAG:         true,
+			ECMPRoCEQPN:   false,
+		},
+		NOSType:  meta.NOSTypeSONiCCLSPlusBroadcom,
+		Platform: "x86_64-cel_ds2000-r0", // TODO get rid of or update
+		Config:   wiringapi.SwitchProfileConfig{},
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},
+			"E1/1":  {NOSName: "Ethernet0", Label: "1", Profile: "SFP28-25G"},
+			"E1/2":  {NOSName: "Ethernet1", Label: "2", Profile: "SFP28-25G"},
+			"E1/3":  {NOSName: "Ethernet2", Label: "3", Profile: "SFP28-25G"},
+			"E1/4":  {NOSName: "Ethernet3", Label: "4", Profile: "SFP28-25G"},
+			"E1/5":  {NOSName: "Ethernet4", Label: "5", Profile: "SFP28-25G"},
+			"E1/6":  {NOSName: "Ethernet5", Label: "6", Profile: "SFP28-25G"},
+			"E1/7":  {NOSName: "Ethernet6", Label: "7", Profile: "SFP28-25G"},
+			"E1/8":  {NOSName: "Ethernet7", Label: "8", Profile: "SFP28-25G"},
+			"E1/9":  {NOSName: "Ethernet8", Label: "9", Profile: "SFP28-25G"},
+			"E1/10": {NOSName: "Ethernet9", Label: "10", Profile: "SFP28-25G"},
+			"E1/11": {NOSName: "Ethernet10", Label: "11", Profile: "SFP28-25G"},
+			"E1/12": {NOSName: "Ethernet11", Label: "12", Profile: "SFP28-25G"},
+			"E1/13": {NOSName: "Ethernet12", Label: "13", Profile: "SFP28-25G"},
+			"E1/14": {NOSName: "Ethernet13", Label: "14", Profile: "SFP28-25G"},
+			"E1/15": {NOSName: "Ethernet14", Label: "15", Profile: "SFP28-25G"},
+			"E1/16": {NOSName: "Ethernet15", Label: "16", Profile: "SFP28-25G"},
+			"E1/17": {NOSName: "Ethernet16", Label: "17", Profile: "SFP28-25G"},
+			"E1/18": {NOSName: "Ethernet17", Label: "18", Profile: "SFP28-25G"},
+			"E1/19": {NOSName: "Ethernet18", Label: "19", Profile: "SFP28-25G"},
+			"E1/20": {NOSName: "Ethernet19", Label: "20", Profile: "SFP28-25G"},
+			"E1/21": {NOSName: "Ethernet20", Label: "21", Profile: "SFP28-25G"},
+			"E1/22": {NOSName: "Ethernet21", Label: "22", Profile: "SFP28-25G"},
+			"E1/23": {NOSName: "Ethernet22", Label: "23", Profile: "SFP28-25G"},
+			"E1/24": {NOSName: "Ethernet23", Label: "24", Profile: "SFP28-25G"},
+			"E1/25": {NOSName: "Ethernet24", Label: "25", Profile: "SFP28-25G"},
+			"E1/26": {NOSName: "Ethernet25", Label: "26", Profile: "SFP28-25G"},
+			"E1/27": {NOSName: "Ethernet26", Label: "27", Profile: "SFP28-25G"},
+			"E1/28": {NOSName: "Ethernet27", Label: "28", Profile: "SFP28-25G"},
+			"E1/29": {NOSName: "Ethernet28", Label: "29", Profile: "SFP28-25G"},
+			"E1/30": {NOSName: "Ethernet29", Label: "30", Profile: "SFP28-25G"},
+			"E1/31": {NOSName: "Ethernet30", Label: "31", Profile: "SFP28-25G"},
+			"E1/32": {NOSName: "Ethernet31", Label: "32", Profile: "SFP28-25G"},
+			"E1/33": {NOSName: "Ethernet32", Label: "33", Profile: "SFP28-25G"},
+			"E1/34": {NOSName: "Ethernet33", Label: "34", Profile: "SFP28-25G"},
+			"E1/35": {NOSName: "Ethernet34", Label: "35", Profile: "SFP28-25G"},
+			"E1/36": {NOSName: "Ethernet35", Label: "36", Profile: "SFP28-25G"},
+			"E1/37": {NOSName: "Ethernet36", Label: "37", Profile: "SFP28-25G"},
+			"E1/38": {NOSName: "Ethernet37", Label: "38", Profile: "SFP28-25G"},
+			"E1/39": {NOSName: "Ethernet38", Label: "39", Profile: "SFP28-25G"},
+			"E1/40": {NOSName: "Ethernet39", Label: "40", Profile: "SFP28-25G"},
+			"E1/41": {NOSName: "Ethernet40", Label: "41", Profile: "SFP28-25G"},
+			"E1/42": {NOSName: "Ethernet41", Label: "42", Profile: "SFP28-25G"},
+			"E1/43": {NOSName: "Ethernet42", Label: "43", Profile: "SFP28-25G"},
+			"E1/44": {NOSName: "Ethernet43", Label: "44", Profile: "SFP28-25G"},
+			"E1/45": {NOSName: "Ethernet44", Label: "45", Profile: "SFP28-25G"},
+			"E1/46": {NOSName: "Ethernet45", Label: "46", Profile: "SFP28-25G"},
+			"E1/47": {NOSName: "Ethernet46", Label: "47", Profile: "SFP28-25G"},
+			"E1/48": {NOSName: "Ethernet47", Label: "48", Profile: "SFP28-25G"},
+			"E1/49": {NOSName: "1/49", BaseNOSName: "Ethernet48", Label: "49", Profile: "QSFP28-100G"},
+			"E1/50": {NOSName: "Ethernet52", Label: "50", Profile: "QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix},
+			"E1/51": {NOSName: "Ethernet56", Label: "51", Profile: "QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix},
+			"E1/52": {NOSName: "Ethernet60", Label: "52", Profile: "QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix},
+			"E1/53": {NOSName: "Ethernet64", Label: "53", Profile: "QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix},
+			"E1/54": {NOSName: "Ethernet68", Label: "54", Profile: "QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix},
+			"E1/55": {NOSName: "Ethernet72", Label: "55", Profile: "QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix},
+			"E1/56": {NOSName: "1/56", BaseNOSName: "Ethernet76", Label: "56", Profile: "QSFP28-100G"},
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"SFP28-25G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "25G",
+					Supported: []string{"10G", "25G"},
+				},
+			},
+			"QSFP28-100G" + wiringapi.NonBreakoutPortExceptionSuffix: {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "100G",
+					Supported: []string{"40G", "100G"},
+				},
+			},
+			"QSFP28-100G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "1x100G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x40G":  {Offsets: []string{"0"}},
+						"1x100G": {Offsets: []string{"0"}},
+						"4x25G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"4x10G":  {Offsets: []string{"0", "1", "2", "3"}},
+					},
+				},
+			},
+		},
+	},
+}

--- a/netbox_hedgehog/fabric_profiles/p_clsp_celestica_ds3000.go
+++ b/netbox_hedgehog/fabric_profiles/p_clsp_celestica_ds3000.go
@@ -1,0 +1,89 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var CLSPCelesticaDS3000 = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "celestica-ds3000-clsp",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Celestica DS3000",
+		OtherNames:    []string{"Celestica Seastone2"},
+		SwitchSilicon: SiliconBroadcomTD3_X7_3_2T,
+		Features: wiringapi.SwitchProfileFeatures{ // TODO update
+			Subinterfaces: true,
+			ACLs:          true,
+			L2VNI:         true,
+			L3VNI:         true,
+			RoCE:          true,
+			MCLAG:         true,
+			ESLAG:         true,
+			ECMPRoCEQPN:   false,
+		},
+		NOSType:  meta.NOSTypeSONiCCLSPlusBroadcom,
+		Platform: "x86_64-cel_seastone_2-r0", // TODO get rid of or update
+		Config:   wiringapi.SwitchProfileConfig{},
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},
+			"E1/1":  {NOSName: "1/1", BaseNOSName: "Ethernet0", Label: "1", Profile: "QSFP28-100G"},
+			"E1/2":  {NOSName: "1/2", BaseNOSName: "Ethernet4", Label: "2", Profile: "QSFP28-100G"},
+			"E1/3":  {NOSName: "1/3", BaseNOSName: "Ethernet8", Label: "3", Profile: "QSFP28-100G"},
+			"E1/4":  {NOSName: "1/4", BaseNOSName: "Ethernet12", Label: "4", Profile: "QSFP28-100G"},
+			"E1/5":  {NOSName: "1/5", BaseNOSName: "Ethernet16", Label: "5", Profile: "QSFP28-100G"},
+			"E1/6":  {NOSName: "1/6", BaseNOSName: "Ethernet20", Label: "6", Profile: "QSFP28-100G"},
+			"E1/7":  {NOSName: "1/7", BaseNOSName: "Ethernet24", Label: "7", Profile: "QSFP28-100G"},
+			"E1/8":  {NOSName: "1/8", BaseNOSName: "Ethernet28", Label: "8", Profile: "QSFP28-100G"},
+			"E1/9":  {NOSName: "1/9", BaseNOSName: "Ethernet32", Label: "9", Profile: "QSFP28-100G"},
+			"E1/10": {NOSName: "1/10", BaseNOSName: "Ethernet36", Label: "10", Profile: "QSFP28-100G"},
+			"E1/11": {NOSName: "1/11", BaseNOSName: "Ethernet40", Label: "11", Profile: "QSFP28-100G"},
+			"E1/12": {NOSName: "1/12", BaseNOSName: "Ethernet44", Label: "12", Profile: "QSFP28-100G"},
+			"E1/13": {NOSName: "1/13", BaseNOSName: "Ethernet48", Label: "13", Profile: "QSFP28-100G"},
+			"E1/14": {NOSName: "1/14", BaseNOSName: "Ethernet52", Label: "14", Profile: "QSFP28-100G"},
+			"E1/15": {NOSName: "1/15", BaseNOSName: "Ethernet56", Label: "15", Profile: "QSFP28-100G"},
+			"E1/16": {NOSName: "1/16", BaseNOSName: "Ethernet60", Label: "16", Profile: "QSFP28-100G"},
+			"E1/17": {NOSName: "1/17", BaseNOSName: "Ethernet64", Label: "17", Profile: "QSFP28-100G"},
+			"E1/18": {NOSName: "1/18", BaseNOSName: "Ethernet68", Label: "18", Profile: "QSFP28-100G"},
+			"E1/19": {NOSName: "1/19", BaseNOSName: "Ethernet72", Label: "19", Profile: "QSFP28-100G"},
+			"E1/20": {NOSName: "1/20", BaseNOSName: "Ethernet76", Label: "20", Profile: "QSFP28-100G"},
+			"E1/21": {NOSName: "1/21", BaseNOSName: "Ethernet80", Label: "21", Profile: "QSFP28-100G"},
+			"E1/22": {NOSName: "1/22", BaseNOSName: "Ethernet84", Label: "22", Profile: "QSFP28-100G"},
+			"E1/23": {NOSName: "1/23", BaseNOSName: "Ethernet88", Label: "23", Profile: "QSFP28-100G"},
+			"E1/24": {NOSName: "1/24", BaseNOSName: "Ethernet92", Label: "24", Profile: "QSFP28-100G"},
+			"E1/25": {NOSName: "1/25", BaseNOSName: "Ethernet96", Label: "25", Profile: "QSFP28-100G"},
+			"E1/26": {NOSName: "1/26", BaseNOSName: "Ethernet100", Label: "26", Profile: "QSFP28-100G"},
+			"E1/27": {NOSName: "1/27", BaseNOSName: "Ethernet104", Label: "27", Profile: "QSFP28-100G"},
+			"E1/28": {NOSName: "1/28", BaseNOSName: "Ethernet108", Label: "28", Profile: "QSFP28-100G"},
+			"E1/29": {NOSName: "1/29", BaseNOSName: "Ethernet112", Label: "29", Profile: "QSFP28-100G"},
+			"E1/30": {NOSName: "1/30", BaseNOSName: "Ethernet116", Label: "30", Profile: "QSFP28-100G"},
+			"E1/31": {NOSName: "1/31", BaseNOSName: "Ethernet120", Label: "31", Profile: "QSFP28-100G"},
+			"E1/32": {NOSName: "1/32", BaseNOSName: "Ethernet124", Label: "32", Profile: "QSFP28-100G"}, // 32x QSFP28-100G
+			"E1/33": {NOSName: "Ethernet128", Label: "33", Profile: "SFP28-10G"},                        // 1x SFP28-10G
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"SFP28-10G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "10G",
+					Supported: []string{"1G", "10G"},
+				},
+			},
+			"QSFP28-100G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "1x100G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x100G": {Offsets: []string{"0"}},
+						"1x40G":  {Offsets: []string{"0"}},
+						"4x25G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"4x10G":  {Offsets: []string{"0", "1", "2", "3"}},
+					},
+				},
+			},
+		},
+	},
+}

--- a/netbox_hedgehog/fabric_profiles/p_clsp_celestica_ds4000.go
+++ b/netbox_hedgehog/fabric_profiles/p_clsp_celestica_ds4000.go
@@ -1,0 +1,99 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var CLSPCelesticaDS4000 = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "celestica-ds4000-clsp",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Celestica DS4000",
+		OtherNames:    []string{"Celestica Silverstone2"},
+		SwitchSilicon: SiliconBroadcomTH3,
+		Features: wiringapi.SwitchProfileFeatures{ // TODO update
+			Subinterfaces: false,
+			ACLs:          true,
+			L2VNI:         false,
+			L3VNI:         false,
+			RoCE:          true,
+			MCLAG:         false,
+			ESLAG:         false,
+			ECMPRoCEQPN:   false,
+		},
+		NOSType:  meta.NOSTypeSONiCCLSPlusBroadcom,
+		Platform: "x86_64-cel_silverstone-r0", // TODO get rid of or update
+		Config:   wiringapi.SwitchProfileConfig{},
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},
+			"E1/1":  {NOSName: "1/1", BaseNOSName: "Ethernet0", Label: "1", Profile: "QSFPDD-400G"},
+			"E1/2":  {NOSName: "1/2", BaseNOSName: "Ethernet8", Label: "2", Profile: "QSFPDD-400G"},
+			"E1/3":  {NOSName: "1/3", BaseNOSName: "Ethernet16", Label: "3", Profile: "QSFPDD-400G"},
+			"E1/4":  {NOSName: "1/4", BaseNOSName: "Ethernet24", Label: "4", Profile: "QSFPDD-400G"},
+			"E1/5":  {NOSName: "1/5", BaseNOSName: "Ethernet32", Label: "5", Profile: "QSFPDD-400G"},
+			"E1/6":  {NOSName: "1/6", BaseNOSName: "Ethernet40", Label: "6", Profile: "QSFPDD-400G"},
+			"E1/7":  {NOSName: "1/7", BaseNOSName: "Ethernet48", Label: "7", Profile: "QSFPDD-400G"},
+			"E1/8":  {NOSName: "1/8", BaseNOSName: "Ethernet56", Label: "8", Profile: "QSFPDD-400G"},
+			"E1/9":  {NOSName: "1/9", BaseNOSName: "Ethernet64", Label: "9", Profile: "QSFPDD-400G"},
+			"E1/10": {NOSName: "1/10", BaseNOSName: "Ethernet72", Label: "10", Profile: "QSFPDD-400G"},
+			"E1/11": {NOSName: "1/11", BaseNOSName: "Ethernet80", Label: "11", Profile: "QSFPDD-400G"},
+			"E1/12": {NOSName: "1/12", BaseNOSName: "Ethernet88", Label: "12", Profile: "QSFPDD-400G"},
+			"E1/13": {NOSName: "1/13", BaseNOSName: "Ethernet96", Label: "13", Profile: "QSFPDD-400G"},
+			"E1/14": {NOSName: "1/14", BaseNOSName: "Ethernet104", Label: "14", Profile: "QSFPDD-400G"},
+			"E1/15": {NOSName: "1/15", BaseNOSName: "Ethernet112", Label: "15", Profile: "QSFPDD-400G"},
+			"E1/16": {NOSName: "1/16", BaseNOSName: "Ethernet120", Label: "16", Profile: "QSFPDD-400G"},
+			"E1/17": {NOSName: "1/17", BaseNOSName: "Ethernet128", Label: "17", Profile: "QSFPDD-400G"},
+			"E1/18": {NOSName: "1/18", BaseNOSName: "Ethernet136", Label: "18", Profile: "QSFPDD-400G"},
+			"E1/19": {NOSName: "1/19", BaseNOSName: "Ethernet144", Label: "19", Profile: "QSFPDD-400G"},
+			"E1/20": {NOSName: "1/20", BaseNOSName: "Ethernet152", Label: "20", Profile: "QSFPDD-400G"},
+			"E1/21": {NOSName: "1/21", BaseNOSName: "Ethernet160", Label: "21", Profile: "QSFPDD-400G"},
+			"E1/22": {NOSName: "1/22", BaseNOSName: "Ethernet168", Label: "22", Profile: "QSFPDD-400G"},
+			"E1/23": {NOSName: "1/23", BaseNOSName: "Ethernet176", Label: "23", Profile: "QSFPDD-400G"},
+			"E1/24": {NOSName: "1/24", BaseNOSName: "Ethernet184", Label: "24", Profile: "QSFPDD-400G"},
+			"E1/25": {NOSName: "1/25", BaseNOSName: "Ethernet192", Label: "25", Profile: "QSFPDD-400G"},
+			"E1/26": {NOSName: "1/26", BaseNOSName: "Ethernet200", Label: "26", Profile: "QSFPDD-400G"},
+			"E1/27": {NOSName: "1/27", BaseNOSName: "Ethernet208", Label: "27", Profile: "QSFPDD-400G"},
+			"E1/28": {NOSName: "1/28", BaseNOSName: "Ethernet216", Label: "28", Profile: "QSFPDD-400G"},
+			"E1/29": {NOSName: "1/29", BaseNOSName: "Ethernet224", Label: "29", Profile: "QSFPDD-400G"},
+			"E1/30": {NOSName: "1/30", BaseNOSName: "Ethernet232", Label: "30", Profile: "QSFPDD-400G"},
+			"E1/31": {NOSName: "1/31", BaseNOSName: "Ethernet240", Label: "31", Profile: "QSFPDD-400G"},
+			"E1/32": {NOSName: "1/32", BaseNOSName: "Ethernet248", Label: "32", Profile: "QSFPDD-400G"}, // 32x QSFPDD-400G
+			"E1/33": {NOSName: "Ethernet256", Label: "33", Profile: "SFP28-10G"},                        // 1x SFP28-10G
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"SFP28-10G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "10G",
+					Supported: []string{"1G", "10G"},
+				},
+			},
+			"QSFPDD-400G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "1x400G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x400G": {Offsets: []string{"0"}},
+						"1x100G": {Offsets: []string{"0"}},
+						"1x40G":  {Offsets: []string{"0"}},
+						"1x25G":  {Offsets: []string{"0"}},
+						"1x10G":  {Offsets: []string{"0"}},
+						"2x200G": {Offsets: []string{"0", "4"}},
+						"2x100G": {Offsets: []string{"0", "4"}},
+						"2x40G":  {Offsets: []string{"0", "4"}},
+						"4x100G": {Offsets: []string{"0", "2", "4", "6"}},
+						"4x25G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"4x10G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"8x50G":  {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+						"8x25G":  {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+						"8x10G":  {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+					},
+				},
+			},
+		},
+	},
+}

--- a/netbox_hedgehog/fabric_profiles/p_clsp_celestica_ds4101.go
+++ b/netbox_hedgehog/fabric_profiles/p_clsp_celestica_ds4101.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var CLSPCelesticaDS4101 = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "celestica-ds4101-clsp",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Celestica DS4101",
+		OtherNames:    []string{"Celestica Greystone"},
+		SwitchSilicon: SiliconBroadcomTH4G,
+		Features: wiringapi.SwitchProfileFeatures{ // TODO update
+			Subinterfaces: false,
+			ACLs:          true,
+			L2VNI:         false,
+			L3VNI:         false,
+			RoCE:          true,
+			MCLAG:         false,
+			ESLAG:         false,
+			ECMPRoCEQPN:   true,
+		},
+		NOSType:  meta.NOSTypeSONiCCLSPlusBroadcom,
+		Platform: "x86_64-cel_ds4101-r0", // TODO get rid of or update
+		Config:   wiringapi.SwitchProfileConfig{},
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},
+			"E1/1":  {NOSName: "1/1", BaseNOSName: "Ethernet0", Label: "1", Profile: "OSFP-2x400G"},
+			"E1/2":  {NOSName: "1/2", BaseNOSName: "Ethernet8", Label: "2", Profile: "OSFP-2x400G"},
+			"E1/3":  {NOSName: "1/3", BaseNOSName: "Ethernet16", Label: "3", Profile: "OSFP-2x400G"},
+			"E1/4":  {NOSName: "1/4", BaseNOSName: "Ethernet24", Label: "4", Profile: "OSFP-2x400G"},
+			"E1/5":  {NOSName: "1/5", BaseNOSName: "Ethernet32", Label: "5", Profile: "OSFP-2x400G"},
+			"E1/6":  {NOSName: "1/6", BaseNOSName: "Ethernet40", Label: "6", Profile: "OSFP-2x400G"},
+			"E1/7":  {NOSName: "1/7", BaseNOSName: "Ethernet48", Label: "7", Profile: "OSFP-2x400G"},
+			"E1/8":  {NOSName: "1/8", BaseNOSName: "Ethernet56", Label: "8", Profile: "OSFP-2x400G"},
+			"E1/9":  {NOSName: "1/9", BaseNOSName: "Ethernet64", Label: "9", Profile: "OSFP-2x400G"},
+			"E1/10": {NOSName: "1/10", BaseNOSName: "Ethernet72", Label: "10", Profile: "OSFP-2x400G"},
+			"E1/11": {NOSName: "1/11", BaseNOSName: "Ethernet80", Label: "11", Profile: "OSFP-2x400G"},
+			"E1/12": {NOSName: "1/12", BaseNOSName: "Ethernet88", Label: "12", Profile: "OSFP-2x400G"},
+			"E1/13": {NOSName: "1/13", BaseNOSName: "Ethernet96", Label: "13", Profile: "OSFP-2x400G"},
+			"E1/14": {NOSName: "1/14", BaseNOSName: "Ethernet104", Label: "14", Profile: "OSFP-2x400G"},
+			"E1/15": {NOSName: "1/15", BaseNOSName: "Ethernet112", Label: "15", Profile: "OSFP-2x400G"},
+			"E1/16": {NOSName: "1/16", BaseNOSName: "Ethernet120", Label: "16", Profile: "OSFP-2x400G"},
+			"E1/17": {NOSName: "1/17", BaseNOSName: "Ethernet128", Label: "17", Profile: "OSFP-2x400G"},
+			"E1/18": {NOSName: "1/18", BaseNOSName: "Ethernet136", Label: "18", Profile: "OSFP-2x400G"},
+			"E1/19": {NOSName: "1/19", BaseNOSName: "Ethernet144", Label: "19", Profile: "OSFP-2x400G"},
+			"E1/20": {NOSName: "1/20", BaseNOSName: "Ethernet152", Label: "20", Profile: "OSFP-2x400G"},
+			"E1/21": {NOSName: "1/21", BaseNOSName: "Ethernet160", Label: "21", Profile: "OSFP-2x400G"},
+			"E1/22": {NOSName: "1/22", BaseNOSName: "Ethernet168", Label: "22", Profile: "OSFP-2x400G"},
+			"E1/23": {NOSName: "1/23", BaseNOSName: "Ethernet176", Label: "23", Profile: "OSFP-2x400G"},
+			"E1/24": {NOSName: "1/24", BaseNOSName: "Ethernet184", Label: "24", Profile: "OSFP-2x400G"},
+			"E1/25": {NOSName: "1/25", BaseNOSName: "Ethernet192", Label: "25", Profile: "OSFP-2x400G"},
+			"E1/26": {NOSName: "1/26", BaseNOSName: "Ethernet200", Label: "26", Profile: "OSFP-2x400G"},
+			"E1/27": {NOSName: "1/27", BaseNOSName: "Ethernet208", Label: "27", Profile: "OSFP-2x400G"},
+			"E1/28": {NOSName: "1/28", BaseNOSName: "Ethernet216", Label: "28", Profile: "OSFP-2x400G"},
+			"E1/29": {NOSName: "1/29", BaseNOSName: "Ethernet224", Label: "29", Profile: "OSFP-2x400G"},
+			"E1/30": {NOSName: "1/30", BaseNOSName: "Ethernet232", Label: "30", Profile: "OSFP-2x400G"},
+			"E1/31": {NOSName: "1/31", BaseNOSName: "Ethernet240", Label: "31", Profile: "OSFP-2x400G"},
+			"E1/32": {NOSName: "1/32", BaseNOSName: "Ethernet248", Label: "32", Profile: "OSFP-2x400G"}, // 32x OSFP-2x400G
+			"E1/33": {NOSName: "Ethernet256", Label: "M1", Profile: "SFP28-10G"},                        // 1x SFP28-10G
+			"E1/34": {NOSName: "Ethernet257", Label: "M2", Profile: "SFP28-10G"},                        // 1x SFP28-10G
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"SFP28-10G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "10G",
+					Supported: []string{"1G", "10G"},
+				},
+			},
+			"OSFP-2x400G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "2x400G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x100G": {Offsets: []string{"0"}},
+						"1x200G": {Offsets: []string{"0"}},
+						"1x400G": {Offsets: []string{"0"}},
+						"2x40G":  {Offsets: []string{"0", "4"}},
+						"2x100G": {Offsets: []string{"0", "4"}},
+						"2x200G": {Offsets: []string{"0", "4"}},
+						"2x400G": {Offsets: []string{"0", "4"}},
+						"4x50G":  {Offsets: []string{"0", "2", "4", "6"}},
+						"4x100G": {Offsets: []string{"0", "2", "4", "6"}},
+						"4x200G": {Offsets: []string{"0", "2", "4", "6"}},
+						"8x10G":  {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+						"8x25G":  {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+						"8x50G":  {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+						"8x100G": {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+					},
+				},
+				AutoNegAllowed: true,
+				AutoNegDefault: false,
+			},
+		},
+	},
+}

--- a/netbox_hedgehog/fabric_profiles/p_clsp_celestica_ds5000.go
+++ b/netbox_hedgehog/fabric_profiles/p_clsp_celestica_ds5000.go
@@ -1,0 +1,133 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var CLSPCelesticaDS5000 = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "celestica-ds5000-clsp",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Celestica DS5000",
+		OtherNames:    []string{"Celestica Moonstone"},
+		SwitchSilicon: SiliconBroadcomTH5,
+		Features: wiringapi.SwitchProfileFeatures{ // TODO update
+			Subinterfaces: true,
+			ACLs:          true,
+			L2VNI:         false,
+			L3VNI:         true,
+			RoCE:          true,
+			MCLAG:         false,
+			ESLAG:         false,
+			ECMPRoCEQPN:   true,
+		},
+		Notes:    "Doesn't support non-L3 VPC modes due to the lack of L2VNI support.", // TODO get rid of or update
+		NOSType:  meta.NOSTypeSONiCCLSPlusBroadcom,
+		Platform: "x86-64-cls-ds5000-r0", // TODO get rid of or update
+		Config:   wiringapi.SwitchProfileConfig{},
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},
+			"E1/1":  {NOSName: "1/1", BaseNOSName: "Ethernet0", Label: "1", Profile: "OSFP-800G"},
+			"E1/2":  {NOSName: "1/2", BaseNOSName: "Ethernet8", Label: "2", Profile: "OSFP-800G"},
+			"E1/3":  {NOSName: "1/3", BaseNOSName: "Ethernet16", Label: "3", Profile: "OSFP-800G"},
+			"E1/4":  {NOSName: "1/4", BaseNOSName: "Ethernet24", Label: "4", Profile: "OSFP-800G"},
+			"E1/5":  {NOSName: "1/5", BaseNOSName: "Ethernet32", Label: "5", Profile: "OSFP-800G"},
+			"E1/6":  {NOSName: "1/6", BaseNOSName: "Ethernet40", Label: "6", Profile: "OSFP-800G"},
+			"E1/7":  {NOSName: "1/7", BaseNOSName: "Ethernet48", Label: "7", Profile: "OSFP-800G"},
+			"E1/8":  {NOSName: "1/8", BaseNOSName: "Ethernet56", Label: "8", Profile: "OSFP-800G"},
+			"E1/9":  {NOSName: "1/9", BaseNOSName: "Ethernet64", Label: "9", Profile: "OSFP-800G"},
+			"E1/10": {NOSName: "1/10", BaseNOSName: "Ethernet72", Label: "10", Profile: "OSFP-800G"},
+			"E1/11": {NOSName: "1/11", BaseNOSName: "Ethernet80", Label: "11", Profile: "OSFP-800G"},
+			"E1/12": {NOSName: "1/12", BaseNOSName: "Ethernet88", Label: "12", Profile: "OSFP-800G"},
+			"E1/13": {NOSName: "1/13", BaseNOSName: "Ethernet96", Label: "13", Profile: "OSFP-800G"},
+			"E1/14": {NOSName: "1/14", BaseNOSName: "Ethernet104", Label: "14", Profile: "OSFP-800G"},
+			"E1/15": {NOSName: "1/15", BaseNOSName: "Ethernet112", Label: "15", Profile: "OSFP-800G"},
+			"E1/16": {NOSName: "1/16", BaseNOSName: "Ethernet120", Label: "16", Profile: "OSFP-800G"},
+			"E1/17": {NOSName: "1/17", BaseNOSName: "Ethernet128", Label: "17", Profile: "OSFP-800G"},
+			"E1/18": {NOSName: "1/18", BaseNOSName: "Ethernet136", Label: "18", Profile: "OSFP-800G"},
+			"E1/19": {NOSName: "1/19", BaseNOSName: "Ethernet144", Label: "19", Profile: "OSFP-800G"},
+			"E1/20": {NOSName: "1/20", BaseNOSName: "Ethernet152", Label: "20", Profile: "OSFP-800G"},
+			"E1/21": {NOSName: "1/21", BaseNOSName: "Ethernet160", Label: "21", Profile: "OSFP-800G"},
+			"E1/22": {NOSName: "1/22", BaseNOSName: "Ethernet168", Label: "22", Profile: "OSFP-800G"},
+			"E1/23": {NOSName: "1/23", BaseNOSName: "Ethernet176", Label: "23", Profile: "OSFP-800G"},
+			"E1/24": {NOSName: "1/24", BaseNOSName: "Ethernet184", Label: "24", Profile: "OSFP-800G"},
+			"E1/25": {NOSName: "1/25", BaseNOSName: "Ethernet192", Label: "25", Profile: "OSFP-800G"},
+			"E1/26": {NOSName: "1/26", BaseNOSName: "Ethernet200", Label: "26", Profile: "OSFP-800G"},
+			"E1/27": {NOSName: "1/27", BaseNOSName: "Ethernet208", Label: "27", Profile: "OSFP-800G"},
+			"E1/28": {NOSName: "1/28", BaseNOSName: "Ethernet216", Label: "28", Profile: "OSFP-800G"},
+			"E1/29": {NOSName: "1/29", BaseNOSName: "Ethernet224", Label: "29", Profile: "OSFP-800G"},
+			"E1/30": {NOSName: "1/30", BaseNOSName: "Ethernet232", Label: "30", Profile: "OSFP-800G"},
+			"E1/31": {NOSName: "1/31", BaseNOSName: "Ethernet240", Label: "31", Profile: "OSFP-800G"},
+			"E1/32": {NOSName: "1/32", BaseNOSName: "Ethernet248", Label: "32", Profile: "OSFP-800G"},
+			"E1/33": {NOSName: "1/33", BaseNOSName: "Ethernet256", Label: "33", Profile: "OSFP-800G"},
+			"E1/34": {NOSName: "1/34", BaseNOSName: "Ethernet264", Label: "34", Profile: "OSFP-800G"},
+			"E1/35": {NOSName: "1/35", BaseNOSName: "Ethernet272", Label: "35", Profile: "OSFP-800G"},
+			"E1/36": {NOSName: "1/36", BaseNOSName: "Ethernet280", Label: "36", Profile: "OSFP-800G"},
+			"E1/37": {NOSName: "1/37", BaseNOSName: "Ethernet288", Label: "37", Profile: "OSFP-800G"},
+			"E1/38": {NOSName: "1/38", BaseNOSName: "Ethernet296", Label: "38", Profile: "OSFP-800G"},
+			"E1/39": {NOSName: "1/39", BaseNOSName: "Ethernet304", Label: "39", Profile: "OSFP-800G"},
+			"E1/40": {NOSName: "1/40", BaseNOSName: "Ethernet312", Label: "40", Profile: "OSFP-800G"},
+			"E1/41": {NOSName: "1/41", BaseNOSName: "Ethernet320", Label: "41", Profile: "OSFP-800G"},
+			"E1/42": {NOSName: "1/42", BaseNOSName: "Ethernet328", Label: "42", Profile: "OSFP-800G"},
+			"E1/43": {NOSName: "1/43", BaseNOSName: "Ethernet336", Label: "43", Profile: "OSFP-800G"},
+			"E1/44": {NOSName: "1/44", BaseNOSName: "Ethernet344", Label: "44", Profile: "OSFP-800G"},
+			"E1/45": {NOSName: "1/45", BaseNOSName: "Ethernet352", Label: "45", Profile: "OSFP-800G"},
+			"E1/46": {NOSName: "1/46", BaseNOSName: "Ethernet360", Label: "46", Profile: "OSFP-800G"},
+			"E1/47": {NOSName: "1/47", BaseNOSName: "Ethernet368", Label: "47", Profile: "OSFP-800G"},
+			"E1/48": {NOSName: "1/48", BaseNOSName: "Ethernet376", Label: "48", Profile: "OSFP-800G"},
+			"E1/49": {NOSName: "1/49", BaseNOSName: "Ethernet384", Label: "49", Profile: "OSFP-800G"},
+			"E1/50": {NOSName: "1/50", BaseNOSName: "Ethernet392", Label: "50", Profile: "OSFP-800G"},
+			"E1/51": {NOSName: "1/51", BaseNOSName: "Ethernet400", Label: "51", Profile: "OSFP-800G"},
+			"E1/52": {NOSName: "1/52", BaseNOSName: "Ethernet408", Label: "52", Profile: "OSFP-800G"},
+			"E1/53": {NOSName: "1/53", BaseNOSName: "Ethernet416", Label: "53", Profile: "OSFP-800G"},
+			"E1/54": {NOSName: "1/54", BaseNOSName: "Ethernet424", Label: "54", Profile: "OSFP-800G"},
+			"E1/55": {NOSName: "1/55", BaseNOSName: "Ethernet432", Label: "55", Profile: "OSFP-800G"},
+			"E1/56": {NOSName: "1/56", BaseNOSName: "Ethernet440", Label: "56", Profile: "OSFP-800G"},
+			"E1/57": {NOSName: "1/57", BaseNOSName: "Ethernet448", Label: "57", Profile: "OSFP-800G"},
+			"E1/58": {NOSName: "1/58", BaseNOSName: "Ethernet456", Label: "58", Profile: "OSFP-800G"},
+			"E1/59": {NOSName: "1/59", BaseNOSName: "Ethernet464", Label: "59", Profile: "OSFP-800G"},
+			"E1/60": {NOSName: "1/60", BaseNOSName: "Ethernet472", Label: "60", Profile: "OSFP-800G"},
+			"E1/61": {NOSName: "1/61", BaseNOSName: "Ethernet480", Label: "61", Profile: "OSFP-800G"},
+			"E1/62": {NOSName: "1/62", BaseNOSName: "Ethernet488", Label: "62", Profile: "OSFP-800G"},
+			"E1/63": {NOSName: "1/63", BaseNOSName: "Ethernet496", Label: "63", Profile: "OSFP-800G"},
+			"E1/64": {NOSName: "1/64", BaseNOSName: "Ethernet504", Label: "64", Profile: "OSFP-800G"}, // 64x OSFP-800G
+			"E1/65": {NOSName: "Ethernet512", Label: "65", Profile: "SFP28-25G"},                      // 1x SFP-28-25G
+			"E1/66": {NOSName: "Ethernet513", Label: "66", Profile: "SFP28-25G"},                      // 1x SFP-28-25G
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"SFP28-25G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "25G",
+					Supported: []string{"1G", "10G", "25G"},
+				},
+			},
+			"OSFP-800G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "1x800G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x50G":  {Offsets: []string{"0"}},
+						"1x100G": {Offsets: []string{"0"}},
+						"1x200G": {Offsets: []string{"0"}},
+						"1x400G": {Offsets: []string{"0"}},
+						"1x800G": {Offsets: []string{"0"}},
+						"2x50G":  {Offsets: []string{"0", "2"}},
+						"2x100G": {Offsets: []string{"0", "4"}},
+						"2x200G": {Offsets: []string{"0", "4"}},
+						"2x400G": {Offsets: []string{"0", "4"}},
+						"4x100G": {Offsets: []string{"0", "2", "4", "6"}},
+						"4x200G": {Offsets: []string{"0", "2", "4", "6"}},
+						"8x100G": {Offsets: []string{"0", "1", "2", "3", "4", "5", "6", "7"}},
+					},
+				},
+				AutoNegAllowed: true,
+				AutoNegDefault: false,
+			},
+		},
+	},
+}

--- a/netbox_hedgehog/management/commands/load_diet_reference_data.py
+++ b/netbox_hedgehog/management/commands/load_diet_reference_data.py
@@ -297,22 +297,17 @@ class Command(BaseCommand):
             ))
             return 0
 
-        before_exists = DeviceType.objects.filter(model="celestica-ds5000").exists()
+        before_count = DeviceType.objects.count()
 
         call_command(
             "import_fabric_profiles",
             source_dir=str(profile_dir),
-            profiles="celestica-ds5000",
             stdout=self.stdout,
             stderr=self.stderr,
         )
 
-        after_exists = DeviceType.objects.filter(model="celestica-ds5000").exists()
-        if after_exists and not before_exists:
-            return 1
-        if after_exists:
-            return 1
-        return 0
+        after_count = DeviceType.objects.count()
+        return after_count - before_count
 
     @transaction.atomic
     def seed_management_switch_device_types(self) -> int:

--- a/netbox_hedgehog/tests/test_topology_planning/test_reference_data_bootstrap.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_reference_data_bootstrap.py
@@ -517,21 +517,17 @@ class BootstrapInventoryContractTestCase(TestCase):
 
     def test_breakout_option_count_is_exact(self):
         """
-        load_diet_reference_data must produce exactly 16 BreakoutOptions.
+        load_diet_reference_data must produce exactly 23 BreakoutOptions.
 
-        14 canonical ones from load_breakout_options plus 2 added by the DS5000
-        profile (1x50g, 2x100g).  The spec (#564) stated 14; the actual value
-        is 16 — corrected here based on observed bootstrap output.
-
-        NOTE (DIET-569): This expected value will increase when GREEN copies the
-        17 missing profile files and removes the DS5000-only filter in
-        import_bundled_switch_profiles().  Discover the new exact count by running
-        load_diet_reference_data after the GREEN file copy and update the assertEqual
-        below to the observed value.
+        14 canonical ones from load_breakout_options plus 9 added by the full
+        hardware profile import (all 18 p_*.go files). The original 16 count
+        reflected only the DS5000 profile (14 canonical + 2 from DS5000: 1x50g,
+        2x100g). After DIET-569 bundled all 18 hardware profiles the observed
+        count is 23 — updated from the verified bootstrap output.
         """
         self._seed()
         count = BreakoutOption.objects.count()
-        self.assertEqual(count, 16, f"Expected 16 BreakoutOptions (14 canonical + 2 from DS5000 profile); got {count}")
+        self.assertEqual(count, 23, f"Expected 23 BreakoutOptions (14 canonical + 9 from full profile import); got {count}")
 
     def test_module_type_count_is_exact(self):
         """load_diet_reference_data must produce exactly 33 ModuleTypes."""

--- a/netbox_hedgehog/tests/test_topology_planning/test_reference_data_bootstrap.py
+++ b/netbox_hedgehog/tests/test_topology_planning/test_reference_data_bootstrap.py
@@ -11,6 +11,7 @@ Gate 3 — seeded-catalog tests are green.
 """
 
 from io import StringIO
+from pathlib import Path
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -18,6 +19,71 @@ from django.test import TestCase
 from dcim.models import DeviceType, InterfaceTemplate, Manufacturer, ModuleBayTemplate, ModuleType, ModuleTypeProfile
 
 from netbox_hedgehog.models.topology_planning import BreakoutOption, DeviceTypeExtension
+
+# ── DIET-569: Complete supported-switch library contract ─────────────────────
+#
+# REQUIRED_SWITCH_SLUGS is the exact set of 21 switch DeviceType slugs that
+# load_diet_reference_data must produce.  Tests assert membership (all 21 present)
+# and count (== 21); extras tolerated.
+#
+# Slug sources:
+#   BCM hardware   — parsed from p_bcm_*.go files in fabric_profiles/
+#   CLSP hardware  — parsed from p_clsp_*.go files in fabric_profiles/
+#   alias          — supermicro-sse-c4632sb defined in ALIAS_PROFILES, source file
+#                    p_bcm_supermicro_sse_c4632.go
+#   virtual        — vs, vs-clsp from FabricProfileImporter.VIRTUAL_SWITCH_PROFILES
+#   static mgmt    — celestica-es1000 from seed_management_switch_device_types()
+REQUIRED_SWITCH_SLUGS = frozenset([
+    # BCM hardware (13)
+    "celestica-ds2000",
+    "celestica-ds3000",
+    "celestica-ds4000",
+    "celestica-ds4101",
+    "celestica-ds5000",
+    "dell-s5232f-on",
+    "dell-s5248f-on",
+    "dell-z9332f-on",
+    "edgecore-dcs203",
+    "edgecore-dcs204",
+    "edgecore-dcs501",
+    "edgecore-eps203",
+    "supermicro-sse-c4632sb",
+    # CLSP hardware (5)
+    "celestica-ds2000-clsp",
+    "celestica-ds3000-clsp",
+    "celestica-ds4000-clsp",
+    "celestica-ds4101-clsp",
+    "celestica-ds5000-clsp",
+    # Virtual (2) — seeded via VIRTUAL_SWITCH_PROFILES, not .go files
+    "vs",
+    "vs-clsp",
+    # Static management (1) — seeded via seed_management_switch_device_types()
+    "celestica-es1000",
+])
+
+# All 18 hardware .go files that must be present in fabric_profiles/.
+# p_bcm_vs.go and p_clsp_vs.go are intentionally absent: virtual profiles
+# are defined in VIRTUAL_SWITCH_PROFILES (Python), not parsed from Go files.
+EXPECTED_BUNDLED_PROFILE_FILES = frozenset([
+    "p_bcm_celestica_ds2000.go",
+    "p_bcm_celestica_ds3000.go",
+    "p_bcm_celestica_ds4000.go",
+    "p_bcm_celestica_ds4101.go",
+    "p_bcm_celestica_ds5000.go",
+    "p_bcm_dell_s5232f_on.go",
+    "p_bcm_dell_s5248f_on.go",
+    "p_bcm_dell_z9332f_on.go",
+    "p_bcm_edgecore_dcs203.go",
+    "p_bcm_edgecore_dcs204.go",
+    "p_bcm_edgecore_dcs501.go",
+    "p_bcm_edgecore_eps203.go",
+    "p_bcm_supermicro_sse_c4632.go",
+    "p_clsp_celestica_ds2000.go",
+    "p_clsp_celestica_ds3000.go",
+    "p_clsp_celestica_ds4000.go",
+    "p_clsp_celestica_ds4101.go",
+    "p_clsp_celestica_ds5000.go",
+])
 
 
 class CanonicalSwitchInventoryTestCase(TestCase):
@@ -456,6 +522,12 @@ class BootstrapInventoryContractTestCase(TestCase):
         14 canonical ones from load_breakout_options plus 2 added by the DS5000
         profile (1x50g, 2x100g).  The spec (#564) stated 14; the actual value
         is 16 — corrected here based on observed bootstrap output.
+
+        NOTE (DIET-569): This expected value will increase when GREEN copies the
+        17 missing profile files and removes the DS5000-only filter in
+        import_bundled_switch_profiles().  Discover the new exact count by running
+        load_diet_reference_data after the GREEN file copy and update the assertEqual
+        below to the observed value.
         """
         self._seed()
         count = BreakoutOption.objects.count()
@@ -479,3 +551,121 @@ class BootstrapInventoryContractTestCase(TestCase):
             device_type=dt, type="800gbase-x-osfp"
         ).count()
         self.assertEqual(count, 64, f"Expected 64 OSFP templates on celestica-ds5000; got {count}")
+
+
+class BundledProfileCompletenessTestCase(TestCase):
+    """
+    DIET-569: All 18 hardware Go profile files must exist in fabric_profiles/.
+
+    Tests in this class do NOT call load_diet_reference_data — they verify the
+    presence of the source files on disk, independently of the import path.
+
+    RED: 17 of 18 expected files are missing.  Only p_bcm_celestica_ds5000.go
+    is currently bundled.
+    GREEN: all 17 missing files are copied from fabric v0.98.0.
+
+    Implementation seam: missing .go files in fabric_profiles/.
+    """
+
+    _PROFILE_DIR = Path(__file__).resolve().parents[2] / "fabric_profiles"
+
+    def test_all_expected_profile_files_present(self):
+        """
+        Every filename in EXPECTED_BUNDLED_PROFILE_FILES must exist on disk.
+
+        RED: 17 files are absent; the sorted missing list names the gap explicitly.
+        GREEN: all 18 files are present after the file copy.
+        """
+        missing = sorted(
+            fname for fname in EXPECTED_BUNDLED_PROFILE_FILES
+            if not (self._PROFILE_DIR / fname).is_file()
+        )
+        self.assertEqual(
+            missing,
+            [],
+            f"Missing bundled profile file(s) in fabric_profiles/ "
+            f"(seam: copy 17 files from fabric v0.98.0): {missing}",
+        )
+
+    def test_bundled_profile_file_count(self):
+        """
+        fabric_profiles/ must contain exactly 18 p_*.go files.
+
+        RED: only 1 file is present (p_bcm_celestica_ds5000.go).
+        GREEN: 18 files present after the file copy.
+        """
+        actual = sorted(f.name for f in self._PROFILE_DIR.glob("p_*.go"))
+        self.assertEqual(
+            len(actual),
+            18,
+            f"Expected 18 p_*.go files in fabric_profiles/; "
+            f"found {len(actual)}: {actual}",
+        )
+
+
+class FullSwitchCatalogBootstrapTestCase(TestCase):
+    """
+    DIET-569: load_diet_reference_data must seed all 21 required switch DeviceTypes.
+
+    RED failures in this class are attributable to two implementation seams:
+      (1) 17 bundled profile files are missing from fabric_profiles/
+      (2) import_bundled_switch_profiles() passes profiles="celestica-ds5000" to
+          import_fabric_profiles, filtering out everything except DS5000
+
+    Both seams must be fixed in GREEN before these tests pass.
+
+    Currently 2 of 21 required slugs are produced by bootstrap:
+      celestica-ds5000  (profile import passes the DS5000-only filter)
+      celestica-es1000  (seed_management_switch_device_types — independent path)
+    The DS5000-only filter also blocks vs and vs-clsp (the VIRTUAL_SWITCH_PROFILES
+    loop in import_fabric_profiles respects the profiles= filter too).
+    The remaining 19 slugs are absent until both seams are resolved.
+
+    Extras tolerated: assertions use filter(slug__in=REQUIRED_SWITCH_SLUGS) so
+    operator-added DeviceTypes do not cause false failures.
+    """
+
+    def _seed(self):
+        call_command("load_diet_reference_data", stdout=StringIO())
+
+    def test_all_required_switch_slugs_present_after_bootstrap(self):
+        """
+        Every slug in REQUIRED_SWITCH_SLUGS must exist after load_diet_reference_data.
+
+        RED: 17 slugs are missing (all BCM+CLSP hardware except DS5000).
+        GREEN: all 21 slugs present after file copy + filter removal.
+        """
+        self._seed()
+        missing = sorted(
+            slug for slug in REQUIRED_SWITCH_SLUGS
+            if not DeviceType.objects.filter(slug=slug).exists()
+        )
+        self.assertEqual(
+            missing,
+            [],
+            f"Missing switch slugs after load_diet_reference_data "
+            f"(seam: missing files + DS5000-only filter): {missing}",
+        )
+
+    def test_required_switch_slug_count_is_exact(self):
+        """
+        Exactly 21 of the required switch slugs must be present after bootstrap.
+
+        Uses filter(slug__in=REQUIRED_SWITCH_SLUGS) so operator-added extras are
+        not counted.
+
+        RED: exactly 2 of 21 slugs are present (celestica-ds5000, celestica-es1000).
+        GREEN: all 21 present.
+        """
+        self._seed()
+        present = DeviceType.objects.filter(slug__in=REQUIRED_SWITCH_SLUGS).count()
+        missing = sorted(
+            slug for slug in REQUIRED_SWITCH_SLUGS
+            if not DeviceType.objects.filter(slug=slug).exists()
+        )
+        self.assertEqual(
+            present,
+            21,
+            f"Expected 21 required switch slugs; found {present}. "
+            f"Missing (seam: missing files + DS5000-only filter): {missing}",
+        )


### PR DESCRIPTION
## Problem

`load_diet_reference_data` only imported the DS5000 switch profile, leaving the
supported switch catalog incomplete. Two root causes:

1. **17 of 18 hardware profile files missing** from `netbox_hedgehog/fabric_profiles/` —
   only `p_bcm_celestica_ds5000.go` was bundled.
2. **DS5000-only filter** — `import_bundled_switch_profiles()` passed
   `profiles="celestica-ds5000"` to `import_fabric_profiles`, suppressing every
   other BCM profile, all CLSP profiles, and the virtual-profile loop (`vs`,
   `vs-clsp`).

After bootstrap only 2 of 21 required switch slugs were present
(`celestica-ds5000` and `celestica-es1000`).

## Fix

- **Bundle 17 missing hardware profile files** from fabric v0.98.0 into
  `netbox_hedgehog/fabric_profiles/` — 12 BCM (`ds2000/3000/4000/4101`,
  Dell S5232F/S5248F/Z9332F, Edgecore DCS203/204/501/EPS203, Supermicro
  SSE-C4632SB) + 5 CLSP (`celestica-ds2000-clsp` through `celestica-ds5000-clsp`).
- **Remove the DS5000-only filter** from `import_bundled_switch_profiles()` so
  all bundled hardware profiles are processed, including the virtual-profile loop.
- **Update bootstrap contract test** — `BreakoutOption` exact count rises from
  16 → 23 once all profiles are imported (14 canonical + 9 contributed by
  the full hardware set); verified empirically.

## Non-goals

- No parser redesign or importer refactor.
- No live external import dependency for ordinary bootstrap — all 18 profile
  files are now vendored locally.
- No changes to virtual profile semantics beyond unblocking their import.

## Tests

```
docker compose exec -T netbox python manage.py test \
  netbox_hedgehog.tests.test_topology_planning.test_reference_data_bootstrap \
  netbox_hedgehog.tests.test_topology_planning.test_seeded_catalog_regression \
  --keepdb
```

- `test_reference_data_bootstrap`: **24/24** ✓
- `test_seeded_catalog_regression`: **14/14** ✓

All 4 RED failures resolved; all 20 previously-green tests remain green.

## Post-merge sanity check

```bash
docker compose exec netbox python manage.py load_diet_reference_data
```

Expected outcome:
- 21 required switch DeviceType slugs present
- `BreakoutOption` count = 23

## Issue chain

Closes #566
Closes #567
Closes #568
Closes #569
Closes #570
Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)