### PR TITLE
[DIET-592] Promote XOC-128 2x-OPG-64 mesh-conv RO/SH fixtures (Option A)

### DIFF
--- a/netbox_hedgehog/test_cases/training_xoc128_2xopg64_mesh_conv_ro.yaml
+++ b/netbox_hedgehog/test_cases/training_xoc128_2xopg64_mesh_conv_ro.yaml
@@ -1,0 +1,1176 @@
+meta:
+  case_id: training_xoc128_2xopg64_mesh_conv_ro
+  name: Training XOC-128 2x OPG-64 Mesh Converged RO
+  description: 'XOC-128 composition of two independent OPG-64 mesh-converged training
+    building blocks (rail-optimized scale-out). Modeled as explicit A/B fabric pairs;
+    each pair is an independent 2-switch mesh serving half the cluster. Fixes topology-model
+    limitation tracked in hh-netbox-plugin #592.'
+  version: 1
+  managed_by: yaml
+  tags:
+  - reference-architecture
+  - training
+  - xoc128
+  - 2x-opg64
+  - mesh
+  - converged
+  - rail-optimized
+reference_data:
+  manufacturers:
+  - id: generic
+    name: Generic
+    slug: generic
+  - id: celestica
+    name: Celestica
+    slug: celestica
+  - id: nvidia
+    name: NVIDIA
+    slug: nvidia
+  device_types:
+  - id: sw_ds5000_leaf_dt
+    manufacturer: celestica
+    model: Celestica DS5000
+    slug: celestica-ds5000
+  - id: sw_ds2000_inb_dt
+    manufacturer: celestica
+    model: Celestica DS2000
+    slug: celestica-ds2000
+    interface_templates:
+    - name: M1
+      type: 1000base-t
+    - name: E1/1
+      type: 25gbase-x-sfp28
+    - name: E1/2
+      type: 25gbase-x-sfp28
+    - name: E1/3
+      type: 25gbase-x-sfp28
+    - name: E1/4
+      type: 25gbase-x-sfp28
+    - name: E1/5
+      type: 25gbase-x-sfp28
+    - name: E1/6
+      type: 25gbase-x-sfp28
+    - name: E1/7
+      type: 25gbase-x-sfp28
+    - name: E1/8
+      type: 25gbase-x-sfp28
+    - name: E1/9
+      type: 25gbase-x-sfp28
+    - name: E1/10
+      type: 25gbase-x-sfp28
+    - name: E1/11
+      type: 25gbase-x-sfp28
+    - name: E1/12
+      type: 25gbase-x-sfp28
+    - name: E1/13
+      type: 25gbase-x-sfp28
+    - name: E1/14
+      type: 25gbase-x-sfp28
+    - name: E1/15
+      type: 25gbase-x-sfp28
+    - name: E1/16
+      type: 25gbase-x-sfp28
+    - name: E1/17
+      type: 25gbase-x-sfp28
+    - name: E1/18
+      type: 25gbase-x-sfp28
+    - name: E1/19
+      type: 25gbase-x-sfp28
+    - name: E1/20
+      type: 25gbase-x-sfp28
+    - name: E1/21
+      type: 25gbase-x-sfp28
+    - name: E1/22
+      type: 25gbase-x-sfp28
+    - name: E1/23
+      type: 25gbase-x-sfp28
+    - name: E1/24
+      type: 25gbase-x-sfp28
+    - name: E1/25
+      type: 25gbase-x-sfp28
+    - name: E1/26
+      type: 25gbase-x-sfp28
+    - name: E1/27
+      type: 25gbase-x-sfp28
+    - name: E1/28
+      type: 25gbase-x-sfp28
+    - name: E1/29
+      type: 25gbase-x-sfp28
+    - name: E1/30
+      type: 25gbase-x-sfp28
+    - name: E1/31
+      type: 25gbase-x-sfp28
+    - name: E1/32
+      type: 25gbase-x-sfp28
+    - name: E1/33
+      type: 25gbase-x-sfp28
+    - name: E1/34
+      type: 25gbase-x-sfp28
+    - name: E1/35
+      type: 25gbase-x-sfp28
+    - name: E1/36
+      type: 25gbase-x-sfp28
+    - name: E1/37
+      type: 25gbase-x-sfp28
+    - name: E1/38
+      type: 25gbase-x-sfp28
+    - name: E1/39
+      type: 25gbase-x-sfp28
+    - name: E1/40
+      type: 25gbase-x-sfp28
+    - name: E1/41
+      type: 25gbase-x-sfp28
+    - name: E1/42
+      type: 25gbase-x-sfp28
+    - name: E1/43
+      type: 25gbase-x-sfp28
+    - name: E1/44
+      type: 25gbase-x-sfp28
+    - name: E1/45
+      type: 25gbase-x-sfp28
+    - name: E1/46
+      type: 25gbase-x-sfp28
+    - name: E1/47
+      type: 25gbase-x-sfp28
+    - name: E1/48
+      type: 25gbase-x-sfp28
+    - name: E1/49
+      type: 100gbase-x-qsfp28
+    - name: E1/50
+      type: 100gbase-x-qsfp28
+    - name: E1/51
+      type: 100gbase-x-qsfp28
+    - name: E1/52
+      type: 100gbase-x-qsfp28
+    - name: E1/53
+      type: 100gbase-x-qsfp28
+    - name: E1/54
+      type: 100gbase-x-qsfp28
+    - name: E1/55
+      type: 100gbase-x-qsfp28
+    - name: E1/56
+      type: 100gbase-x-qsfp28
+  - id: sw_ds1000_oob_dt
+    manufacturer: celestica
+    model: Celestica DS1000
+    slug: celestica-ds1000
+    interface_templates:
+    - name: M1
+      type: 1000base-t
+    - name: E1/1
+      type: 1000base-t
+    - name: E1/2
+      type: 1000base-t
+    - name: E1/3
+      type: 1000base-t
+    - name: E1/4
+      type: 1000base-t
+    - name: E1/5
+      type: 1000base-t
+    - name: E1/6
+      type: 1000base-t
+    - name: E1/7
+      type: 1000base-t
+    - name: E1/8
+      type: 1000base-t
+    - name: E1/9
+      type: 1000base-t
+    - name: E1/10
+      type: 1000base-t
+    - name: E1/11
+      type: 1000base-t
+    - name: E1/12
+      type: 1000base-t
+    - name: E1/13
+      type: 1000base-t
+    - name: E1/14
+      type: 1000base-t
+    - name: E1/15
+      type: 1000base-t
+    - name: E1/16
+      type: 1000base-t
+    - name: E1/17
+      type: 1000base-t
+    - name: E1/18
+      type: 1000base-t
+    - name: E1/19
+      type: 1000base-t
+    - name: E1/20
+      type: 1000base-t
+    - name: E1/21
+      type: 1000base-t
+    - name: E1/22
+      type: 1000base-t
+    - name: E1/23
+      type: 1000base-t
+    - name: E1/24
+      type: 1000base-t
+    - name: E1/25
+      type: 1000base-t
+    - name: E1/26
+      type: 1000base-t
+    - name: E1/27
+      type: 1000base-t
+    - name: E1/28
+      type: 1000base-t
+    - name: E1/29
+      type: 1000base-t
+    - name: E1/30
+      type: 1000base-t
+    - name: E1/31
+      type: 1000base-t
+    - name: E1/32
+      type: 1000base-t
+    - name: E1/33
+      type: 1000base-t
+    - name: E1/34
+      type: 1000base-t
+    - name: E1/35
+      type: 1000base-t
+    - name: E1/36
+      type: 1000base-t
+    - name: E1/37
+      type: 1000base-t
+    - name: E1/38
+      type: 1000base-t
+    - name: E1/39
+      type: 1000base-t
+    - name: E1/40
+      type: 1000base-t
+    - name: E1/41
+      type: 1000base-t
+    - name: E1/42
+      type: 1000base-t
+    - name: E1/43
+      type: 1000base-t
+    - name: E1/44
+      type: 1000base-t
+    - name: E1/45
+      type: 1000base-t
+    - name: E1/46
+      type: 1000base-t
+    - name: E1/47
+      type: 1000base-t
+    - name: E1/48
+      type: 1000base-t
+    - name: E1/49
+      type: 10gbase-x-sfpp
+    - name: E1/50
+      type: 10gbase-x-sfpp
+    - name: E1/51
+      type: 10gbase-x-sfpp
+    - name: E1/52
+      type: 10gbase-x-sfpp
+    - name: E1/53
+      type: 10gbase-x-sfpp
+    - name: E1/54
+      type: 10gbase-x-sfpp
+    - name: E1/55
+      type: 10gbase-x-sfpp
+    - name: E1/56
+      type: 10gbase-x-sfpp
+  - id: srv_xpu_generic_dt
+    manufacturer: generic
+    model: OCP-Compliant xPU Server
+    slug: ocp-compliant-xpu-server
+    u_height: 4
+    is_full_depth: true
+  - id: srv_storage_generic_dt
+    manufacturer: generic
+    model: OCP-Compliant Storage Server
+    slug: ocp-compliant-storage-server
+    u_height: 2
+    is_full_depth: true
+  - id: srv_metadata_generic_dt
+    manufacturer: generic
+    model: OCP-Compliant Metadata Server
+    slug: ocp-compliant-metadata-server
+    u_height: 1
+    is_full_depth: false
+  - id: srv_hh_gateway_dt
+    manufacturer: generic
+    model: Hedgehog Gateway x86
+    slug: hedgehog-gateway-x86
+    u_height: 1
+    is_full_depth: false
+  - id: srv_hh_controller_dt
+    manufacturer: generic
+    model: Hedgehog Controller x86
+    slug: hedgehog-controller-x86
+    u_height: 1
+    is_full_depth: false
+  device_type_extensions:
+  - id: sw_ds5000_mesh_leaf_ext
+    device_type: sw_ds5000_leaf_dt
+    mclag_capable: false
+    hedgehog_roles:
+    - server-leaf
+    supported_breakouts:
+    - 1x800g
+    - 2x400g
+    - 4x200g
+    - 8x100g
+    native_speed: 800
+    uplink_ports: 32
+    hedgehog_profile_name: celestica-ds5000
+    notes: Canonical DS5000 mesh leaf for XOC-128 2x-OPG-64 A/B fabric pairs.
+  - id: sw_ds2000_inb_ext
+    device_type: sw_ds2000_inb_dt
+    mclag_capable: false
+    hedgehog_roles:
+    - server-leaf
+    supported_breakouts: []
+    native_speed: 25
+    uplink_ports: 8
+    hedgehog_profile_name: celestica-ds2000
+    notes: DS2000 in-band management fabric.
+  - id: sw_ds1000_oob_ext
+    device_type: sw_ds1000_oob_dt
+    mclag_capable: false
+    hedgehog_roles:
+    - server-leaf
+    supported_breakouts: []
+    native_speed: 1
+    uplink_ports: 8
+    hedgehog_profile_name: celestica-ds1000
+    notes: DS1000 OOB management switch pair.
+  breakout_options:
+  - id: b_1x800
+    breakout_id: 1x800g
+    from_speed: 800
+    logical_ports: 1
+    logical_speed: 800
+    optic_type: OSFP-800G-DR8
+  - id: brk_2x400_osfp
+    breakout_id: 2x400g
+    from_speed: 800
+    logical_ports: 2
+    logical_speed: 400
+    optic_type: OSFP-800G-2x400G-DR4
+  - id: brk_4x200_osfp
+    breakout_id: 4x200g
+    from_speed: 800
+    logical_ports: 4
+    logical_speed: 200
+    optic_type: OSFP-800G-4x200G-DR4
+  - id: b_1x25
+    breakout_id: 1x25g
+    from_speed: 25
+    logical_ports: 1
+    logical_speed: 25
+  - id: b_1x10
+    breakout_id: 1x10g
+    from_speed: 10
+    logical_ports: 1
+    logical_speed: 10
+  - id: b_1x1
+    breakout_id: 1x1g
+    from_speed: 1
+    logical_ports: 1
+    logical_speed: 1
+  module_types:
+  - id: nic_xpu_scale_out_8x400
+    manufacturer: nvidia
+    model: Generic xPU Scale-Out 8x400G NIC
+    interface_templates:
+    - name: so0
+      type: other
+    - name: so1
+      type: other
+    - name: so2
+      type: other
+    - name: so3
+      type: other
+    - name: so4
+      type: other
+    - name: so5
+      type: other
+    - name: so6
+      type: other
+    - name: so7
+      type: other
+  - id: nic_xpu_soc_storage_2x200
+    manufacturer: nvidia
+    model: Generic xPU SoC/Storage 2x200G NIC
+    interface_templates:
+    - name: ss0
+      type: other
+    - name: ss1
+      type: other
+  - id: nic_dual_200g
+    manufacturer: generic
+    model: Generic Dual-Port 200G NIC
+    interface_templates:
+    - name: port0
+      type: other
+    - name: port1
+      type: other
+  - id: nic_dual_25g
+    manufacturer: generic
+    model: Generic Dual-Port 25GbE NIC
+    interface_templates:
+    - name: mgmt0
+      type: other
+    - name: mgmt1
+      type: other
+  - id: bmc_module
+    manufacturer: generic
+    model: BMC Management Port
+    interface_templates:
+    - name: bmc0
+      type: other
+  - id: osfp_400g_dr4
+    manufacturer: generic
+    model: OSFP-400G-DR4
+  - id: osfp_200g_dr4
+    manufacturer: generic
+    model: OSFP-200G-DR4
+plan:
+  name: Training XOC-128 2x OPG-64 Mesh Converged RO
+  status: draft
+  description: 'XOC-128 composition of two OPG-64 training building blocks modeled
+    as independent A/B mesh fabric pairs. See hh-netbox-plugin #592 for topology-model
+    rationale.'
+switch_classes:
+- switch_class_id: scale_out_leaf_a
+  fabric_name: scale-out-a
+  fabric_class: managed
+  hedgehog_role: server-leaf
+  device_type_extension: sw_ds5000_mesh_leaf_ext
+  topology_mode: mesh
+  override_quantity: 2
+  uplink_ports_per_switch: 32
+  mclag_pair: false
+- switch_class_id: soc_storage_leaf_a
+  fabric_name: soc-storage-a
+  fabric_class: managed
+  hedgehog_role: server-leaf
+  device_type_extension: sw_ds5000_mesh_leaf_ext
+  topology_mode: mesh
+  override_quantity: 2
+  uplink_ports_per_switch: 32
+  mclag_pair: false
+- switch_class_id: scale_out_leaf_b
+  fabric_name: scale-out-b
+  fabric_class: managed
+  hedgehog_role: server-leaf
+  device_type_extension: sw_ds5000_mesh_leaf_ext
+  topology_mode: mesh
+  override_quantity: 2
+  uplink_ports_per_switch: 32
+  mclag_pair: false
+- switch_class_id: soc_storage_leaf_b
+  fabric_name: soc-storage-b
+  fabric_class: managed
+  hedgehog_role: server-leaf
+  device_type_extension: sw_ds5000_mesh_leaf_ext
+  topology_mode: mesh
+  override_quantity: 2
+  uplink_ports_per_switch: 32
+  mclag_pair: false
+- switch_class_id: inb_mgmt_leaf
+  fabric_name: inb-mgmt
+  fabric_class: managed
+  hedgehog_role: server-leaf
+  device_type_extension: sw_ds2000_inb_ext
+  override_quantity: 2
+  uplink_ports_per_switch: 8
+  mclag_pair: false
+- switch_class_id: oob_leaf
+  fabric_name: oob-mgmt
+  fabric_class: unmanaged
+  hedgehog_role: server-leaf
+  device_type_extension: sw_ds1000_oob_ext
+  override_quantity: 2
+  uplink_ports_per_switch: 8
+  mclag_pair: false
+switch_port_zones:
+- switch_class: scale_out_leaf_a
+  zone_name: scale_out_a_uplink_800
+  zone_type: uplink
+  port_spec: 26,28,30,32,34,36,38-63
+  breakout_option: b_1x800
+  allocation_strategy: sequential
+  priority: 10
+- switch_class: scale_out_leaf_a
+  zone_name: scale_out_a_server_2x400
+  zone_type: server
+  port_spec: 1-16
+  breakout_option: brk_2x400_osfp
+  allocation_strategy: sequential
+  priority: 20
+- switch_class: scale_out_leaf_a
+  zone_name: scale_out_a_mesh_800
+  zone_type: mesh
+  port_spec: 26,28
+  breakout_option: b_1x800
+  allocation_strategy: sequential
+  priority: 30
+- switch_class: soc_storage_leaf_a
+  zone_name: soc_storage_a_uplink_800
+  zone_type: uplink
+  port_spec: 26,28,30,32,34,36,38-63
+  breakout_option: b_1x800
+  allocation_strategy: sequential
+  priority: 10
+- switch_class: soc_storage_leaf_a
+  zone_name: soc_storage_a_server_4x200
+  zone_type: server
+  port_spec: 27,29,31,33,35,37
+  breakout_option: brk_4x200_osfp
+  allocation_strategy: sequential
+  priority: 20
+- switch_class: soc_storage_leaf_a
+  zone_name: soc_storage_a_mesh_800
+  zone_type: mesh
+  port_spec: 26,28
+  breakout_option: b_1x800
+  allocation_strategy: sequential
+  priority: 30
+- switch_class: scale_out_leaf_b
+  zone_name: scale_out_b_uplink_800
+  zone_type: uplink
+  port_spec: 26,28,30,32,34,36,38-63
+  breakout_option: b_1x800
+  allocation_strategy: sequential
+  priority: 10
+- switch_class: scale_out_leaf_b
+  zone_name: scale_out_b_server_2x400
+  zone_type: server
+  port_spec: 1-16
+  breakout_option: brk_2x400_osfp
+  allocation_strategy: sequential
+  priority: 20
+- switch_class: scale_out_leaf_b
+  zone_name: scale_out_b_mesh_800
+  zone_type: mesh
+  port_spec: 26,28
+  breakout_option: b_1x800
+  allocation_strategy: sequential
+  priority: 30
+- switch_class: soc_storage_leaf_b
+  zone_name: soc_storage_b_uplink_800
+  zone_type: uplink
+  port_spec: 26,28,30,32,34,36,38-63
+  breakout_option: b_1x800
+  allocation_strategy: sequential
+  priority: 10
+- switch_class: soc_storage_leaf_b
+  zone_name: soc_storage_b_server_4x200
+  zone_type: server
+  port_spec: 27,29,31,33,35,37
+  breakout_option: brk_4x200_osfp
+  allocation_strategy: sequential
+  priority: 20
+- switch_class: soc_storage_leaf_b
+  zone_name: soc_storage_b_mesh_800
+  zone_type: mesh
+  port_spec: 26,28
+  breakout_option: b_1x800
+  allocation_strategy: sequential
+  priority: 30
+- switch_class: inb_mgmt_leaf
+  zone_name: inb_mgmt_server_25g
+  zone_type: server
+  port_spec: 1-24
+  breakout_option: b_1x25
+  allocation_strategy: sequential
+  priority: 10
+- switch_class: oob_leaf
+  zone_name: oob_server_1g
+  zone_type: oob
+  port_spec: 1-48
+  breakout_option: b_1x1
+  allocation_strategy: sequential
+  priority: 10
+- switch_class: oob_leaf
+  zone_name: oob_uplink_10g
+  zone_type: oob
+  port_spec: 49-56
+  breakout_option: b_1x10
+  allocation_strategy: sequential
+  priority: 20
+server_classes:
+- server_class_id: compute_xpu_a
+  description: OPG-64 block A compute servers (8 xPU each)
+  category: gpu
+  quantity: 8
+  gpus_per_server: 8
+  server_device_type: srv_xpu_generic_dt
+- server_class_id: storage_srv_a
+  description: OPG-64 block A storage servers
+  category: storage
+  quantity: 3
+  gpus_per_server: 0
+  server_device_type: srv_storage_generic_dt
+- server_class_id: metadata_srv_a
+  description: OPG-64 block A metadata servers
+  category: infrastructure
+  quantity: 3
+  gpus_per_server: 0
+  server_device_type: srv_metadata_generic_dt
+- server_class_id: compute_xpu_b
+  description: OPG-64 block B compute servers (8 xPU each)
+  category: gpu
+  quantity: 8
+  gpus_per_server: 8
+  server_device_type: srv_xpu_generic_dt
+- server_class_id: storage_srv_b
+  description: OPG-64 block B storage servers
+  category: storage
+  quantity: 3
+  gpus_per_server: 0
+  server_device_type: srv_storage_generic_dt
+- server_class_id: metadata_srv_b
+  description: OPG-64 block B metadata servers
+  category: infrastructure
+  quantity: 3
+  gpus_per_server: 0
+  server_device_type: srv_metadata_generic_dt
+- server_class_id: hh_gateway
+  description: Hedgehog gateway nodes
+  category: infrastructure
+  quantity: 4
+  gpus_per_server: 0
+  server_device_type: srv_hh_gateway_dt
+- server_class_id: hh_controller
+  description: Hedgehog controller node
+  category: infrastructure
+  quantity: 2
+  gpus_per_server: 0
+  server_device_type: srv_hh_controller_dt
+server_nics:
+- server_class: compute_xpu_a
+  nic_id: scale_out
+  module_type: nic_xpu_scale_out_8x400
+- server_class: compute_xpu_a
+  nic_id: soc_storage
+  module_type: nic_xpu_soc_storage_2x200
+- server_class: compute_xpu_a
+  nic_id: inb_mgmt
+  module_type: nic_dual_25g
+- server_class: compute_xpu_a
+  nic_id: bmc
+  module_type: bmc_module
+- server_class: storage_srv_a
+  nic_id: soc_storage
+  module_type: nic_dual_200g
+- server_class: storage_srv_a
+  nic_id: inb_mgmt
+  module_type: nic_dual_25g
+- server_class: storage_srv_a
+  nic_id: bmc
+  module_type: bmc_module
+- server_class: metadata_srv_a
+  nic_id: soc_storage
+  module_type: nic_dual_200g
+- server_class: metadata_srv_a
+  nic_id: inb_mgmt
+  module_type: nic_dual_25g
+- server_class: metadata_srv_a
+  nic_id: bmc
+  module_type: bmc_module
+- server_class: compute_xpu_b
+  nic_id: scale_out
+  module_type: nic_xpu_scale_out_8x400
+- server_class: compute_xpu_b
+  nic_id: soc_storage
+  module_type: nic_xpu_soc_storage_2x200
+- server_class: compute_xpu_b
+  nic_id: inb_mgmt
+  module_type: nic_dual_25g
+- server_class: compute_xpu_b
+  nic_id: bmc
+  module_type: bmc_module
+- server_class: storage_srv_b
+  nic_id: soc_storage
+  module_type: nic_dual_200g
+- server_class: storage_srv_b
+  nic_id: inb_mgmt
+  module_type: nic_dual_25g
+- server_class: storage_srv_b
+  nic_id: bmc
+  module_type: bmc_module
+- server_class: metadata_srv_b
+  nic_id: soc_storage
+  module_type: nic_dual_200g
+- server_class: metadata_srv_b
+  nic_id: inb_mgmt
+  module_type: nic_dual_25g
+- server_class: metadata_srv_b
+  nic_id: bmc
+  module_type: bmc_module
+- server_class: hh_gateway
+  nic_id: inb_mgmt
+  module_type: nic_dual_25g
+- server_class: hh_gateway
+  nic_id: bmc
+  module_type: bmc_module
+- server_class: hh_controller
+  nic_id: inb_mgmt
+  module_type: nic_dual_25g
+- server_class: hh_controller
+  nic_id: bmc
+  module_type: bmc_module
+server_connections:
+- server_class: compute_xpu_a
+  connection_id: scale-out-rail-0
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: rail-optimized
+  target_zone: scale_out_leaf_a/scale_out_a_server_2x400
+  speed: 400
+  rail: 0
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_a
+  connection_id: scale-out-rail-1
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 1
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: rail-optimized
+  target_zone: scale_out_leaf_a/scale_out_a_server_2x400
+  speed: 400
+  rail: 1
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_a
+  connection_id: scale-out-rail-2
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 2
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: rail-optimized
+  target_zone: scale_out_leaf_a/scale_out_a_server_2x400
+  speed: 400
+  rail: 2
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_a
+  connection_id: scale-out-rail-3
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 3
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: rail-optimized
+  target_zone: scale_out_leaf_a/scale_out_a_server_2x400
+  speed: 400
+  rail: 3
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_a
+  connection_id: scale-out-rail-4
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 4
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: rail-optimized
+  target_zone: scale_out_leaf_a/scale_out_a_server_2x400
+  speed: 400
+  rail: 4
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_a
+  connection_id: scale-out-rail-5
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 5
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: rail-optimized
+  target_zone: scale_out_leaf_a/scale_out_a_server_2x400
+  speed: 400
+  rail: 5
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_a
+  connection_id: scale-out-rail-6
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 6
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: rail-optimized
+  target_zone: scale_out_leaf_a/scale_out_a_server_2x400
+  speed: 400
+  rail: 6
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_a
+  connection_id: scale-out-rail-7
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 7
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: rail-optimized
+  target_zone: scale_out_leaf_a/scale_out_a_server_2x400
+  speed: 400
+  rail: 7
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_a
+  connection_id: soc-storage
+  connection_name: soc-storage
+  nic: soc_storage
+  port_index: 0
+  ports_per_connection: 2
+  hedgehog_conn_type: unbundled
+  distribution: alternating
+  target_zone: soc_storage_leaf_a/soc_storage_a_server_4x200
+  speed: 200
+  port_type: data
+  transceiver_module_type: osfp_200g_dr4
+- server_class: compute_xpu_a
+  connection_id: inb-mgmt
+  connection_name: inb-mgmt
+  nic: inb_mgmt
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: inb_mgmt_leaf/inb_mgmt_server_25g
+  speed: 25
+  port_type: data
+- server_class: compute_xpu_a
+  connection_id: oob-mgmt
+  connection_name: oob-mgmt
+  nic: bmc
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: oob_leaf/oob_server_1g
+  speed: 1
+  port_type: ipmi
+- server_class: storage_srv_a
+  connection_id: soc-storage
+  connection_name: soc-storage
+  nic: soc_storage
+  port_index: 0
+  ports_per_connection: 2
+  hedgehog_conn_type: unbundled
+  distribution: alternating
+  target_zone: soc_storage_leaf_a/soc_storage_a_server_4x200
+  speed: 200
+  port_type: data
+  transceiver_module_type: osfp_200g_dr4
+- server_class: storage_srv_a
+  connection_id: inb-mgmt
+  connection_name: inb-mgmt
+  nic: inb_mgmt
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: inb_mgmt_leaf/inb_mgmt_server_25g
+  speed: 25
+  port_type: data
+- server_class: storage_srv_a
+  connection_id: oob-mgmt
+  connection_name: oob-mgmt
+  nic: bmc
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: oob_leaf/oob_server_1g
+  speed: 1
+  port_type: ipmi
+- server_class: metadata_srv_a
+  connection_id: soc-storage
+  connection_name: soc-storage
+  nic: soc_storage
+  port_index: 0
+  ports_per_connection: 2
+  hedgehog_conn_type: unbundled
+  distribution: alternating
+  target_zone: soc_storage_leaf_a/soc_storage_a_server_4x200
+  speed: 200
+  port_type: data
+  transceiver_module_type: osfp_200g_dr4
+- server_class: metadata_srv_a
+  connection_id: inb-mgmt
+  connection_name: inb-mgmt
+  nic: inb_mgmt
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: inb_mgmt_leaf/inb_mgmt_server_25g
+  speed: 25
+  port_type: data
+- server_class: metadata_srv_a
+  connection_id: oob-mgmt
+  connection_name: oob-mgmt
+  nic: bmc
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: oob_leaf/oob_server_1g
+  speed: 1
+  port_type: ipmi
+- server_class: compute_xpu_b
+  connection_id: scale-out-rail-0
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: rail-optimized
+  target_zone: scale_out_leaf_b/scale_out_b_server_2x400
+  speed: 400
+  rail: 0
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_b
+  connection_id: scale-out-rail-1
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 1
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: rail-optimized
+  target_zone: scale_out_leaf_b/scale_out_b_server_2x400
+  speed: 400
+  rail: 1
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_b
+  connection_id: scale-out-rail-2
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 2
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: rail-optimized
+  target_zone: scale_out_leaf_b/scale_out_b_server_2x400
+  speed: 400
+  rail: 2
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_b
+  connection_id: scale-out-rail-3
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 3
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: rail-optimized
+  target_zone: scale_out_leaf_b/scale_out_b_server_2x400
+  speed: 400
+  rail: 3
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_b
+  connection_id: scale-out-rail-4
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 4
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: rail-optimized
+  target_zone: scale_out_leaf_b/scale_out_b_server_2x400
+  speed: 400
+  rail: 4
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_b
+  connection_id: scale-out-rail-5
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 5
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: rail-optimized
+  target_zone: scale_out_leaf_b/scale_out_b_server_2x400
+  speed: 400
+  rail: 5
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_b
+  connection_id: scale-out-rail-6
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 6
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: rail-optimized
+  target_zone: scale_out_leaf_b/scale_out_b_server_2x400
+  speed: 400
+  rail: 6
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_b
+  connection_id: scale-out-rail-7
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 7
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: rail-optimized
+  target_zone: scale_out_leaf_b/scale_out_b_server_2x400
+  speed: 400
+  rail: 7
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_b
+  connection_id: soc-storage
+  connection_name: soc-storage
+  nic: soc_storage
+  port_index: 0
+  ports_per_connection: 2
+  hedgehog_conn_type: unbundled
+  distribution: alternating
+  target_zone: soc_storage_leaf_b/soc_storage_b_server_4x200
+  speed: 200
+  port_type: data
+  transceiver_module_type: osfp_200g_dr4
+- server_class: compute_xpu_b
+  connection_id: inb-mgmt
+  connection_name: inb-mgmt
+  nic: inb_mgmt
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: inb_mgmt_leaf/inb_mgmt_server_25g
+  speed: 25
+  port_type: data
+- server_class: compute_xpu_b
+  connection_id: oob-mgmt
+  connection_name: oob-mgmt
+  nic: bmc
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: oob_leaf/oob_server_1g
+  speed: 1
+  port_type: ipmi
+- server_class: storage_srv_b
+  connection_id: soc-storage
+  connection_name: soc-storage
+  nic: soc_storage
+  port_index: 0
+  ports_per_connection: 2
+  hedgehog_conn_type: unbundled
+  distribution: alternating
+  target_zone: soc_storage_leaf_b/soc_storage_b_server_4x200
+  speed: 200
+  port_type: data
+  transceiver_module_type: osfp_200g_dr4
+- server_class: storage_srv_b
+  connection_id: inb-mgmt
+  connection_name: inb-mgmt
+  nic: inb_mgmt
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: inb_mgmt_leaf/inb_mgmt_server_25g
+  speed: 25
+  port_type: data
+- server_class: storage_srv_b
+  connection_id: oob-mgmt
+  connection_name: oob-mgmt
+  nic: bmc
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: oob_leaf/oob_server_1g
+  speed: 1
+  port_type: ipmi
+- server_class: metadata_srv_b
+  connection_id: soc-storage
+  connection_name: soc-storage
+  nic: soc_storage
+  port_index: 0
+  ports_per_connection: 2
+  hedgehog_conn_type: unbundled
+  distribution: alternating
+  target_zone: soc_storage_leaf_b/soc_storage_b_server_4x200
+  speed: 200
+  port_type: data
+  transceiver_module_type: osfp_200g_dr4
+- server_class: metadata_srv_b
+  connection_id: inb-mgmt
+  connection_name: inb-mgmt
+  nic: inb_mgmt
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: inb_mgmt_leaf/inb_mgmt_server_25g
+  speed: 25
+  port_type: data
+- server_class: metadata_srv_b
+  connection_id: oob-mgmt
+  connection_name: oob-mgmt
+  nic: bmc
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: oob_leaf/oob_server_1g
+  speed: 1
+  port_type: ipmi
+- server_class: hh_gateway
+  connection_id: inb-mgmt
+  connection_name: inb-mgmt
+  nic: inb_mgmt
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: inb_mgmt_leaf/inb_mgmt_server_25g
+  speed: 25
+  port_type: data
+- server_class: hh_gateway
+  connection_id: oob-mgmt
+  connection_name: oob-mgmt
+  nic: bmc
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: oob_leaf/oob_server_1g
+  speed: 1
+  port_type: ipmi
+- server_class: hh_controller
+  connection_id: inb-mgmt
+  connection_name: inb-mgmt
+  nic: inb_mgmt
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: inb_mgmt_leaf/inb_mgmt_server_25g
+  speed: 25
+  port_type: data
+- server_class: hh_controller
+  connection_id: oob-mgmt
+  connection_name: oob-mgmt
+  nic: bmc
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: oob_leaf/oob_server_1g
+  speed: 1
+  port_type: ipmi
+expected:
+  counts:
+    server_classes: 8
+    switch_classes: 6
+    connections: 38

