### PR TITLE
Fix --liquid-clone-of help text: clarify diagrams/ parent path

### DIFF
--- a/scripts/run_ra_pipeline.sh
+++ b/scripts/run_ra_pipeline.sh
@@ -6,15 +6,16 @@
 #     --case <case_id> \
 #     --site <site_slug> \
 #     --composition-dir <absolute_path> \
-#     [--liquid-clone-of <air_variant_dir>] \
+#     [--liquid-clone-of <air_variant_diagrams_dir>] \
 #     [--fe-only]
 #
 # Options:
 #   --case               DIET case_id (fixture filename without .yaml)
 #   --site               Unique site slug for device generation
 #   --composition-dir    Absolute path to the target RA composition directory
-#   --liquid-clone-of    (optional) If this is a liquid clone, path to the air variant's
-#                        hhfab dir — skips hhfab validate, documents liquid=air equivalence
+#   --liquid-clone-of    (optional) Path to the air variant's diagrams/ directory
+#                        (parent of hhfab/; script appends /hhfab/ internally).
+#                        Skips hhfab validate; clones drawios and validate logs from air.
 #   --fe-only            No backend fabric; skip wiring export / hhfab
 
 set -euo pipefail


### PR DESCRIPTION
## Summary

- `--liquid-clone-of` help text previously said "path to the air variant's hhfab dir" which is wrong — the script appends `/hhfab/` internally, so the caller must pass the **parent** `diagrams/` directory
- Updated usage line and option description to say `<air_variant_diagrams_dir>` and `(parent of hhfab/; script appends /hhfab/ internally)`
- No behavior change; help text only

## Files changed

- `scripts/run_ra_pipeline.sh` — usage line + option description (3 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)