### PR TITLE
[DIET-562] Promote XOC-128 1x-OPG-128 Clos RO DIET fixture

### DIFF
--- a/netbox_hedgehog/test_cases/training_xoc128_1xopg128_clos_ro.yaml
+++ b/netbox_hedgehog/test_cases/training_xoc128_1xopg128_clos_ro.yaml
@@ -1,0 +1,444 @@
+meta:
+  case_id: training_xoc128_1xopg128_clos_ro
+  name: Training XOC-128 1x OPG-128 Clos RO
+  description: Compute-only DIET translation for the XOC-128 (1x OPG-128) rail-optimized training RA
+  version: 1
+  managed_by: yaml
+  tags:
+    - reference-architecture
+    - training
+    - xoc128
+    - 1x-opg128
+    - clos-ro
+    - pilot
+
+reference_data:
+  manufacturers:
+    - id: generic
+      name: Generic
+      slug: generic
+    - id: celestica
+      name: Celestica
+      slug: celestica
+    - id: nvidia
+      name: NVIDIA
+      slug: nvidia
+
+  device_types:
+    - id: ds5000
+      manufacturer: celestica
+      model: Celestica DS5000
+      slug: celestica-ds5000
+      interface_templates:
+        - name: E1/1
+          type: 800gbase-x-osfp
+        - name: E1/2
+          type: 800gbase-x-osfp
+        - name: E1/3
+          type: 800gbase-x-osfp
+        - name: E1/4
+          type: 800gbase-x-osfp
+        - name: E1/5
+          type: 800gbase-x-osfp
+        - name: E1/6
+          type: 800gbase-x-osfp
+        - name: E1/7
+          type: 800gbase-x-osfp
+        - name: E1/8
+          type: 800gbase-x-osfp
+        - name: E1/9
+          type: 800gbase-x-osfp
+        - name: E1/10
+          type: 800gbase-x-osfp
+        - name: E1/11
+          type: 800gbase-x-osfp
+        - name: E1/12
+          type: 800gbase-x-osfp
+        - name: E1/13
+          type: 800gbase-x-osfp
+        - name: E1/14
+          type: 800gbase-x-osfp
+        - name: E1/15
+          type: 800gbase-x-osfp
+        - name: E1/16
+          type: 800gbase-x-osfp
+        - name: E1/17
+          type: 800gbase-x-osfp
+        - name: E1/18
+          type: 800gbase-x-osfp
+        - name: E1/19
+          type: 800gbase-x-osfp
+        - name: E1/20
+          type: 800gbase-x-osfp
+        - name: E1/21
+          type: 800gbase-x-osfp
+        - name: E1/22
+          type: 800gbase-x-osfp
+        - name: E1/23
+          type: 800gbase-x-osfp
+        - name: E1/24
+          type: 800gbase-x-osfp
+        - name: E1/25
+          type: 800gbase-x-osfp
+        - name: E1/26
+          type: 800gbase-x-osfp
+        - name: E1/27
+          type: 800gbase-x-osfp
+        - name: E1/28
+          type: 800gbase-x-osfp
+        - name: E1/29
+          type: 800gbase-x-osfp
+        - name: E1/30
+          type: 800gbase-x-osfp
+        - name: E1/31
+          type: 800gbase-x-osfp
+        - name: E1/32
+          type: 800gbase-x-osfp
+        - name: E1/33
+          type: 800gbase-x-osfp
+        - name: E1/34
+          type: 800gbase-x-osfp
+        - name: E1/35
+          type: 800gbase-x-osfp
+        - name: E1/36
+          type: 800gbase-x-osfp
+        - name: E1/37
+          type: 800gbase-x-osfp
+        - name: E1/38
+          type: 800gbase-x-osfp
+        - name: E1/39
+          type: 800gbase-x-osfp
+        - name: E1/40
+          type: 800gbase-x-osfp
+        - name: E1/41
+          type: 800gbase-x-osfp
+        - name: E1/42
+          type: 800gbase-x-osfp
+        - name: E1/43
+          type: 800gbase-x-osfp
+        - name: E1/44
+          type: 800gbase-x-osfp
+        - name: E1/45
+          type: 800gbase-x-osfp
+        - name: E1/46
+          type: 800gbase-x-osfp
+        - name: E1/47
+          type: 800gbase-x-osfp
+        - name: E1/48
+          type: 800gbase-x-osfp
+        - name: E1/49
+          type: 800gbase-x-osfp
+        - name: E1/50
+          type: 800gbase-x-osfp
+        - name: E1/51
+          type: 800gbase-x-osfp
+        - name: E1/52
+          type: 800gbase-x-osfp
+        - name: E1/53
+          type: 800gbase-x-osfp
+        - name: E1/54
+          type: 800gbase-x-osfp
+        - name: E1/55
+          type: 800gbase-x-osfp
+        - name: E1/56
+          type: 800gbase-x-osfp
+        - name: E1/57
+          type: 800gbase-x-osfp
+        - name: E1/58
+          type: 800gbase-x-osfp
+        - name: E1/59
+          type: 800gbase-x-osfp
+        - name: E1/60
+          type: 800gbase-x-osfp
+        - name: E1/61
+          type: 800gbase-x-osfp
+        - name: E1/62
+          type: 800gbase-x-osfp
+        - name: E1/63
+          type: 800gbase-x-osfp
+        - name: E1/64
+          type: 800gbase-x-osfp
+    - id: gpu_server_fe_be
+      manufacturer: generic
+      model: OPG-128 Compute Server FE-BE
+      slug: opg128-compute-server-fe-be
+      u_height: 2
+      is_full_depth: true
+
+  device_type_extensions:
+    - id: ds5000_ext
+      device_type: ds5000
+      mclag_capable: false
+      hedgehog_roles: [spine, server-leaf]
+      supported_breakouts: [1x800g, 2x400g, 4x200g, 8x100g]
+      native_speed: 800
+      uplink_ports: 32
+      hedgehog_profile_name: celestica-ds5000
+      notes: DS5000 profile for XOC-128 (1x OPG-128) rail-optimized pilot
+
+  breakout_options:
+    - id: b_1x800
+      breakout_id: 1x800g
+      from_speed: 800
+      logical_ports: 1
+      logical_speed: 800
+      optic_type: OSFP-800G-DR8
+    - id: b_2x400
+      breakout_id: 2x400g
+      from_speed: 800
+      logical_ports: 2
+      logical_speed: 400
+      optic_type: OSFP-800G-2x400G-DR4
+    - id: b_4x200
+      breakout_id: 4x200g
+      from_speed: 800
+      logical_ports: 4
+      logical_speed: 200
+      optic_type: OSFP-800G-4x200G-DR4
+
+  module_types:
+    - id: nic_bf3_2x200
+      manufacturer: nvidia
+      model: BlueField-3 2x200G
+      interface_templates:
+        - name: p0
+          type: other
+        - name: p1
+          type: other
+    - id: nic_cx7_single_400
+      manufacturer: nvidia
+      model: ConnectX-7 Single-Port 400G
+      interface_templates:
+        - name: port0
+          type: other
+
+plan:
+  name: Training XOC-128 1x OPG-128 Clos RO
+  status: draft
+  description: Compute-only DIET translation of the XOC-128 (1x OPG-128) rail-optimized training reference architecture. Non-compute endpoint counts remain intentionally excluded pending source confirmation.
+
+switch_classes:
+  - switch_class_id: fe-leaf
+    fabric_name: frontend
+    fabric_class: managed
+    hedgehog_role: server-leaf
+    device_type_extension: ds5000_ext
+    mclag_pair: false
+    redundancy_type: mclag
+    redundancy_group: fe-mclag
+  - switch_class_id: fe-spine
+    fabric_name: frontend
+    fabric_class: managed
+    hedgehog_role: spine
+    device_type_extension: ds5000_ext
+    uplink_ports_per_switch: 0
+    mclag_pair: false
+  - switch_class_id: be-rail-leaf
+    fabric_name: backend
+    fabric_class: managed
+    hedgehog_role: server-leaf
+    device_type_extension: ds5000_ext
+    mclag_pair: false
+  - switch_class_id: be-spine
+    fabric_name: backend
+    fabric_class: managed
+    hedgehog_role: spine
+    device_type_extension: ds5000_ext
+    uplink_ports_per_switch: 0
+    mclag_pair: false
+
+switch_port_zones:
+  - switch_class: fe-leaf
+    zone_name: fe-server-ports
+    zone_type: server
+    port_spec: 1-63:2
+    breakout_option: b_4x200
+    allocation_strategy: sequential
+    priority: 10
+  - switch_class: fe-leaf
+    zone_name: fe-uplinks
+    zone_type: uplink
+    port_spec: 2-64:2
+    breakout_option: b_1x800
+    allocation_strategy: sequential
+    priority: 20
+  - switch_class: fe-spine
+    zone_name: fe-fabric-downlinks
+    zone_type: fabric
+    port_spec: 1-64
+    breakout_option: b_1x800
+    allocation_strategy: sequential
+    priority: 10
+  - switch_class: be-rail-leaf
+    zone_name: be-server-ports
+    zone_type: server
+    port_spec: 1-32
+    breakout_option: b_2x400
+    allocation_strategy: sequential
+    priority: 10
+  - switch_class: be-rail-leaf
+    zone_name: be-uplinks
+    zone_type: uplink
+    port_spec: 33-64
+    breakout_option: b_1x800
+    allocation_strategy: sequential
+    priority: 20
+  - switch_class: be-spine
+    zone_name: be-fabric-downlinks
+    zone_type: fabric
+    port_spec: 1-64
+    breakout_option: b_1x800
+    allocation_strategy: sequential
+    priority: 10
+
+server_classes:
+  - server_class_id: compute
+    description: 16 training compute servers, 8 xPUs each
+    category: gpu
+    quantity: 16
+    gpus_per_server: 8
+    server_device_type: gpu_server_fe_be
+
+server_nics:
+  - server_class: compute
+    nic_id: fe
+    module_type: nic_bf3_2x200
+  - server_class: compute
+    nic_id: be0
+    module_type: nic_cx7_single_400
+  - server_class: compute
+    nic_id: be1
+    module_type: nic_cx7_single_400
+  - server_class: compute
+    nic_id: be2
+    module_type: nic_cx7_single_400
+  - server_class: compute
+    nic_id: be3
+    module_type: nic_cx7_single_400
+  - server_class: compute
+    nic_id: be4
+    module_type: nic_cx7_single_400
+  - server_class: compute
+    nic_id: be5
+    module_type: nic_cx7_single_400
+  - server_class: compute
+    nic_id: be6
+    module_type: nic_cx7_single_400
+  - server_class: compute
+    nic_id: be7
+    module_type: nic_cx7_single_400
+
+server_connections:
+  - server_class: compute
+    connection_id: fe
+    connection_name: frontend
+    nic: fe
+    port_index: 0
+    ports_per_connection: 2
+    hedgehog_conn_type: unbundled
+    distribution: alternating
+    target_zone: fe-leaf/fe-server-ports
+    speed: 200
+    port_type: data
+  - server_class: compute
+    connection_id: be-rail-0
+    connection_name: backend-rail-0
+    nic: be0
+    port_index: 0
+    ports_per_connection: 1
+    hedgehog_conn_type: unbundled
+    distribution: rail-optimized
+    target_zone: be-rail-leaf/be-server-ports
+    speed: 400
+    rail: 0
+    port_type: data
+  - server_class: compute
+    connection_id: be-rail-1
+    connection_name: backend-rail-1
+    nic: be1
+    port_index: 0
+    ports_per_connection: 1
+    hedgehog_conn_type: unbundled
+    distribution: rail-optimized
+    target_zone: be-rail-leaf/be-server-ports
+    speed: 400
+    rail: 1
+    port_type: data
+  - server_class: compute
+    connection_id: be-rail-2
+    connection_name: backend-rail-2
+    nic: be2
+    port_index: 0
+    ports_per_connection: 1
+    hedgehog_conn_type: unbundled
+    distribution: rail-optimized
+    target_zone: be-rail-leaf/be-server-ports
+    speed: 400
+    rail: 2
+    port_type: data
+  - server_class: compute
+    connection_id: be-rail-3
+    connection_name: backend-rail-3
+    nic: be3
+    port_index: 0
+    ports_per_connection: 1
+    hedgehog_conn_type: unbundled
+    distribution: rail-optimized
+    target_zone: be-rail-leaf/be-server-ports
+    speed: 400
+    rail: 3
+    port_type: data
+  - server_class: compute
+    connection_id: be-rail-4
+    connection_name: backend-rail-4
+    nic: be4
+    port_index: 0
+    ports_per_connection: 1
+    hedgehog_conn_type: unbundled
+    distribution: rail-optimized
+    target_zone: be-rail-leaf/be-server-ports
+    speed: 400
+    rail: 4
+    port_type: data
+  - server_class: compute
+    connection_id: be-rail-5
+    connection_name: backend-rail-5
+    nic: be5
+    port_index: 0
+    ports_per_connection: 1
+    hedgehog_conn_type: unbundled
+    distribution: rail-optimized
+    target_zone: be-rail-leaf/be-server-ports
+    speed: 400
+    rail: 5
+    port_type: data
+  - server_class: compute
+    connection_id: be-rail-6
+    connection_name: backend-rail-6
+    nic: be6
+    port_index: 0
+    ports_per_connection: 1
+    hedgehog_conn_type: unbundled
+    distribution: rail-optimized
+    target_zone: be-rail-leaf/be-server-ports
+    speed: 400
+    rail: 6
+    port_type: data
+  - server_class: compute
+    connection_id: be-rail-7
+    connection_name: backend-rail-7
+    nic: be7
+    port_index: 0
+    ports_per_connection: 1
+    hedgehog_conn_type: unbundled
+    distribution: rail-optimized
+    target_zone: be-rail-leaf/be-server-ports
+    speed: 400
+    rail: 7
+    port_type: data
+
+expected:
+  counts:
+    server_classes: 1
+    switch_classes: 4
+    connections: 9