--- a/netbox_hedgehog/test_cases/training_xoc128_2xopg64_mesh_conv_sh.yaml
+++ b/netbox_hedgehog/test_cases/training_xoc128_2xopg64_mesh_conv_sh.yaml
@@ -1,0 +1,992 @@
+meta:
+  case_id: training_xoc128_2xopg64_mesh_conv_sh
+  name: Training XOC-128 2x OPG-64 Mesh Converged SH
+  description: 'XOC-128 composition of two independent OPG-64 mesh-converged training
+    building blocks (single-homed scale-out). Modeled as explicit A/B fabric pairs;
+    each pair is an independent 2-switch mesh serving half the cluster. Fixes topology-model
+    limitation tracked in hh-netbox-plugin #592.'
+  version: 1
+  managed_by: yaml
+  tags:
+  - reference-architecture
+  - training
+  - xoc128
+  - 2x-opg64
+  - mesh
+  - converged
+  - single-homed
+reference_data:
+  manufacturers:
+  - id: generic
+    name: Generic
+    slug: generic
+  - id: celestica
+    name: Celestica
+    slug: celestica
+  - id: nvidia
+    name: NVIDIA
+    slug: nvidia
+  device_types:
+  - id: sw_ds5000_leaf_dt
+    manufacturer: celestica
+    model: Celestica DS5000
+    slug: celestica-ds5000
+  - id: sw_ds2000_inb_dt
+    manufacturer: celestica
+    model: Celestica DS2000
+    slug: celestica-ds2000
+    interface_templates:
+    - name: M1
+      type: 1000base-t
+    - name: E1/1
+      type: 25gbase-x-sfp28
+    - name: E1/2
+      type: 25gbase-x-sfp28
+    - name: E1/3
+      type: 25gbase-x-sfp28
+    - name: E1/4
+      type: 25gbase-x-sfp28
+    - name: E1/5
+      type: 25gbase-x-sfp28
+    - name: E1/6
+      type: 25gbase-x-sfp28
+    - name: E1/7
+      type: 25gbase-x-sfp28
+    - name: E1/8
+      type: 25gbase-x-sfp28
+    - name: E1/9
+      type: 25gbase-x-sfp28
+    - name: E1/10
+      type: 25gbase-x-sfp28
+    - name: E1/11
+      type: 25gbase-x-sfp28
+    - name: E1/12
+      type: 25gbase-x-sfp28
+    - name: E1/13
+      type: 25gbase-x-sfp28
+    - name: E1/14
+      type: 25gbase-x-sfp28
+    - name: E1/15
+      type: 25gbase-x-sfp28
+    - name: E1/16
+      type: 25gbase-x-sfp28
+    - name: E1/17
+      type: 25gbase-x-sfp28
+    - name: E1/18
+      type: 25gbase-x-sfp28
+    - name: E1/19
+      type: 25gbase-x-sfp28
+    - name: E1/20
+      type: 25gbase-x-sfp28
+    - name: E1/21
+      type: 25gbase-x-sfp28
+    - name: E1/22
+      type: 25gbase-x-sfp28
+    - name: E1/23
+      type: 25gbase-x-sfp28
+    - name: E1/24
+      type: 25gbase-x-sfp28
+    - name: E1/25
+      type: 25gbase-x-sfp28
+    - name: E1/26
+      type: 25gbase-x-sfp28
+    - name: E1/27
+      type: 25gbase-x-sfp28
+    - name: E1/28
+      type: 25gbase-x-sfp28
+    - name: E1/29
+      type: 25gbase-x-sfp28
+    - name: E1/30
+      type: 25gbase-x-sfp28
+    - name: E1/31
+      type: 25gbase-x-sfp28
+    - name: E1/32
+      type: 25gbase-x-sfp28
+    - name: E1/33
+      type: 25gbase-x-sfp28
+    - name: E1/34
+      type: 25gbase-x-sfp28
+    - name: E1/35
+      type: 25gbase-x-sfp28
+    - name: E1/36
+      type: 25gbase-x-sfp28
+    - name: E1/37
+      type: 25gbase-x-sfp28
+    - name: E1/38
+      type: 25gbase-x-sfp28
+    - name: E1/39
+      type: 25gbase-x-sfp28
+    - name: E1/40
+      type: 25gbase-x-sfp28
+    - name: E1/41
+      type: 25gbase-x-sfp28
+    - name: E1/42
+      type: 25gbase-x-sfp28
+    - name: E1/43
+      type: 25gbase-x-sfp28
+    - name: E1/44
+      type: 25gbase-x-sfp28
+    - name: E1/45
+      type: 25gbase-x-sfp28
+    - name: E1/46
+      type: 25gbase-x-sfp28
+    - name: E1/47
+      type: 25gbase-x-sfp28
+    - name: E1/48
+      type: 25gbase-x-sfp28
+    - name: E1/49
+      type: 100gbase-x-qsfp28
+    - name: E1/50
+      type: 100gbase-x-qsfp28
+    - name: E1/51
+      type: 100gbase-x-qsfp28
+    - name: E1/52
+      type: 100gbase-x-qsfp28
+    - name: E1/53
+      type: 100gbase-x-qsfp28
+    - name: E1/54
+      type: 100gbase-x-qsfp28
+    - name: E1/55
+      type: 100gbase-x-qsfp28
+    - name: E1/56
+      type: 100gbase-x-qsfp28
+  - id: sw_ds1000_oob_dt
+    manufacturer: celestica
+    model: Celestica DS1000
+    slug: celestica-ds1000
+    interface_templates:
+    - name: M1
+      type: 1000base-t
+    - name: E1/1
+      type: 1000base-t
+    - name: E1/2
+      type: 1000base-t
+    - name: E1/3
+      type: 1000base-t
+    - name: E1/4
+      type: 1000base-t
+    - name: E1/5
+      type: 1000base-t
+    - name: E1/6
+      type: 1000base-t
+    - name: E1/7
+      type: 1000base-t
+    - name: E1/8
+      type: 1000base-t
+    - name: E1/9
+      type: 1000base-t
+    - name: E1/10
+      type: 1000base-t
+    - name: E1/11
+      type: 1000base-t
+    - name: E1/12
+      type: 1000base-t
+    - name: E1/13
+      type: 1000base-t
+    - name: E1/14
+      type: 1000base-t
+    - name: E1/15
+      type: 1000base-t
+    - name: E1/16
+      type: 1000base-t
+    - name: E1/17
+      type: 1000base-t
+    - name: E1/18
+      type: 1000base-t
+    - name: E1/19
+      type: 1000base-t
+    - name: E1/20
+      type: 1000base-t
+    - name: E1/21
+      type: 1000base-t
+    - name: E1/22
+      type: 1000base-t
+    - name: E1/23
+      type: 1000base-t
+    - name: E1/24
+      type: 1000base-t
+    - name: E1/25
+      type: 1000base-t
+    - name: E1/26
+      type: 1000base-t
+    - name: E1/27
+      type: 1000base-t
+    - name: E1/28
+      type: 1000base-t
+    - name: E1/29
+      type: 1000base-t
+    - name: E1/30
+      type: 1000base-t
+    - name: E1/31
+      type: 1000base-t
+    - name: E1/32
+      type: 1000base-t
+    - name: E1/33
+      type: 1000base-t
+    - name: E1/34
+      type: 1000base-t
+    - name: E1/35
+      type: 1000base-t
+    - name: E1/36
+      type: 1000base-t
+    - name: E1/37
+      type: 1000base-t
+    - name: E1/38
+      type: 1000base-t
+    - name: E1/39
+      type: 1000base-t
+    - name: E1/40
+      type: 1000base-t
+    - name: E1/41
+      type: 1000base-t
+    - name: E1/42
+      type: 1000base-t
+    - name: E1/43
+      type: 1000base-t
+    - name: E1/44
+      type: 1000base-t
+    - name: E1/45
+      type: 1000base-t
+    - name: E1/46
+      type: 1000base-t
+    - name: E1/47
+      type: 1000base-t
+    - name: E1/48
+      type: 1000base-t
+    - name: E1/49
+      type: 10gbase-x-sfpp
+    - name: E1/50
+      type: 10gbase-x-sfpp
+    - name: E1/51
+      type: 10gbase-x-sfpp
+    - name: E1/52
+      type: 10gbase-x-sfpp
+    - name: E1/53
+      type: 10gbase-x-sfpp
+    - name: E1/54
+      type: 10gbase-x-sfpp
+    - name: E1/55
+      type: 10gbase-x-sfpp
+    - name: E1/56
+      type: 10gbase-x-sfpp
+  - id: srv_xpu_generic_dt
+    manufacturer: generic
+    model: OCP-Compliant xPU Server
+    slug: ocp-compliant-xpu-server
+    u_height: 4
+    is_full_depth: true
+  - id: srv_storage_generic_dt
+    manufacturer: generic
+    model: OCP-Compliant Storage Server
+    slug: ocp-compliant-storage-server
+    u_height: 2
+    is_full_depth: true
+  - id: srv_metadata_generic_dt
+    manufacturer: generic
+    model: OCP-Compliant Metadata Server
+    slug: ocp-compliant-metadata-server
+    u_height: 1
+    is_full_depth: false
+  - id: srv_hh_gateway_dt
+    manufacturer: generic
+    model: Hedgehog Gateway x86
+    slug: hedgehog-gateway-x86
+    u_height: 1
+    is_full_depth: false
+  - id: srv_hh_controller_dt
+    manufacturer: generic
+    model: Hedgehog Controller x86
+    slug: hedgehog-controller-x86
+    u_height: 1
+    is_full_depth: false
+  device_type_extensions:
+  - id: sw_ds5000_mesh_leaf_ext
+    device_type: sw_ds5000_leaf_dt
+    mclag_capable: false
+    hedgehog_roles:
+    - server-leaf
+    supported_breakouts:
+    - 1x800g
+    - 2x400g
+    - 4x200g
+    - 8x100g
+    native_speed: 800
+    uplink_ports: 32
+    hedgehog_profile_name: celestica-ds5000
+    notes: Canonical DS5000 mesh leaf for XOC-128 2x-OPG-64 A/B fabric pairs.
+  - id: sw_ds2000_inb_ext
+    device_type: sw_ds2000_inb_dt
+    mclag_capable: false
+    hedgehog_roles:
+    - server-leaf
+    supported_breakouts: []
+    native_speed: 25
+    uplink_ports: 8
+    hedgehog_profile_name: celestica-ds2000
+    notes: DS2000 in-band management fabric.
+  - id: sw_ds1000_oob_ext
+    device_type: sw_ds1000_oob_dt
+    mclag_capable: false
+    hedgehog_roles:
+    - server-leaf
+    supported_breakouts: []
+    native_speed: 1
+    uplink_ports: 8
+    hedgehog_profile_name: celestica-ds1000
+    notes: DS1000 OOB management switch pair.
+  breakout_options:
+  - id: b_1x800
+    breakout_id: 1x800g
+    from_speed: 800
+    logical_ports: 1
+    logical_speed: 800
+    optic_type: OSFP-800G-DR8
+  - id: brk_2x400_osfp
+    breakout_id: 2x400g
+    from_speed: 800
+    logical_ports: 2
+    logical_speed: 400
+    optic_type: OSFP-800G-2x400G-DR4
+  - id: brk_4x200_osfp
+    breakout_id: 4x200g
+    from_speed: 800
+    logical_ports: 4
+    logical_speed: 200
+    optic_type: OSFP-800G-4x200G-DR4
+  - id: b_1x25
+    breakout_id: 1x25g
+    from_speed: 25
+    logical_ports: 1
+    logical_speed: 25
+  - id: b_1x10
+    breakout_id: 1x10g
+    from_speed: 10
+    logical_ports: 1
+    logical_speed: 10
+  - id: b_1x1
+    breakout_id: 1x1g
+    from_speed: 1
+    logical_ports: 1
+    logical_speed: 1
+  module_types:
+  - id: nic_xpu_scale_out_8x400
+    manufacturer: nvidia
+    model: Generic xPU Scale-Out 8x400G NIC
+    interface_templates:
+    - name: so0
+      type: other
+    - name: so1
+      type: other
+    - name: so2
+      type: other
+    - name: so3
+      type: other
+    - name: so4
+      type: other
+    - name: so5
+      type: other
+    - name: so6
+      type: other
+    - name: so7
+      type: other
+  - id: nic_xpu_soc_storage_2x200
+    manufacturer: nvidia
+    model: Generic xPU SoC/Storage 2x200G NIC
+    interface_templates:
+    - name: ss0
+      type: other
+    - name: ss1
+      type: other
+  - id: nic_dual_200g
+    manufacturer: generic
+    model: Generic Dual-Port 200G NIC
+    interface_templates:
+    - name: port0
+      type: other
+    - name: port1
+      type: other
+  - id: nic_dual_25g
+    manufacturer: generic
+    model: Generic Dual-Port 25GbE NIC
+    interface_templates:
+    - name: mgmt0
+      type: other
+    - name: mgmt1
+      type: other
+  - id: bmc_module
+    manufacturer: generic
+    model: BMC Management Port
+    interface_templates:
+    - name: bmc0
+      type: other
+  - id: osfp_400g_dr4
+    manufacturer: generic
+    model: OSFP-400G-DR4
+  - id: osfp_200g_dr4
+    manufacturer: generic
+    model: OSFP-200G-DR4
+plan:
+  name: Training XOC-128 2x OPG-64 Mesh Converged SH
+  status: draft
+  description: 'XOC-128 composition of two OPG-64 training building blocks modeled
+    as independent A/B mesh fabric pairs. See hh-netbox-plugin #592 for topology-model
+    rationale.'
+switch_classes:
+- switch_class_id: scale_out_leaf_a
+  fabric_name: scale-out-a
+  fabric_class: managed
+  hedgehog_role: server-leaf
+  device_type_extension: sw_ds5000_mesh_leaf_ext
+  topology_mode: mesh
+  override_quantity: 2
+  uplink_ports_per_switch: 32
+  mclag_pair: false
+- switch_class_id: soc_storage_leaf_a
+  fabric_name: soc-storage-a
+  fabric_class: managed
+  hedgehog_role: server-leaf
+  device_type_extension: sw_ds5000_mesh_leaf_ext
+  topology_mode: mesh
+  override_quantity: 2
+  uplink_ports_per_switch: 32
+  mclag_pair: false
+- switch_class_id: scale_out_leaf_b
+  fabric_name: scale-out-b
+  fabric_class: managed
+  hedgehog_role: server-leaf
+  device_type_extension: sw_ds5000_mesh_leaf_ext
+  topology_mode: mesh
+  override_quantity: 2
+  uplink_ports_per_switch: 32
+  mclag_pair: false
+- switch_class_id: soc_storage_leaf_b
+  fabric_name: soc-storage-b
+  fabric_class: managed
+  hedgehog_role: server-leaf
+  device_type_extension: sw_ds5000_mesh_leaf_ext
+  topology_mode: mesh
+  override_quantity: 2
+  uplink_ports_per_switch: 32
+  mclag_pair: false
+- switch_class_id: inb_mgmt_leaf
+  fabric_name: inb-mgmt
+  fabric_class: managed
+  hedgehog_role: server-leaf
+  device_type_extension: sw_ds2000_inb_ext
+  override_quantity: 2
+  uplink_ports_per_switch: 8
+  mclag_pair: false
+- switch_class_id: oob_leaf
+  fabric_name: oob-mgmt
+  fabric_class: unmanaged
+  hedgehog_role: server-leaf
+  device_type_extension: sw_ds1000_oob_ext
+  override_quantity: 2
+  uplink_ports_per_switch: 8
+  mclag_pair: false
+switch_port_zones:
+- switch_class: scale_out_leaf_a
+  zone_name: scale_out_a_uplink_800
+  zone_type: uplink
+  port_spec: 26,28,30,32,34,36,38-63
+  breakout_option: b_1x800
+  allocation_strategy: sequential
+  priority: 10
+- switch_class: scale_out_leaf_a
+  zone_name: scale_out_a_server_2x400
+  zone_type: server
+  port_spec: 1-16
+  breakout_option: brk_2x400_osfp
+  allocation_strategy: sequential
+  priority: 20
+- switch_class: scale_out_leaf_a
+  zone_name: scale_out_a_mesh_800
+  zone_type: mesh
+  port_spec: 26,28
+  breakout_option: b_1x800
+  allocation_strategy: sequential
+  priority: 30
+- switch_class: soc_storage_leaf_a
+  zone_name: soc_storage_a_uplink_800
+  zone_type: uplink
+  port_spec: 26,28,30,32,34,36,38-63
+  breakout_option: b_1x800
+  allocation_strategy: sequential
+  priority: 10
+- switch_class: soc_storage_leaf_a
+  zone_name: soc_storage_a_server_4x200
+  zone_type: server
+  port_spec: 27,29,31,33,35,37
+  breakout_option: brk_4x200_osfp
+  allocation_strategy: sequential
+  priority: 20
+- switch_class: soc_storage_leaf_a
+  zone_name: soc_storage_a_mesh_800
+  zone_type: mesh
+  port_spec: 26,28
+  breakout_option: b_1x800
+  allocation_strategy: sequential
+  priority: 30
+- switch_class: scale_out_leaf_b
+  zone_name: scale_out_b_uplink_800
+  zone_type: uplink
+  port_spec: 26,28,30,32,34,36,38-63
+  breakout_option: b_1x800
+  allocation_strategy: sequential
+  priority: 10
+- switch_class: scale_out_leaf_b
+  zone_name: scale_out_b_server_2x400
+  zone_type: server
+  port_spec: 1-16
+  breakout_option: brk_2x400_osfp
+  allocation_strategy: sequential
+  priority: 20
+- switch_class: scale_out_leaf_b
+  zone_name: scale_out_b_mesh_800
+  zone_type: mesh
+  port_spec: 26,28
+  breakout_option: b_1x800
+  allocation_strategy: sequential
+  priority: 30
+- switch_class: soc_storage_leaf_b
+  zone_name: soc_storage_b_uplink_800
+  zone_type: uplink
+  port_spec: 26,28,30,32,34,36,38-63
+  breakout_option: b_1x800
+  allocation_strategy: sequential
+  priority: 10
+- switch_class: soc_storage_leaf_b
+  zone_name: soc_storage_b_server_4x200
+  zone_type: server
+  port_spec: 27,29,31,33,35,37
+  breakout_option: brk_4x200_osfp
+  allocation_strategy: sequential
+  priority: 20
+- switch_class: soc_storage_leaf_b
+  zone_name: soc_storage_b_mesh_800
+  zone_type: mesh
+  port_spec: 26,28
+  breakout_option: b_1x800
+  allocation_strategy: sequential
+  priority: 30
+- switch_class: inb_mgmt_leaf
+  zone_name: inb_mgmt_server_25g
+  zone_type: server
+  port_spec: 1-24
+  breakout_option: b_1x25
+  allocation_strategy: sequential
+  priority: 10
+- switch_class: oob_leaf
+  zone_name: oob_server_1g
+  zone_type: oob
+  port_spec: 1-48
+  breakout_option: b_1x1
+  allocation_strategy: sequential
+  priority: 10
+- switch_class: oob_leaf
+  zone_name: oob_uplink_10g
+  zone_type: oob
+  port_spec: 49-56
+  breakout_option: b_1x10
+  allocation_strategy: sequential
+  priority: 20
+server_classes:
+- server_class_id: compute_xpu_a
+  description: OPG-64 block A compute servers (8 xPU each)
+  category: gpu
+  quantity: 8
+  gpus_per_server: 8
+  server_device_type: srv_xpu_generic_dt
+- server_class_id: storage_srv_a
+  description: OPG-64 block A storage servers
+  category: storage
+  quantity: 3
+  gpus_per_server: 0
+  server_device_type: srv_storage_generic_dt
+- server_class_id: metadata_srv_a
+  description: OPG-64 block A metadata servers
+  category: infrastructure
+  quantity: 3
+  gpus_per_server: 0
+  server_device_type: srv_metadata_generic_dt
+- server_class_id: compute_xpu_b
+  description: OPG-64 block B compute servers (8 xPU each)
+  category: gpu
+  quantity: 8
+  gpus_per_server: 8
+  server_device_type: srv_xpu_generic_dt
+- server_class_id: storage_srv_b
+  description: OPG-64 block B storage servers
+  category: storage
+  quantity: 3
+  gpus_per_server: 0
+  server_device_type: srv_storage_generic_dt
+- server_class_id: metadata_srv_b
+  description: OPG-64 block B metadata servers
+  category: infrastructure
+  quantity: 3
+  gpus_per_server: 0
+  server_device_type: srv_metadata_generic_dt
+- server_class_id: hh_gateway
+  description: Hedgehog gateway nodes
+  category: infrastructure
+  quantity: 4
+  gpus_per_server: 0
+  server_device_type: srv_hh_gateway_dt
+- server_class_id: hh_controller
+  description: Hedgehog controller node
+  category: infrastructure
+  quantity: 2
+  gpus_per_server: 0
+  server_device_type: srv_hh_controller_dt
+server_nics:
+- server_class: compute_xpu_a
+  nic_id: scale_out
+  module_type: nic_xpu_scale_out_8x400
+- server_class: compute_xpu_a
+  nic_id: soc_storage
+  module_type: nic_xpu_soc_storage_2x200
+- server_class: compute_xpu_a
+  nic_id: inb_mgmt
+  module_type: nic_dual_25g
+- server_class: compute_xpu_a
+  nic_id: bmc
+  module_type: bmc_module
+- server_class: storage_srv_a
+  nic_id: soc_storage
+  module_type: nic_dual_200g
+- server_class: storage_srv_a
+  nic_id: inb_mgmt
+  module_type: nic_dual_25g
+- server_class: storage_srv_a
+  nic_id: bmc
+  module_type: bmc_module
+- server_class: metadata_srv_a
+  nic_id: soc_storage
+  module_type: nic_dual_200g
+- server_class: metadata_srv_a
+  nic_id: inb_mgmt
+  module_type: nic_dual_25g
+- server_class: metadata_srv_a
+  nic_id: bmc
+  module_type: bmc_module
+- server_class: compute_xpu_b
+  nic_id: scale_out
+  module_type: nic_xpu_scale_out_8x400
+- server_class: compute_xpu_b
+  nic_id: soc_storage
+  module_type: nic_xpu_soc_storage_2x200
+- server_class: compute_xpu_b
+  nic_id: inb_mgmt
+  module_type: nic_dual_25g
+- server_class: compute_xpu_b
+  nic_id: bmc
+  module_type: bmc_module
+- server_class: storage_srv_b
+  nic_id: soc_storage
+  module_type: nic_dual_200g
+- server_class: storage_srv_b
+  nic_id: inb_mgmt
+  module_type: nic_dual_25g
+- server_class: storage_srv_b
+  nic_id: bmc
+  module_type: bmc_module
+- server_class: metadata_srv_b
+  nic_id: soc_storage
+  module_type: nic_dual_200g
+- server_class: metadata_srv_b
+  nic_id: inb_mgmt
+  module_type: nic_dual_25g
+- server_class: metadata_srv_b
+  nic_id: bmc
+  module_type: bmc_module
+- server_class: hh_gateway
+  nic_id: inb_mgmt
+  module_type: nic_dual_25g
+- server_class: hh_gateway
+  nic_id: bmc
+  module_type: bmc_module
+- server_class: hh_controller
+  nic_id: inb_mgmt
+  module_type: nic_dual_25g
+- server_class: hh_controller
+  nic_id: bmc
+  module_type: bmc_module
+server_connections:
+- server_class: compute_xpu_a
+  connection_id: scale-out
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 0
+  ports_per_connection: 8
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: scale_out_leaf_a/scale_out_a_server_2x400
+  speed: 400
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_a
+  connection_id: soc-storage
+  connection_name: soc-storage
+  nic: soc_storage
+  port_index: 0
+  ports_per_connection: 2
+  hedgehog_conn_type: unbundled
+  distribution: alternating
+  target_zone: soc_storage_leaf_a/soc_storage_a_server_4x200
+  speed: 200
+  port_type: data
+  transceiver_module_type: osfp_200g_dr4
+- server_class: compute_xpu_a
+  connection_id: inb-mgmt
+  connection_name: inb-mgmt
+  nic: inb_mgmt
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: inb_mgmt_leaf/inb_mgmt_server_25g
+  speed: 25
+  port_type: data
+- server_class: compute_xpu_a
+  connection_id: oob-mgmt
+  connection_name: oob-mgmt
+  nic: bmc
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: oob_leaf/oob_server_1g
+  speed: 1
+  port_type: ipmi
+- server_class: storage_srv_a
+  connection_id: soc-storage
+  connection_name: soc-storage
+  nic: soc_storage
+  port_index: 0
+  ports_per_connection: 2
+  hedgehog_conn_type: unbundled
+  distribution: alternating
+  target_zone: soc_storage_leaf_a/soc_storage_a_server_4x200
+  speed: 200
+  port_type: data
+  transceiver_module_type: osfp_200g_dr4
+- server_class: storage_srv_a
+  connection_id: inb-mgmt
+  connection_name: inb-mgmt
+  nic: inb_mgmt
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: inb_mgmt_leaf/inb_mgmt_server_25g
+  speed: 25
+  port_type: data
+- server_class: storage_srv_a
+  connection_id: oob-mgmt
+  connection_name: oob-mgmt
+  nic: bmc
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: oob_leaf/oob_server_1g
+  speed: 1
+  port_type: ipmi
+- server_class: metadata_srv_a
+  connection_id: soc-storage
+  connection_name: soc-storage
+  nic: soc_storage
+  port_index: 0
+  ports_per_connection: 2
+  hedgehog_conn_type: unbundled
+  distribution: alternating
+  target_zone: soc_storage_leaf_a/soc_storage_a_server_4x200
+  speed: 200
+  port_type: data
+  transceiver_module_type: osfp_200g_dr4
+- server_class: metadata_srv_a
+  connection_id: inb-mgmt
+  connection_name: inb-mgmt
+  nic: inb_mgmt
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: inb_mgmt_leaf/inb_mgmt_server_25g
+  speed: 25
+  port_type: data
+- server_class: metadata_srv_a
+  connection_id: oob-mgmt
+  connection_name: oob-mgmt
+  nic: bmc
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: oob_leaf/oob_server_1g
+  speed: 1
+  port_type: ipmi
+- server_class: compute_xpu_b
+  connection_id: scale-out
+  connection_name: scale-out
+  nic: scale_out
+  port_index: 0
+  ports_per_connection: 8
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: scale_out_leaf_b/scale_out_b_server_2x400
+  speed: 400
+  port_type: data
+  transceiver_module_type: osfp_400g_dr4
+- server_class: compute_xpu_b
+  connection_id: soc-storage
+  connection_name: soc-storage
+  nic: soc_storage
+  port_index: 0
+  ports_per_connection: 2
+  hedgehog_conn_type: unbundled
+  distribution: alternating
+  target_zone: soc_storage_leaf_b/soc_storage_b_server_4x200
+  speed: 200
+  port_type: data
+  transceiver_module_type: osfp_200g_dr4
+- server_class: compute_xpu_b
+  connection_id: inb-mgmt
+  connection_name: inb-mgmt
+  nic: inb_mgmt
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: inb_mgmt_leaf/inb_mgmt_server_25g
+  speed: 25
+  port_type: data
+- server_class: compute_xpu_b
+  connection_id: oob-mgmt
+  connection_name: oob-mgmt
+  nic: bmc
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: oob_leaf/oob_server_1g
+  speed: 1
+  port_type: ipmi
+- server_class: storage_srv_b
+  connection_id: soc-storage
+  connection_name: soc-storage
+  nic: soc_storage
+  port_index: 0
+  ports_per_connection: 2
+  hedgehog_conn_type: unbundled
+  distribution: alternating
+  target_zone: soc_storage_leaf_b/soc_storage_b_server_4x200
+  speed: 200
+  port_type: data
+  transceiver_module_type: osfp_200g_dr4
+- server_class: storage_srv_b
+  connection_id: inb-mgmt
+  connection_name: inb-mgmt
+  nic: inb_mgmt
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: inb_mgmt_leaf/inb_mgmt_server_25g
+  speed: 25
+  port_type: data
+- server_class: storage_srv_b
+  connection_id: oob-mgmt
+  connection_name: oob-mgmt
+  nic: bmc
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: oob_leaf/oob_server_1g
+  speed: 1
+  port_type: ipmi
+- server_class: metadata_srv_b
+  connection_id: soc-storage
+  connection_name: soc-storage
+  nic: soc_storage
+  port_index: 0
+  ports_per_connection: 2
+  hedgehog_conn_type: unbundled
+  distribution: alternating
+  target_zone: soc_storage_leaf_b/soc_storage_b_server_4x200
+  speed: 200
+  port_type: data
+  transceiver_module_type: osfp_200g_dr4
+- server_class: metadata_srv_b
+  connection_id: inb-mgmt
+  connection_name: inb-mgmt
+  nic: inb_mgmt
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: inb_mgmt_leaf/inb_mgmt_server_25g
+  speed: 25
+  port_type: data
+- server_class: metadata_srv_b
+  connection_id: oob-mgmt
+  connection_name: oob-mgmt
+  nic: bmc
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: oob_leaf/oob_server_1g
+  speed: 1
+  port_type: ipmi
+- server_class: hh_gateway
+  connection_id: inb-mgmt
+  connection_name: inb-mgmt
+  nic: inb_mgmt
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: inb_mgmt_leaf/inb_mgmt_server_25g
+  speed: 25
+  port_type: data
+- server_class: hh_gateway
+  connection_id: oob-mgmt
+  connection_name: oob-mgmt
+  nic: bmc
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: oob_leaf/oob_server_1g
+  speed: 1
+  port_type: ipmi
+- server_class: hh_controller
+  connection_id: inb-mgmt
+  connection_name: inb-mgmt
+  nic: inb_mgmt
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: inb_mgmt_leaf/inb_mgmt_server_25g
+  speed: 25
+  port_type: data
+- server_class: hh_controller
+  connection_id: oob-mgmt
+  connection_name: oob-mgmt
+  nic: bmc
+  port_index: 0
+  ports_per_connection: 1
+  hedgehog_conn_type: unbundled
+  distribution: same-switch
+  target_zone: oob_leaf/oob_server_1g
+  speed: 1
+  port_type: ipmi
+expected:
+  counts:
+    server_classes: 8
+    switch_classes: 6
+    connections: 24


