### PR TITLE
Fix yaml_generator cross-plan Device collision and pipeline script issues (XOC-64 RO proving run)

### DIFF
--- a/netbox_hedgehog/services/yaml_generator.py
+++ b/netbox_hedgehog/services/yaml_generator.py
@@ -1427,9 +1427,9 @@ class YAMLGenerator:
         # Generate MCLAG domain CRDs
         mclag_domain_crds = []
         for switch_pair, links in mclag_domain_links.items():
-            # Get switch devices by name (sorted alphabetically)
-            switch1 = Device.objects.get(name=switch_pair[0])
-            switch2 = Device.objects.get(name=switch_pair[1])
+            # Get switch devices by name (sorted alphabetically), scoped to this plan
+            switch1 = self._plan_devices().get(name=switch_pair[0])
+            switch2 = self._plan_devices().get(name=switch_pair[1])
 
             mclag_domain_crds.append(self._create_mclag_domain_crd(
                 switch1, switch2,
@@ -1498,8 +1498,8 @@ class YAMLGenerator:
         # Generate mesh CRDs
         mesh_crds = []
         for switch_pair, raw_links in mesh_links_by_pair.items():
-            switch_a = Device.objects.get(name=switch_pair[0])
-            switch_b = Device.objects.get(name=switch_pair[1])
+            switch_a = self._plan_devices().get(name=switch_pair[0])
+            switch_b = self._plan_devices().get(name=switch_pair[1])
             # Pre-format link_data into the mesh CRD link entry format (IPs omitted per DIET-311)
             formatted_links = [
                 {

--- a/scripts/publish_ra_assets.sh
+++ b/scripts/publish_ra_assets.sh
@@ -121,6 +121,25 @@ for FILE in "${CR_ASSETS[@]}"; do
   fi
 done
 
+# --- generated/ → <comp>/generated/ (pipeline provenance) ---
+# Publishes: inputs/ (case fixture, translation-notes), logs/ (pipeline run logs).
+# Atomically replaces generated/ so stale data from prior pipeline versions is removed.
+GENERATED_DEST="${COMPOSITION_DIR}/generated"
+rm -rf "$GENERATED_DEST"
+mkdir -p "$GENERATED_DEST"
+PROVENANCE_PUBLISHED=false
+for PROV_DIR in inputs logs; do
+  PROV_SRC="${ARTIFACT_ROOT}/${PROV_DIR}"
+  if [[ -d "$PROV_SRC" ]]; then
+    cp -a "$PROV_SRC" "${GENERATED_DEST}/"
+    PROVENANCE_PUBLISHED=true
+  fi
+done
+if [[ "$PROVENANCE_PUBLISHED" == "true" ]]; then
+  echo "  generated/      →  ${GENERATED_DEST}"
+  PUBLISHED=$((PUBLISHED + 1))
+fi
+
 if [[ "$PUBLISHED" -eq 0 ]]; then
   echo "WARNING: nothing published — wiring/, hhfab/, and CR-level assets all absent from $ARTIFACT_ROOT" >&2
   exit 1

--- a/scripts/run_ra_pipeline.sh
+++ b/scripts/run_ra_pipeline.sh
@@ -67,7 +67,7 @@ echo "$PLAN_ID" > "$ARTIFACT_DIR/logs/plan_id.txt"
 # 3. Generate devices
 echo "[2/7] Generating devices (plan $PLAN_ID, site $SITE_SLUG)..."
 RUN generate_devices "$PLAN_ID" --site "$SITE_SLUG" > "$ARTIFACT_DIR/logs/generate.log" 2>&1
-DEVICE_COUNT=$(SHELL_QUERY "from dcim.models import Device; print(Device.objects.filter(custom_field_data__hedgehog_plan_id=${PLAN_ID}).count())")
+DEVICE_COUNT=$(SHELL_QUERY "from dcim.models import Device; print(Device.objects.filter(custom_field_data__hedgehog_plan_id='${PLAN_ID}').count())")
 echo "  Devices: $DEVICE_COUNT"
 
 # 4. Export inventory JSON, CSV, and BOM


### PR DESCRIPTION
## Summary

These fixes were discovered during the first real end-to-end Tier 1 composition remediation run (XOC-64 `mesh-conv-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g`). All three changes were required to produce a correct, complete artifact set.

### yaml_generator.py — cross-plan Device.objects.get() collision

`Device.objects.get(name=...)` in the MCLAG-domain and mesh CRD generation paths was a global query with no plan scope. When a prior plan's devices (any site) share device names with the current plan, `MultipleObjectsReturned` is raised and the entire fabric export fails.

Fix: replace with `self._plan_devices().get(name=...)`, which scopes the lookup to `custom_field_data__hedgehog_plan_id=str(self.plan.pk)` — the same filter used everywhere else in the generator.

This blocked the `soc-storage-scale-out` fabric from exporting at all until fixed.

### run_ra_pipeline.sh — DEVICE_COUNT query string vs integer mismatch

The `DEVICE_COUNT` SHELL_QUERY used a bare integer plan ID (`hedgehog_plan_id=${PLAN_ID}`), but the custom field stores values as strings (`'10'` not `10`). The count always returned 0, so translation-notes.md reported "Device count: 0" even when generation succeeded.

Fix: quote the value in the Python query string: `hedgehog_plan_id='${PLAN_ID}'`.

### publish_ra_assets.sh — stale generated/ content from prior pipeline versions

Prior pipeline versions wrote wiring, netbox, and hhfab artifacts into `generated/wiring/`, `generated/netbox/`, and `generated/hhfab/`. The new Tier 1 layout promotes those to flat CR-level assets and `diagrams/hhfab/`. Without explicit cleanup, the old paths accumulate stale files with outdated fabric names (e.g., `wiring-scale-out.yaml` / `wiring-soc-storage.yaml` for a plan that now uses a single `soc-storage-scale-out` fabric).

Fix: add an atomic `generated/` replacement step to `publish_ra_assets.sh` — wipe `generated/` and write fresh `inputs/` + `logs/` provenance on every run.

## Validation

Successful end-to-end run:
```
scripts/run_ra_pipeline.sh \
  --case training_xoc64_1xopg64_mesh_conv_ro \
  --site xoc64-ro-air \
  --composition-dir <ocp-repo>/compositions/xoc/xoc-64/1x-OPG-64/mesh-conv-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g--inb-2x25g
```

```
scripts/verify_ra_artifacts.sh \
  --artifact-root /tmp/ra_pipeline/training_xoc64_1xopg64_mesh_conv_ro
=== All checks PASSED ===
```

Both managed fabrics passed `hhfab validate`:
- `inb-mgmt`: Fabricator config and wiring are valid
- `soc-storage-scale-out`: Fabricator config and wiring are valid

Composition assets published to OCP repo in companion PR: opencomputeproject/OCP-OCDAI-training-fabric#<TBD>

## Files changed

- `netbox_hedgehog/services/yaml_generator.py` — scope Device lookups in MCLAG/mesh CRD generation to plan
- `scripts/run_ra_pipeline.sh` — quote plan ID string in DEVICE_COUNT query
- `scripts/publish_ra_assets.sh` — atomic generated/ provenance replacement

🤖 Generated with [Claude Code](https://claude.com/claude-code)