### PR DESCRIPTION
## Summary

- Promotes `training_xoc128_1xopg128_clos_ro` as the first XOC-128 DIET fixture
- Source: `topology-map.yaml` from `compositions/xoc/xoc-128/1x-opg-128/clos-ro--cx7-1x400g--bf3-2x200g--storage-conv-2x200g/`
- No translation needed — the composition was already in DIET fixture format with the canonical `celestica-ds5000` slug

## Pipeline Validation

| Step | Result |
|------|--------|
| `apply_diet_test_case` (ingest) | OK |
| `generate_devices` | OK — 22 devices, 416 interfaces, 288 cables |
| Wiring export | OK — `wiring-backend.yaml`, `wiring-frontend.yaml` |
| hhfab validate backend | VALID |
| hhfab validate frontend | VALID |

## XOC-128 Coverage After This PR

| Composition | Status |
|-------------|--------|
| `1x-opg-128/clos-ro` | **This PR — complete** |
| `1x-opg-128/clos-sh` | Pending (structurally similar, next candidate) |
| `2x-opg-64/mesh-conv-ro` | Blocked — needs DIET-446 template fix for `celestica-ds5000-leaf` |
| `2x-opg-64/mesh-conv-sh` | Blocked — same blocker as mesh-conv-ro |

## OCP Companion PR

https://github.com/opencomputeproject/OCP-OCDAI-training-fabric/pull/11

🤖 Generated with [Claude Code](https://claude.com/claude-code)