### PR DESCRIPTION
Closes #592.

## Summary

Promotes both XOC-128 2x-OPG-64 mesh-conv fixtures using the approved Option A A/B split topology. No DIET code changes required.

## Topology model

The source topology-map.yaml assumed a single 4-switch mesh per fabric, which DIET's mesh model rejects (hard limit: 2 or 3 switches). Solution: model each OPG-64 building block as its own independent 2-switch mesh fabric pair.

| Original | DIET fixture |
|---------|-------------|
| `scale_out_leaf` (override_qty=2, capacity insufficient) | `scale_out_leaf_a` + `scale_out_leaf_b` (2 switches each, independent fabrics) |
| `soc_storage_leaf` | `soc_storage_leaf_a` + `soc_storage_leaf_b` |
| `compute_xpu` (16) | `compute_xpu_a` (8) + `compute_xpu_b` (8) |
| `storage_srv` (6) | `storage_srv_a` (3) + `storage_srv_b` (3) |
| `metadata_srv` (6) | `metadata_srv_a` (3) + `metadata_srv_b` (3) |
| `inb_mgmt_leaf`, `oob_leaf`, `hh_gateway`, `hh_controller` | unsplit |

Additional fix: inb-mgmt distribution changed `alternating` → `same-switch` (DIET's `alternating` selects switch by `port_index % n`; for single-port connections `port_index` is always 0, routing all servers to switch 0).

## Pipeline results

| | RO | SH |
|-|----|----|
| Devices | 46 | 46 |
| Wiring fabrics | 5 | 5 |
| hhfab scale-out-a | VALID | VALID |
| hhfab scale-out-b | VALID | VALID |
| hhfab soc-storage-a | VALID | VALID |
| hhfab soc-storage-b | VALID | VALID |
| hhfab inb-mgmt | VALID | VALID |

## OCP companion PR
https://github.com/opencomputeproject/OCP-OCDAI-training-fabric/pull/13

🤖 Generated with [Claude Code](https://claude.com/claude-code)